### PR TITLE
Add /SILENT flag to installation for git

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ function createMainWindow () {
 
   //mainWindow.webContents.openDevTools();
 
-  let installerLocation = path.join(path.datadir('translationCore'), 'Git-2.11.1.exe');
+  let installerLocation = path.join(path.datadir('translationCore'), 'Git-2.11.1.exe /SILENT /COMPONENTS="assoc"');
   exec('git', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function createMainWindow () {
   exec('git', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {
-        dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nDuring installation, select the option: "Use git from the Windows Command Prompt" if you are on Windows.');
+        dialog.showErrorBox('Startup Failed', 'You must have git installed and on your path in order to use translationCore. \nInstalling Git now.');
         fs.copySync(__dirname + '/installers/Git-2.11.1.exe', installerLocation);
         exec('Git-2.11.1.exe', {cwd: path.datadir('translationCore')}, function(err, data) {
           if (err) {


### PR DESCRIPTION
#### This pull request addresses:

Addresses #1364 

Instead of making users go through the complicated installation process of Git, this is handled automatically, removing any possibility of user error. 

#### How to test this pull request:

Try on windows, with Git not on the path env variable. It will install git, and add it to the path. To test for Git on the Path, open a command window and type `git`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1388)
<!-- Reviewable:end -->
