### PR TITLE
Small bug fix

### DIFF
--- a/modules/translationNotes_Check_plugin/parsers/tNParser.js
+++ b/modules/translationNotes_Check_plugin/parsers/tNParser.js
@@ -53,7 +53,6 @@ var TNParser = function(book, bookAbbr, progCallback = () => {}) {
           let linkRes = linkReg.exec(piece.tNote);
           if (linkRes != null) {
             let [,volNum,partOfSpeech] = linkRes;
-            if (bookData[partOfSpeech] === undefined) bookData[partOfSpeech] = {tnLink: linkBuilder(volNum, partOfSpeech), verses: []};
             // find verse
             let quotePieces = piece.origText.split(" ... ");
             let verseStart, verseEnd, startPos, searchVerse;
@@ -90,6 +89,9 @@ var TNParser = function(book, bookAbbr, progCallback = () => {}) {
             };
             if (verseEnd !== undefined && verseEnd != verseStart) {
               newVerse.verseEnd = verseEnd;
+            }
+            if (bookData[partOfSpeech] === undefined) {
+              bookData[partOfSpeech] = {tnLink: linkBuilder(volNum, partOfSpeech), verses: []};
             }
             bookData[partOfSpeech].verses.push(newVerse);
           }


### PR DESCRIPTION
In the translationNotes check, some menu groups were being created without any checks associated with them. This fixes that

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/154)

<!-- Reviewable:end -->
