### PR TITLE
Force users to sign in

### DIFF
--- a/src/js/components/core/AppDescription.js
+++ b/src/js/components/core/AppDescription.js
@@ -87,7 +87,7 @@ class AppDescription extends React.Component {
             {title}
           </h4><span>{"Version " + version}</span><br />
           <span style={{color: "#FFFFFF", marginBottom: ""}}>{description}</span><br /><br /><br />
-          <Button bsStyle="white" onClick={() => this.props.handleLoadTool(folderName)}
+          <Button bsStyle="white" onClick={() => this.props.handleLoadTool(folderName, this.props.loggedInUser)}
                   title={"Click to load tool"}>
             Select
           </Button>

--- a/src/js/components/core/licenses/ThirdParty.js
+++ b/src/js/components/core/licenses/ThirdParty.js
@@ -5,9 +5,8 @@ class ThirdParty extends React.Component {
   render() {
     let libraries = []
     for(let license in Licenses){
-      console.log(license);
       libraries.push(
-        <div style={{padding: "20px"}}>
+        <div style={{padding: "20px"}} key={license}>
           <center>{license}</center>
           <center>{Licenses[license].licenses}</center>
           <center><a href={Licenses[license].repository}>link to license</a></center>

--- a/src/js/containers/ImportOnlineContainer.js
+++ b/src/js/containers/ImportOnlineContainer.js
@@ -105,8 +105,14 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       }
       dispatch(importOnlineActions.loadProjectFromLink(link));
     },
-    openOnlineProject: (projectPath) => {
+    openOnlineProject: (projectPath, loggedInUser) => {
+      if (!loggedInUser) {
+        dispatch(ModalActions.selectModalTab(1, 1, true));
+        dispatch(NotificationActions.showNotification("Please login before loading a project", 5));
+        return;
+      }
       dispatch(importOnlineActions.openOnlineProject(projectPath));
+      
     }
   };
 };

--- a/src/js/containers/ImportOnlineContainer.js
+++ b/src/js/containers/ImportOnlineContainer.js
@@ -6,6 +6,8 @@ import Projects from '../components/core/login/Projects';
 import OnlineInput from '../components/core/OnlineInput';
 // Actions
 import * as importOnlineActions from '../actions/ImportOnlineActions.js';
+import * as ModalActions from '../actions/ModalActions.js';
+import * as NotificationActions from '../actions/NotificationActions.js';
 
 class ImportOnlineContainer extends React.Component {
 
@@ -66,7 +68,7 @@ class ImportOnlineContainer extends React.Component {
                               or
         </span>
                       </div>
-                      <OnlineInput onChange={this.props.handleOnlineChange} load={() => this.props.loadProjectFromLink(this.props.importLink)} />
+                      <OnlineInput onChange={this.props.handleOnlineChange} load={() => this.props.loadProjectFromLink(this.props.importLink, this.props.loggedIn)} />
                   </center>
               </div>)
               :
@@ -95,7 +97,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     updateRepos: () => {
       dispatch(importOnlineActions.updateRepos());
     },
-    loadProjectFromLink: (link) => {
+    loadProjectFromLink: (link, loggedInUser) => {
+      if (!loggedInUser) {
+        dispatch(ModalActions.selectModalTab(1, 1, true));
+        dispatch(NotificationActions.showNotification("Please login before loading a project", 5));
+        return;
+      }
       dispatch(importOnlineActions.loadProjectFromLink(link));
     },
     openOnlineProject: (projectPath) => {

--- a/src/js/containers/RecentProjectsContainer.js
+++ b/src/js/containers/RecentProjectsContainer.js
@@ -7,6 +7,8 @@ import { Modal, Tabs, Tab, Button, Glyphicon } from 'react-bootstrap/lib';
 import RecentProjects from '../components/core/RecentProjects';
 // actions
 import * as recentProjectsActions from '../actions/RecentProjectsActions.js';
+import * as ModalActions from '../actions/ModalActions.js';
+import * as NotificationActions from '../actions/NotificationActions.js';
 // constant declaration
 const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore');
 
@@ -20,7 +22,7 @@ class RecentProjectsContainer extends React.Component {
   generateButton(projectPath) {
     return (
         <span>
-            <Button style={{ width: "50%", backgroundColor: '#C3105A', borderWidth: '0px', borderRadius: '0px', backgroundImage: 'linear-gradient(to bottom,#C3105A 0,#C3105A 100%)', color: 'white' }} onClick={() => this.props.onLoad(projectPath)}>
+            <Button style={{ width: "50%", backgroundColor: '#C3105A', borderWidth: '0px', borderRadius: '0px', backgroundImage: 'linear-gradient(to bottom,#C3105A 0,#C3105A 100%)', color: 'white' }} onClick={() => this.props.onLoad(projectPath, this.props.loggedInUser)}>
                 <Glyphicon glyph={'folder-open'} />
                 <span style={{ marginLeft: '10px', marginRight: '20px' }}>Select</span>
             </Button>
@@ -85,13 +87,19 @@ class RecentProjectsContainer extends React.Component {
 const mapStateToProps = (state) => {
   return {
     ...state.recentProjectsReducer,
-    manifest: state.projectDetailsReducer.manifest
+    manifest: state.projectDetailsReducer.manifest,
+    loggedInUser: state.loginReducer.loggedInUser
   };
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onLoad: projectPath => {
+    onLoad: (projectPath, loggedInUser) => {
+      if (!loggedInUser) {
+        dispatch(ModalActions.selectModalTab(1, 1, true));
+        dispatch(NotificationActions.showNotification("Please login before loading a project", 5));
+        return;
+      }
       dispatch(recentProjectsActions.onLoad(projectPath));
     },
     syncProject: (projectPath, manifest) => {

--- a/src/js/containers/ToolsModalContainer.js
+++ b/src/js/containers/ToolsModalContainer.js
@@ -6,6 +6,7 @@ import SwitchCheck from '../components/core/SwitchCheck.js';
 // actions
 import * as ToolsActions from '../actions/ToolsActions.js';
 import * as modalActions from '../actions/ModalActions.js';
+import * as NotificationActions from '../actions/NotificationActions.js';
 
 class ToolsModalContainer extends React.Component {
 
@@ -29,7 +30,7 @@ class ToolsModalContainer extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  return Object.assign({}, state.toolsReducer, state.settingsReducer, state.projectDetailsReducer);
+  return Object.assign({}, state.toolsReducer, state.settingsReducer, state.projectDetailsReducer, state.loginReducer);
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
@@ -37,7 +38,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     getToolsMetadatas: () => {
       dispatch(ToolsActions.getToolsMetadatas());
     },
-    handleLoadTool: (toolFolderPath) => {
+    handleLoadTool: (toolFolderPath, loggedInUser) => {
+      if (!loggedInUser) {
+        dispatch(modalActions.selectModalTab(1, 1, true));
+        dispatch(NotificationActions.showNotification("Please login before opening a tool", 5));
+        return;
+      }
       dispatch(ToolsActions.loadTool(toolFolderPath));
     },
     showLoad: () => {


### PR DESCRIPTION
#### This pull request addresses:

This pull request addresses #1265, by making users sign in before loading an online project, loading a recent project, and opening a tool. 

#### How to test this pull request:

Try loading a project with out logging in, via recent projects, and the online import. Next login, load a project, then logout. Try to load a tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1358)
<!-- Reviewable:end -->
