### PR TITLE
Fixed spelling in Login page 

### DIFF
--- a/src/js/components/core/login/Door43Login.js
+++ b/src/js/components/core/login/Door43Login.js
@@ -23,7 +23,7 @@ class Door43Login extends React.Component {
           <div style={{display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center"}}>
             <img src="images/D43_LOGO.png" style={{margin: "30px 0px 0px"}} /><br/>
             <h4>
-              <b>{"Login in with Door43 "}</b>
+              <b>{"Log in with Door43"}</b>&nbsp;
               <Glyphicon glyph="info-sign" style={{fontSize: "20px"}} />
             </h4>
             <TextField


### PR DESCRIPTION
## This pull request addresses:

- Misspelled verbiage 

## Test:

- Open the login page and verify it says "Log in to Door43"

**this is the funniest mistake lol**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1506)
<!-- Reviewable:end -->
