### PR TITLE
Let users know to load a tool first

### DIFF
--- a/src/js/components/core/SwitchCheck.js
+++ b/src/js/components/core/SwitchCheck.js
@@ -18,6 +18,9 @@ class SwitchCheck extends React.Component{
     var buttons = [];
     if(this.props.moduleMetadatas.length == 0) {
       return <div>No tC default modules found.</div>;
+    } else if (!api.getDataFromCommon('saveLocation') || !api.getDataFromCommon('tcManifest')) {
+      return <h3 style={{color: 'white', textAlign: 'center', fontWeight: 'bold', margin: '55px 0'}}>Please <a> load a project </a> before choosing a tool</h3>;
+
     }
     else {
       for (var i in this.props.moduleMetadatas) {

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -447,14 +447,7 @@ var Main = React.createClass({
             dispatch(showCreateProject("Languages"));
           },
           handleSelectTool: () => {
-            var dispatch = this.props.dispatch;
-            if (api.getDataFromCommon('saveLocation') && api.getDataFromCommon('tcManifest')) {
-              //this.updateTools(null);
-              this.props.dispatch(showSwitchCheckModal(true));
-            } else {
-              api.Toast.info('Open a project first, then try again', '', 3);
-              dispatch(showCreateProject("Languages"));
-            }
+            this.props.dispatch(showSwitchCheckModal(true));
           }
         },
         sideNavBarProps: {


### PR DESCRIPTION
As per issue #526 

Testing instructions: Clear localStorage, and attempt to open a tool before loading a project.

Note: The link will not work until after this is moved to the main modal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/556)
<!-- Reviewable:end -->
