### PR TITLE
new api method

### DIFF
--- a/src/js/ModuleApi.js
+++ b/src/js/ModuleApi.js
@@ -433,6 +433,11 @@ class ModuleApi {
     );
   }
 
+  //this method returns the Current Check Namespace 
+  getCurrentCheckNamespace(){
+    return CoreStore.getCurrentCheckNamespace();
+  }
+
 }
 
 const api = new ModuleApi();


### PR DESCRIPTION
Added new api method **getCurrentCheckNamespace()** that returns the Current Check(tool) Namespace

**I will need this method in the new version of  scripture pane**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/406)
<!-- Reviewable:end -->
