### PR TITLE
Removed trailing commas preventing app launch

### DIFF
--- a/src/js/containers/ModuleWrapperContainer.js
+++ b/src/js/containers/ModuleWrapperContainer.js
@@ -43,7 +43,7 @@ function mapStateToProps(state) {
       state.toolsReducer,
       state.settingsReducer,
       state.checkStoreReducer,
-      state.loaderReducer,
+      state.loaderReducer
     );
 }
 

--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -20,7 +20,7 @@ function mapStateToProps(state) {
       state.loginReducer,
       state.settingsReducer,
       state.statusBarReducer,
-      state.loaderReducer,
+      state.loaderReducer
     );
 }
 


### PR DESCRIPTION
This is a special PR. These commas I have removed were preventing my app from starting on windows. I am not sure if that was just for me or anyone else but I had to remove them to get the app to launch. 

Lets try to avoid leaving these in in the future.

**THESE COULD POTENTIALLY EXIST IN OTHER PLACES THROUGHOUT THE CODEBASE. I have not done thorough testing across the entire app to see if trailing commas cause problems anywhere else. These are just the two that were preventing startup.** If you see them anywhere else we should delete them just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/920)
<!-- Reviewable:end -->
