### PR TITLE
Fixed capitalization typos, and used different methods where they were appropriate

### DIFF
--- a/modules/t_pane/Verse.js
+++ b/modules/t_pane/Verse.js
@@ -5,9 +5,10 @@
 
 const api = window.ModuleApi;
 const React = api.React;
+const ReactBootstrap = api.ReactBootstrap;
 const lookup = require("./LexiconLookup");
-const Popover = require('react-bootstrap/lib/popover');
-const OverlayTrigger = require('react-bootstrap/lib/OverlayTrigger');
+const Popover = ReactBootstrap.Popover;
+const OverlayTrigger = ReactBootstrap.OverlayTrigger;
 
 class Verse extends React.Component {
   constructor() {

--- a/src/js/components/core/Popover.js
+++ b/src/js/components/core/Popover.js
@@ -2,7 +2,7 @@ const React = require('react');
 const CoreActions = require('../../actions/CoreActions.js');
 const CoreStore = require('../../stores/CoreStore.js');
 const Popover = require('react-bootstrap/lib/Popover');
-const style = require('./style');
+const style = require('./Style');
 
 
 class PopoverComponent extends React.Component{

--- a/src/js/components/core/Upload.js
+++ b/src/js/components/core/Upload.js
@@ -202,7 +202,7 @@ const UploadModal = React.createClass({
   translationCoreManifestPresent: function(path) {
     //this currently just uses 'require' and if it throws an error it will return false
     try {
-      require(Path.join(path, 'tc-manifest.json'));
+      fs.accessSync(Path.join(path, 'tc-manifest.json'));
       return true;
     }
     catch(e) {


### PR DESCRIPTION
I guess my computer is the only one that fails on these capitalization errors, because this has happened to me all summer that I'm the only one that has been getting these bugs. Also changed a method that's better than 'require'

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/31)

<!-- Reviewable:end -->
