### PR TITLE
Prevent projects with an old manifest from failing silently

### DIFF
--- a/src/js/components/core/UploadMethods.js
+++ b/src/js/components/core/UploadMethods.js
@@ -328,19 +328,23 @@ function saveManifest(saveLocation, link, tsManifest, callback) {
  */
 function fixManifestVerThree(oldManifest) {
   var newManifest = {};
-  for (var oldElements in oldManifest) {
-    newManifest[oldElements] = oldManifest[oldElements];
-  }
-  newManifest.finished_chunks = oldManifest.finished_frames;
-  newManifest.ts_project = {};
-  newManifest.ts_project.id = oldManifest.project_id;
-  newManifest.ts_project.name = api.convertToFullBookName(oldManifest.project_id);
-  for (var el in oldManifest.source_translations) {
-    newManifest.source_translations = oldManifest.source_translations[el];
-    var parameters = el.split("-");
-    newManifest.source_translations.language_id = parameters[1];
-    newManifest.source_translations.resource_id = parameters[2];
-    break;
+  try{
+    for (var oldElements in oldManifest) {
+      newManifest[oldElements] = oldManifest[oldElements];
+    }
+    newManifest.finished_chunks = oldManifest.finished_frames;
+    newManifest.ts_project = {};
+    newManifest.ts_project.id = oldManifest.project_id;
+    newManifest.ts_project.name = api.convertToFullBookName(oldManifest.project_id);
+    for (var el in oldManifest.source_translations) {
+      newManifest.source_translations = oldManifest.source_translations[el];
+      var parameters = el.split("-");
+      newManifest.source_translations.language_id = parameters[1];
+      newManifest.source_translations.resource_id = parameters[2];
+      break;
+    }
+  }catch(e){
+    console.error(e);
   }
   return newManifest;
 }


### PR DESCRIPTION
#### This pull request addresses:

This just catches any errors that may occur when trying to convert an old manifest to a new one.
NOTE: This does not explicitly address the exact error mentioned on #682 however it does prevent tc from failing without ever prompting the user of the error.

#### How to test this pull request:

Load the following project (https://git.door43.org/551c802a05f3140c/uw-jhn-pt-br.git) you should get an error. Formerly you would get no error on the screen just in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/780)
<!-- Reviewable:end -->
