### PR TITLE
Make sure users have git installed

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,8 +23,8 @@ function createWindow () {
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', useContentSize: true, show: false});
   exec('gist', (err, data) => {
     if (!data) {
-      dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
       if (process.platform == 'win32') {
+        dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
         exec('Git-2.11.1.exe', {cwd: __dirname + '/installers'}, function(err, data) {
           if (err) {
             dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
@@ -34,14 +34,9 @@ function createWindow () {
           }
         });
       } else {
-        exec('Git-2.10.1.dmg', {cwd: __dirname + '/installers'}, function(err, data) {
-          if (err) {
-            dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
-            app.quit();
-          } else {
-            mainWindow.loadURL(`file://${__dirname}/index.html`);
-          }
-        });
+        dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore.');
+        exec('open https://git-scm.com/downloads');
+        app.quit();
       }
     } else {
       mainWindow.loadURL(`file://${__dirname}/index.html`);

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const electron = require('electron')
 const app = electron.app
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
-
+const dialog = electron.dialog;
 const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
@@ -21,8 +21,34 @@ if (handleStartupEvent()) {
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', useContentSize: true, show: false});
+  exec('gist', (err, data) => {
+    if (!data) {
+      dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
+      if (process.platform == 'win32') {
+        exec('Git-2.11.1.exe', {cwd: __dirname + '/installers'}, function(err, data) {
+          if (err) {
+            dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
+            app.quit();
+          } else {
+            mainWindow.loadURL(`file://${__dirname}/index.html`);
+          }
+        });
+      } else {
+        exec('Git-2.10.1.dmg', {cwd: __dirname + '/installers'}, function(err, data) {
+          if (err) {
+            dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
+            app.quit();
+          } else {
+            mainWindow.loadURL(`file://${__dirname}/index.html`);
+          }
+        });
+      }
+    } else {
+      mainWindow.loadURL(`file://${__dirname}/index.html`);
+    }
+  })
+  // dialog.showErrorBox('Login Failed', 'Incorrect username or password. This could be caused by using an email address instead of a username.');
   // and load the index.html of the app.
-  mainWindow.loadURL(`file://${__dirname}/index.html`)
 
   //Doesn't display until ready
   mainWindow.once('ready-to-show', () => {

--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ if (handleStartupEvent()) {
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', useContentSize: true, show: false});
-  exec('gist', (err, data) => {
+  exec('git', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {
         dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');


### PR DESCRIPTION
On startup, this does a check for if the user has git and installed on the path. On Windows, if they do not have it installed, an installer is run. Due to mac limitations, an internet window is opened directing them to the download. 

To test:
- Delete git from the path, or uninstall it if you're feeling risky. I have not been able to test this very much on mac, but I'm assuming it works just as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/686)
<!-- Reviewable:end -->
