### PR TITLE
made changeContextId actions load files from system if they exist

### DIFF
--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -1,16 +1,29 @@
-import consts from '../actions/CoreActionConsts'
-import {generateTimestamp} from '../helpers/index'
+import consts from './CoreActionConsts'
 import {shiftGroupIndex, shiftGroupDataItem} from '../helpers/navigationHelpers'
+import {loadComments, loadReminders, loadSelections, loadVerseEdit} from './checkDataLoadActions'
+
+
+function loadCheckData(dispatch) {
+  dispatch(loadComments());
+  dispatch(loadReminders());
+  dispatch(loadSelections());
+  dispatch(loadVerseEdit());
+}
+
+
 /**
  * @description this action changes the contextId to the current check.
  * @param {object} contextId - the contextId object.
  * @return {object} New state for contextId reducer.
  */
-export const changeCurrentContextId = (contextId) => {
-  return {
-    type: consts.CHANGE_CURRENT_CONTEXT_ID,
-    contextId
-  }
+export const changeCurrentContextId = contextId => {
+  return ((dispatch, getState) => {
+    dispatch({
+      type: consts.CHANGE_CURRENT_CONTEXT_ID,
+      contextId
+    })
+    loadCheckData(dispatch);
+  });
 }
 
 export const changeToNextContextId = () => {
@@ -30,6 +43,7 @@ export const changeToNextContextId = () => {
       type: consts.CHANGE_CURRENT_CONTEXT_ID,
       contextId
     })
+    loadCheckData(dispatch);
   })
 }
 
@@ -50,5 +64,6 @@ export const changeToPreviousContextId = () => {
       type: consts.CHANGE_CURRENT_CONTEXT_ID,
       contextId
     })
+    loadCheckData(dispatch);
   })
 }

--- a/src/js/actions/checkDataLoadActions.js
+++ b/src/js/actions/checkDataLoadActions.js
@@ -46,25 +46,28 @@ function generateLoadPath(state, checkDataName) {
  */
 function loadCheckData(loadPath) {
   try {
-    let files = fs.readdirSync(loadPath);
-    let ext = '.json';
-    let fileName = '';
-    let sorted = files.sort((a, b) => {
-      if (path.extname(a) === ext && path.extname(b) === ext) {
-        // Turn strings into dates, and then subtract them
-        // to get a value that is either negative, positive, or zero.
-        return new Date(b) - new Date(a);
-      }
-    });
-    sorted.forEach((file, index) => {
-      if (path.extname(file) === ext && index === files.length - 1) {
-        fileName = file;
-      }
-    });
-    let readPath = path.join(loadPath, fileName);
-    console.log(readPath)
-    let checkDataObject = fs.readJsonSync(readPath);
-    return checkDataObject;
+    if (fs.existsSync(loadPath)) {
+      let files = fs.readdirSync(loadPath);
+      let ext = '.json';
+      let fileName = '';
+      let sorted = files.sort((a, b) => {
+        if (path.extname(a) === ext && path.extname(b) === ext) {
+          // Turn strings into dates, and then subtract them
+          // to get a value that is either negative, positive, or zero.
+          return new Date(b) - new Date(a);
+        }
+      });
+      sorted.forEach((file, index) => {
+        if (path.extname(file) === ext && index === files.length - 1) {
+          fileName = file;
+        }
+      });
+      let readPath = path.join(loadPath, fileName);
+      let checkDataObject = fs.readJsonSync(readPath);
+      return checkDataObject;
+    } else {
+      return null;
+    }
   } catch (err) {
     /**
      * @description Will return undefined so that the load method returns and then
@@ -115,6 +118,7 @@ export function loadReminders() {
     if (remindersObject) {
       dispatch({
         type: consts.TOGGLE_REMINDER,
+        enabled: remindersObject.enabled,
         modifiedTimestamp: remindersObject.modifiedTimestamp,
         userName: remindersObject.userName
       });
@@ -122,6 +126,7 @@ export function loadReminders() {
       // The object is undefined because the file wasn't found in the directory thus we init the reducer to a default value.
       dispatch({
         type: consts.TOGGLE_REMINDER,
+        enabled: false,
         modifiedTimestamp: "",
         userName: ""
       });


### PR DESCRIPTION
#### This pull request addresses:

This PR adds the ability to load 'comments', 'reminders', 'selections' and 'verseEdits'files if they exist.


#### How to test this pull request:

click a check in the menu and leave a comment, make a selection and/or make a verse edit then go to another check by either:

- clicking another check in the menu
- clicking save & continue
- clicking save & previous

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1023)
<!-- Reviewable:end -->
