### PR TITLE
Changed 2013 to 2016

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2013 - 2017  unfoldingWord <admin@unfoldingword.org>
+Copyright (C) 2016 - 2017  unfoldingWord <admin@unfoldingword.org>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License


### PR DESCRIPTION
#### This pull request addresses:

Addresses https://github.com/unfoldingWord-dev/translationCore/issues/1397



#### How to test this pull request:
Look at the license file, it should say 2016 instead of 2013 now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1439)
<!-- Reviewable:end -->
