### PR TITLE
Update repos when switching tabs

### DIFF
--- a/src/js/components/core/login/Projects.js
+++ b/src/js/components/core/login/Projects.js
@@ -8,7 +8,6 @@ class Projects extends React.Component {
         <div style={{marginBottom: '15px'}}>
           <span style={{fontSize: '20px'}}>Your Door43 Projects</span>
           <Button bsStyle='primary' style={{display: this.props.showBack}} onClick={this.props.back} className={'pull-right'} bsSize='sm'>Back</Button>
-          <Button bsStyle='warning' className={'pull-right'} onClick={this.props.refresh} bsSize='sm'>Refresh</Button>
         </div>
         {this.props.onlineProjects}
       </div>

--- a/src/js/containers/ImportOnlineContainer.js
+++ b/src/js/containers/ImportOnlineContainer.js
@@ -23,8 +23,13 @@ class ImportOnlineContainer extends React.Component {
     );
   }
 
-  makeList(repos) {
+  componentWillReceiveProps(newProps) {
+    if (newProps.modalReducer.currentSection === 3 && newProps.modalReducer.currentTab === 2 && !newProps.importOnlineReducer.showOnlineButton && (newProps.modalReducer.currentTab !== this.props.modalReducer.currentTab || newProps.modalReducer.currentSection !== this.props.modalReducer.currentSection)) {
+      this.props.actions.updateRepos();
+    }
+  }
 
+  makeList(repos) {
     if (!this.props.importOnlineReducer.loggedIn) {
       return (
         <div>
@@ -82,7 +87,6 @@ class ImportOnlineContainer extends React.Component {
             (<Projects
               onlineProjects={onlineProjects}
               back={() => this.props.actions.changeShowOnlineView(true)}
-              refresh={this.props.updateRepos}
             />)
         }
       </div>
@@ -92,7 +96,8 @@ class ImportOnlineContainer extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    importOnlineReducer: state.importOnlineReducer
+    importOnlineReducer: state.importOnlineReducer,
+    modalReducer: state.newModalReducer
   };
 };
 


### PR DESCRIPTION
#### This pull request addresses:

Addresses #1258 

This pull request updates the list of repos when switching tabs, which eliminates the need of a refresh button. The main purpose of this fix is so that when a user logs in, goes to repos, and switches accounts, the repos that are showing will be for the correct account.

#### How to test this pull request:

Login with one account. Open Door43 projects. Logout, login with another account. Go to door43 projects. Different projects should show. Create or delete a project on Door43, switch tabs in the app, it should update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1378)
<!-- Reviewable:end -->
