### PR TITLE
Invalidate Selections if occurrences don't match current count.

### DIFF
--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -1,5 +1,6 @@
 import consts from '../actions/CoreActionConsts';
 import {generateTimestamp} from '../helpers/index';
+import {checkSelectionOccurrences} from '../helpers/selectionHelpers';
 
 /**
  * @description This method adds a selection array to the selections reducer.
@@ -16,3 +17,22 @@ export const changeSelections = (selections, userName) => {
     userName
   };
 };
+/**
+ * @description This method validates the current selections to see if they are still valid
+ * @param {Array} selection - An array of selections.
+ * @param {String} userName - The username of the author of the selection.
+ * @return {Object} - An action object, consiting of a timestamp, action type,
+ *                    a selection array, and a username.
+ ******************************************************************************/
+export const validateSelections = (targetVerse) => {
+  return ((dispatch, getState) => {
+    const state = getState();
+    let {username} = state.loginReducer.userdata;
+    let {selections} = state.selectionsReducer;
+    let validSelections = checkSelectionOccurrences(targetVerse, selections);
+    if (selections.length !== validSelections.length) {
+      dispatch(changeSelections(validSelections, username));
+      alert('Some selections are no longer valid and are removed.')
+    }
+  });
+}

--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -6,7 +6,7 @@ import { addNewResource, addNewBible } from '../actions/ResourcesActions.js';
 import { addComment } from '../actions/CommentsActions.js';
 import { addVerseEdit } from '../actions/VerseEditActions.js';
 import { toggleReminder } from '../actions/RemindersActions.js';
-import { changeSelections } from '../actions/SelectionsActions.js';
+import { changeSelections, validateSelections } from '../actions/SelectionsActions.js';
 import {changeCurrentContextId, loadCurrentContextId, changeToNextContextId, changeToPreviousContextId} from '../actions/ContextIdActions.js';
 import {addGroupData} from '../actions/GroupsDataActions.js';
 import {setGroupsIndex} from '../actions/GroupsIndexActions.js';
@@ -83,8 +83,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       changeSelections: (selections, userName) => {
         dispatch(changeSelections(selections, userName));
       },
-      removeSelections: (text, userName) => {
-        dispatch(removeSelections(text, userName));
+      validateSelections: (targetVerse) => {
+        dispatch(validateSelections(targetVerse));
       },
       toggleReminder: (userName) => {
         dispatch(toggleReminder(userName));

--- a/src/js/helpers/selectionHelpers.js
+++ b/src/js/helpers/selectionHelpers.js
@@ -1,0 +1,34 @@
+
+ /**
+  * @description Function that count occurrences of a substring in a string
+  * @param {String} string - The string to search in
+  * @param {String} subString - The sub string to search for
+  * @returns {Integer} - the count of the occurrences
+  * @see http://stackoverflow.com/questions/4009756/how-to-count-string-occurrence-in-string/7924240#7924240
+  * modified to fit our use cases, return zero for '' substring, and no use case for overlapping.
+  */
+export const occurrences = (string, subString) => {
+  if (subString.length <= 0) return 0
+  var n = 0, pos = 0, step = subString.length
+  while (true) {
+    pos = string.indexOf(subString, pos)
+    if (pos === -1) break
+    ++n
+    pos += step
+  }
+  return n
+}
+ /**
+  * @description This checks to see if the string still has the same number of occurrences.
+  * It should remove the selections that the occurrences do not match
+  * @param {string} string - the text selections are found in
+  * @param {array}  selections - array of selection objects [Obj,...]
+  * @returns {array} - array of selection objects
+  */
+export const checkSelectionOccurrences = (string, selections) => {
+  selections = selections.filter( selection => {
+    let count = module.exports.occurrences(string, selection.text)
+    return count === selection.occurrences
+  })
+  return selections
+}

--- a/src/js/helpers/selectionHelpers.js
+++ b/src/js/helpers/selectionHelpers.js
@@ -7,7 +7,7 @@
   * @see http://stackoverflow.com/questions/4009756/how-to-count-string-occurrence-in-string/7924240#7924240
   * modified to fit our use cases, return zero for '' substring, and no use case for overlapping.
   */
-export const occurrences = (string, subString) => {
+const occurrences = (string, subString) => {
   if (subString.length <= 0) return 0
   var n = 0, pos = 0, step = subString.length
   while (true) {
@@ -27,7 +27,7 @@ export const occurrences = (string, subString) => {
   */
 export const checkSelectionOccurrences = (string, selections) => {
   selections = selections.filter( selection => {
-    let count = module.exports.occurrences(string, selection.text)
+    let count = occurrences(string, selection.text)
     return count === selection.occurrences
   })
   return selections


### PR DESCRIPTION
## This PR addresses:
Invalidate Selections if occurrences don't match current count. It alerts the user so that they know their edit invalidated the selection that was previously made.

## To test:
Checkout branch of the same name in VerseCheck where the action is called when rendering the text it validates to see if the selections are still valid. 

## TODO: 
Find a common place to check for this validation so that it doesn’t happen deep in the tool but somewhere at a higher level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1096)
<!-- Reviewable:end -->
