### PR TITLE
Fix Git Installer In Builds

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,13 +22,14 @@ function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', useContentSize: true, show: false});
   let installerLocation = path.join(path.datadir('translationCore'), 'Git-2.11.1.exe');
-  exec('gist', (err, data) => {
+  exec('git', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {
         dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
         fs.copySync(__dirname + '/installers/Git-2.11.1.exe', installerLocation);
-        exec(installerLocation, {cwd: __dirname + '/installers'}, function(err, data) {
+        exec('Git-2.11.1.exe', {cwd: path.datadir('translationCore')}, function(err, data) {
           if (err) {
+            console.log(err);
             dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
             app.quit();
           } else {

--- a/main.js
+++ b/main.js
@@ -4,8 +4,8 @@ const app = electron.app
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 const dialog = electron.dialog;
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs-extra');
+const path = require('path-extra');
 const exec = require('child_process').exec;
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -21,11 +21,13 @@ if (handleStartupEvent()) {
 function createWindow () {
   // Create the browser window.
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', useContentSize: true, show: false});
-  exec('git', (err, data) => {
+  let installerLocation = path.join(path.datadir('translationCore'), 'Git-2.11.1.exe');
+  exec('gist', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {
         dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
-        exec('Git-2.11.1.exe', {cwd: __dirname + '/installers'}, function(err, data) {
+        fs.copySync(__dirname + '/installers/Git-2.11.1.exe', installerLocation);
+        exec(installerLocation, {cwd: __dirname + '/installers'}, function(err, data) {
           if (err) {
             dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');
             app.quit();


### PR DESCRIPTION
This pull request fixes an issue with the git installer on builds. Previously, trying to run an .exe inside of an .asar file would cause an error. This pull request addresses that by copying the .exe file to a new folder, and executing from there.

Testing instructions: 

Load branch from a windows computer without git

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/756)
<!-- Reviewable:end -->
