### PR TITLE
Preliminary version of data persistence Implementation w/  redux

### DIFF
--- a/src/js/actions/SettingsActions.js
+++ b/src/js/actions/SettingsActions.js
@@ -7,37 +7,23 @@ const PACKAGE_COMPILE_LOCATION = pathex.join(PARENT, 'packages-compiled');
 const dir = pathex.join(PACKAGE_COMPILE_LOCATION, 'settings.json');
 
 module.exports.setSettings = function(field, value) {
-  return ((dispatch) => {
-    fs.readJson(dir, function (err, settingsObj) {
-      if(err){
-        settingsObj = {};
-      }else {
-        if(field && value != undefined){
-          settingsObj[field] = value;
-        }
-      }
-      fs.outputJson(dir, settingsObj);
-      dispatch({
-        type: consts.CHANGE_SETTINGS,
-        val: settingsObj,
-      });
-    })
+  return ((dispatch, getState) => {
+    let settingsObj = getState().settingsReducer.currentSettings;
+    settingsObj[field] = value;
+    dispatch({
+      type: consts.CHANGE_SETTINGS,
+      val: settingsObj,
+    });
   });
 };
 
 module.exports.toggleSettings = function(field) {
-  return ((dispatch) => {
-    fs.readJson(dir, function (err, settingsObj) {
-      if(err){
-        console.error(err);
-      }else {
-        settingsObj[field] = !settingsObj[field];
-      }
-      fs.outputJson(dir, settingsObj);
-      dispatch({
-        type: consts.CHANGE_SETTINGS,
-        val: settingsObj,
-      });
-    })
+  return ((dispatch, getState) => {
+    let settingsObj = getState().settingsReducer.currentSettings;
+    settingsObj[field] = !settingsObj[field];
+    dispatch({
+      type: consts.CHANGE_SETTINGS,
+      val: settingsObj,
+    });
   });
 };

--- a/src/js/components/core/Settings.js
+++ b/src/js/components/core/Settings.js
@@ -29,13 +29,13 @@ class Settings extends React.Component {
   render() {
     let { currentSettings } = this.props;
     let textSelect = currentSettings.textSelect ? currentSettings.textSelect : 'click';
-    let tutorialView = currentSettings.tutorialView ? currentSettings.tutorialView.toString() : 'false';
+    let tutorialView = currentSettings.showTutorial ? currentSettings.showTutorial.toString() : 'false';
     let developerMode = currentSettings.developerMode ? currentSettings.developerMode.toString() : "false";
     return (
       <div style={{paddingTop: '65px', width: '40%', marginLeft: 'auto', marginRight: 'auto'}}>
         <FormGroup controlId="tutorialView">
           <ControlLabel>Tutorial</ControlLabel>
-          <FormControl componentClass="select" placeholder="select" name="tutorialView"
+          <FormControl componentClass="select" placeholder="select" name="showTutorial"
             style={{marginBottom: '25px'}}
             defaultValue={tutorialView} onChange={this.settingsChange.bind(this)}>
             <option value="true">Show</option>

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -48,7 +48,7 @@ const ModalContainer = require('../containers/ModalContainer.js');
 const ToolsActions = require('../actions/ToolsActions.js');
 const CheckStoreActions = require('../actions/CheckStoreActions.js');
 const LoaderActions = require('../actions/LoaderActions.js');
-const SettingsActions = require('../actions/SettingsActions.js');
+import { setSettings } from '../actions/SettingsActions.js'
 const DragDropActions = require('../actions/DragDropActions.js');
 import NotificationContainer from '../containers/NotificationContainer';
 import { showNotification } from '../actions/NotificationActions.js'
@@ -75,7 +75,7 @@ var Main = React.createClass({
     api.removeEventListener('changeGroupName', this.changeSubMenuItems);
     api.removeEventListener('changedCheckStatus', this.changeSubMenuItemStatus);
   },
-  
+
   changeSubMenuItemStatus({groupIndex, checkIndex, checkStatus}) {
     let groupObjects = this.props.checkStoreReducer.groups;
     let currentGroupIndex = this.props.checkStoreReducer.currentGroupIndex;
@@ -475,7 +475,7 @@ var Main = React.createClass({
     if (localStorage.getItem('crashed') == 'true') {
       localStorage.removeItem('crashed');
       localStorage.removeItem('lastProject');
-      api.setSettings('tutorialView', 'hide');
+      this.props.dispatch(setSettings('showTutorial', false));
     }
 
     if (localStorage.getItem('user')) {

--- a/src/js/pages/root.js
+++ b/src/js/pages/root.js
@@ -1,9 +1,21 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-import configureStore from './configureStore'
+import configureStore from '../utils/configureStore'
 import Application from './app'
-
-const store = configureStore()
+import { loadState, saveState } from '../utils/localStorage'
+import throttle from 'lodash/throttle'
+//loading persistedState from filesystem using loadState()
+const persistedState = loadState();
+const store = configureStore(persistedState)
+/** @description:
+ * The app store will be saved on state changes
+ * subscribe listens for change in store
+ * throttle makes the state to be save only once per second (1000),
+ * which could be increase if we need to
+ */
+store.subscribe(throttle(() => {
+  saveState(store.getState());
+}, 1000));
 
 module.exports.App = (
   <Provider store={store}>

--- a/src/js/reducers/settingsReducer.js
+++ b/src/js/reducers/settingsReducer.js
@@ -1,15 +1,14 @@
-const consts = require('../actions/CoreActionConsts');
-const fs = require('fs-extra');
-const pathex = require('path-extra');
-const PARENT = pathex.datadir('translationCore')
-const PACKAGE_COMPILE_LOCATION = pathex.join(PARENT, 'packages-compiled');
-const dir = pathex.join(PACKAGE_COMPILE_LOCATION, 'settings.json');
+import consts from '../actions/CoreActionConsts'
 
 const initialState = {
-  currentSettings: fs.readJsonSync(dir),
+  currentSettings: {
+    showTutorial: false,
+    textSelect: 'drag',
+    developerMode: false
+  }
 };
 
-module.exports = (state = initialState, action) => {
+const settingsReducer = (state = initialState, action) => {
   switch (action.type) {
     case consts.CHANGE_SETTINGS:
       return { ...state, currentSettings: action.val }
@@ -17,3 +16,5 @@ module.exports = (state = initialState, action) => {
       return state;
   }
 }
+
+export default settingsReducer

--- a/src/js/utils/configureStore.js
+++ b/src/js/utils/configureStore.js
@@ -4,10 +4,10 @@ import rootReducers from '../reducers/index.js'
 
 //preloadedState will be used for Data persistence
 
-export default function configureStore(preloadedState) {
+export default function configureStore(persistedState) {
   return createStore(
     rootReducers,
-    preloadedState,
+    persistedState,
     applyMiddleware(
       thunkMiddleware
     )

--- a/src/js/utils/localStorage.js
+++ b/src/js/utils/localStorage.js
@@ -1,0 +1,44 @@
+import fs from 'fs-extra'
+import pathex from 'path-extra'
+
+const PARENT = pathex.datadir('translationCore')
+//const PACKAGE_COMPILE_LOCATION = pathex.join(PARENT, 'packages-compiled');
+const settingsDirectory = pathex.join(PARENT, 'settings.json');
+
+export const loadState = () => {
+  try {
+    const serializedState = {
+      settingsReducer: loadSettings(),
+    }
+    if(serializedState === null){
+      //returning undefined to allow the reducers to initialize the app state
+      return undefined;
+    }
+    return serializedState;
+  } catch(err) {
+    console.warn(err);
+    //returning undefined to allow the reducers to initialize the app state
+    return undefined;
+  }
+};
+
+export const saveState = (state) => {
+  try {
+    if(state.settingsReducer){
+      fs.outputJson(settingsDirectory, state.settingsReducer);
+    }
+  } catch(err) {
+    console.warn(err);
+  }
+};
+
+//Helpers TODO: will probably move this function helpers to a separate file.
+const loadSettings = () => {
+  let settings = undefined;
+  try {
+    settings = fs.readJsonSync(settingsDirectory)
+  } catch (err) {
+    console.warn(err)
+  }
+  return settings
+};

--- a/src/js/utils/localStorage.js
+++ b/src/js/utils/localStorage.js
@@ -1,8 +1,8 @@
 import fs from 'fs-extra'
 import pathex from 'path-extra'
-
+//translationCore PARENT directory
 const PARENT = pathex.datadir('translationCore')
-//const PACKAGE_COMPILE_LOCATION = pathex.join(PARENT, 'packages-compiled');
+//settings.json directory 
 const settingsDirectory = pathex.join(PARENT, 'settings.json');
 
 export const loadState = () => {

--- a/tests/k.translationCore.js
+++ b/tests/k.translationCore.js
@@ -54,7 +54,7 @@ describe('example shallowWithStore', () => {
 //     assert.equal(wrapper.find('ModuleWrapper').length, 1);
 //   });
 //   it('should render <Welcome /> if first time is set to true', function() {
-//     ModuleApi.setSettings('tutorialView', 'show');
+//     ModuleApi.setSettings('showTutorial', 'show');
 //     newWrapper = shallow(App);
 //     assert.equal(newWrapper.find('Welcome').length, 1)
 //   });


### PR DESCRIPTION
#### This pull request addresses:

This is a Preliminary version of how we are going to handle data persistence w/ **Redux**

This PR adds data persistence to the settingsReducer suing a redux implementation that uses preloaded/persisted state and loads it to the reducers through the combineReducer method.

`settings.json was moved from inside the packages-compiled directory to same directory that packages-compiled lives`

#### How to test this pull request:
- Try changing settings and refreshing to make sure data persistence works 
- A warning should show up on your console. This is because this is your first time opening the app and you don't have the settings file in the directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/896)
<!-- Reviewable:end -->
