### PR TITLE
Reintroduce context to the status bar

### DIFF
--- a/src/js/containers/StatusBarContainer.js
+++ b/src/js/containers/StatusBarContainer.js
@@ -6,12 +6,12 @@ const StatusBar = require('../components/core/SideBar/StatusBar.js');
 
 class StatusBarContainer extends React.Component {
     render() {
-      let { currentBook } = this.props.projectDetailsReducer;
-      let { currentTool } = this.props.currentToolReducer;
+      let { bookName } = this.props.projectDetailsReducer;
+      let { toolName } = this.props.currentToolReducer;
         return (
             <div>
-            <StatusBar bookName={currentBook}
-                       currentCheckNamespace={currentTool}
+            <StatusBar bookName={bookName}
+                       currentCheckNamespace={toolName}
                        open={this.props.openModalAndSpecificTab}
                        online={this.props.online}
                        changeOnlineStatus={this.props.changeOnlineStatus}/>

--- a/src/js/containers/StatusBarContainer.js
+++ b/src/js/containers/StatusBarContainer.js
@@ -6,9 +6,15 @@ const StatusBar = require('../components/core/SideBar/StatusBar.js');
 
 class StatusBarContainer extends React.Component {
     render() {
+      let { currentBook } = this.props.projectDetailsReducer;
+      let { currentTool } = this.props.currentToolReducer;
         return (
             <div>
-            <StatusBar bookName={this.props.bookName} currentCheckNamespace={this.props.currentCheckNamespace} open={this.props.openModalAndSpecificTab} online={this.props.online} changeOnlineStatus={this.props.changeOnlineStatus}/>
+            <StatusBar bookName={currentBook}
+                       currentCheckNamespace={currentTool}
+                       open={this.props.openModalAndSpecificTab}
+                       online={this.props.online}
+                       changeOnlineStatus={this.props.changeOnlineStatus}/>
             </div>
         )
     }
@@ -26,7 +32,11 @@ function mapDispatchToProps(dispatch, ownProps) {
 }
 
 function mapStateToProps(state) {
-    return Object.assign({}, state.statusBarReducer);
+    return {
+       statusBarReducer: state.statusBarReducer,
+       currentToolReducer: state.currentToolReducer,
+       projectDetailsReducer: state.projectDetailsReducer
+    }
 }
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(StatusBarContainer);


### PR DESCRIPTION
#### This pull request addresses:

This addresses the absent context in the statusbar that came with the refactor. These values are grabbed from the permanent reducers now.



#### How to test this pull request:

Open a project and a tool. The status bar at the top of the screen should show which book and tool you currently have open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1022)
<!-- Reviewable:end -->
