### PR TITLE
Filter loading checkDataObjects by groupId, quote and occurrence

### DIFF
--- a/src/js/actions/checkDataLoadActions.js
+++ b/src/js/actions/checkDataLoadActions.js
@@ -68,7 +68,10 @@ function loadCheckData(loadPath, contextId) {
     })
     checkDataObjects = checkDataObjects.filter( _checkDataObject => {
       // filter the checkDataObjects to only use the ones that match the current contextId
-      let keep = _checkDataObject && _checkDataObject.contextId.occurrence === contextId.occurrence
+      let keep = _checkDataObject &&
+                _checkDataObject.contextId.groupId === contextId.groupId &&
+                _checkDataObject.contextId.quote === contextId.quote &&
+                _checkDataObject.contextId.occurrence === contextId.occurrence
       return keep
     })
     // return the first one since it is the latest modified one


### PR DESCRIPTION
## This PR Addresses:
Selections, Quote, edits, Reminders from the same file, were only filtered by reference and occurrence. Now they are filtered by groupId and quote as well.

## To Test This PR:
Open Titus/ImportantWords.
Select a word/phrase in “circumcise” for Titus 1:10. Navigate to “deceive” and the selection should not be there like it would without this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1116)
<!-- Reviewable:end -->
