### PR TITLE
Removes Setup Icon for Windows

### DIFF
--- a/scripts/builds/build-win-installer.js
+++ b/scripts/builds/build-win-installer.js
@@ -7,7 +7,6 @@ function buildInstaller(packageLocation) {
     exe: 'translationCore.exe',
     outputDirectory: packageLocation + '/installer',
     loadingGif: './images/TC_ANIMATED_Logo.gif',
-    setupIcon: './build/icon.ico',
     skipUpdateIcon: true, 
     setupExe: 'translationCoreSetup.exe'
   });


### PR DESCRIPTION
Putting in a Setup Icon on windows caused an issue with the installer, where the `.net` version would be overwritten. This is an issue with electron-winstaller, and to avoid this for now, removing a setup icon fixes it. This does not remove the apps icon, nor the icon of the shortcut, only the icon on the installer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/664)
<!-- Reviewable:end -->
