### PR TITLE
issue 1068, styling changes to sidebar collapse button

### DIFF
--- a/src/js/components/core/SideBar/Style.js
+++ b/src/js/components/core/SideBar/Style.js
@@ -88,22 +88,22 @@ var style = {
 
   slideButton: {
     float: "right",
-    marginTop: "100%",
+    marginTop: "50vh",
     zIndex: "999",
     color: "#fff",
-    backgroundColor: "#333333",
-    padding: "10px 5px 10px 0",
+    backgroundColor: "#000",
+    padding: "10px 0",
     marginRight: "-15px",
     borderRadius: "0 5px 5px 0"
   },
 
   slideButtonCollapsed: {
     float: "left",
-    marginTop: "100%",
+    marginTop: "50vh",
     zIndex: "999",
     color: "#fff",
-    backgroundColor: "#333333",
-    padding: "10px 5px 10px 0",
+    backgroundColor: "#000",
+    padding: "10px 0",
     marginRight: "-15px",
     borderRadius: "0 5px 5px 0"
   }

--- a/src/js/components/core/groupMenu/Group.js
+++ b/src/js/components/core/groupMenu/Group.js
@@ -59,7 +59,7 @@ class Group extends React.Component {
             progress={0.5}
             options={{ strokeWidth: 15, color: "#4ABBE6", trailColor: "#FFF", trailWidth: 15 }}
             initialAnimate={false}
-            containerStyle={{ width: '20px', height: '20px', marginRight: '5px', float: 'left' }}
+            containerStyle={{ width: '20px', height: '20px', marginRight: '10px', float: 'left' }}
           />
           {this.props.groupIndex.name}
         </div>

--- a/src/js/components/core/groupMenu/GroupItem.js
+++ b/src/js/components/core/groupMenu/GroupItem.js
@@ -10,7 +10,7 @@ class GroupItem extends React.Component {
    * @return {component} statusGlyph - component to render
    */
   statusGlyph(selections, active) {
-    let statusGlyph = <div /> // blank as default, in case no data or not active
+    let statusGlyph = <Glyphicon glyph="" style={style.menuItem.statusIcon.blank} /> // blank as default, in case no data or not active
     let { enabled } = this.props.remindersReducer //Is this check bookmarked?
     if (active && enabled) {
       statusGlyph = <Glyphicon glyph="bookmark" style={style.menuItem.statusIcon.bookmark} />

--- a/src/js/components/core/groupMenu/Style.js
+++ b/src/js/components/core/groupMenu/Style.js
@@ -9,7 +9,6 @@
         paddingLeft: '15px',
         cursor: "pointer",
         borderBottom: "1px solid #747474",
-        cursor: 'pointer',
         fontWeight: 'normal',
         color: 'white'
       },
@@ -29,7 +28,8 @@
     statusIcon: {
       correct: {
         color: '#4EBA67',
-        display: 'initial'
+        display: 'initial',
+        padding: '0 10px 0 20px'
       },
       flagged: {
         color: '#FDD910',
@@ -40,22 +40,29 @@
       },
       bookmark: {
         color: '#FFFFFF',
-        display: 'initial'
+        display: 'initial',
+        padding: '0 10px 0 20px'
+      },
+      blank: {
+        display: 'initial',
+        color: 'none',
+        padding: '0 25px 0 20px'
       }
     }
   },
 
   subMenuItem: {
     display: "block",
-    padding: "10px 10px 10px 15px",
+    padding: "10px 0",
     cursor: "pointer",
     borderBottom: "1px solid #333333",
     color: "#FFF",
+    backgroundColor: "#666666",
   },
 
   activeSubMenuItem:  {
     display: "block",
-    padding: "10px 10px 10px 15px",
+    padding: "10px 0",
     cursor: "pointer",
     borderBottom: "1px solid #333333",
     color: "#FFF",


### PR DESCRIPTION
#### This pull request addresses:

change color and size of sidebar collapse button to match desired formatting



#### How to test this pull request:

collapse button should be black and thinner (like the tHelps side) and vertically centered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1079)
<!-- Reviewable:end -->
