### PR TITLE
Addressed issues with Main Modal Navigation  and Main modal screen size

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ let splashScreen;
 
 function createMainWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', autoHideMenuBar: true, minWidth: 1100, minHeight: 600, center: true, useContentSize: true, show: false});
+  mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', autoHideMenuBar: true, minWidth: 1100, minHeight: 650, center: true, useContentSize: true, show: false});
 
   //mainWindow.webContents.openDevTools();
 

--- a/src/js/components/core/AppDescription.js
+++ b/src/js/components/core/AppDescription.js
@@ -93,7 +93,7 @@ class AppDescription extends React.Component {
           </Button>
         </Col>
         <Col md={4} sm={4} xs={4} style={{margin: "0px", padding: "0px"}}>
-          <img style={{width: '100%'}} src={badgeImagePath} />
+          <img style={{width: '100%', height: "230px"}} src={badgeImagePath} />
         </Col>
       </Row>
       </div>

--- a/src/js/components/core/login/Profile.js
+++ b/src/js/components/core/login/Profile.js
@@ -1,20 +1,16 @@
 import React from 'react';
-import { Button, Row, Col, Image, Panel, ListGroup, FormGroup, FormControl } from 'react-bootstrap';
+import { Glyphicon, Image, Panel, ListGroup, FormGroup, FormControl } from 'react-bootstrap';
 
 class Profile extends React.Component {
   render() {
-    let { userdata, onHandleLogout } = this.props;
+    let { userdata, onHandleLogout, goToProjectsTab } = this.props;
     const panelTitle = (
-      <div style={{display: "flex"}}>
-        <h3>Category:</h3>
+      <div style={{display: "flex", justifyContent: "space-between"}}>
+        <h3 style={{marginTop: "10px"}}>Category:</h3>
         <FormControl onChange={this.props.subjectChange}
                      componentClass="select"
                      placeholder="Select Category"
-                     style={{
-                       marginTop: "16px",
-                       marginLeft: "130px",
-                       width: "240px"
-                     }}>
+                     style={{display: "flex", justifyContent: "flex-end", width: "200px", marginTop: "10px"}}>
           <option value="General Feedback">General Feedback</option>
           <option value="Content Feedback">Content & Resources Feedback</option>
           <option value="Bug Report">Bug Report</option>
@@ -22,9 +18,8 @@ class Profile extends React.Component {
       </div>
     );
     return (
-    <div>
-      <Row style={{marginLeft: "0px", marginRight: "0px"}}>
-        <Col sm={12} md={4} lg={4} style={{backgroundColor: "var(--reverse-color)", paddingTop: "20px", height: "520px", display: "flex", flexDirection: "column", justifyContent: "space-between", borderRight: "1px solid var(--border-color)"}}>
+    <div style={{display: "flex"}}>
+        <div style={{backgroundColor: "var(--reverse-color)", overflowY: "auto", display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "center", flex: "1", padding: "1rem", height: "520px"}}>
           <div style={{display: "flex", flexDirection: "column", alignItems: "center" }}>
             <h3>Account Information</h3>
             <Image style={{height: '85px', margin: "30px 0" }}
@@ -33,26 +28,39 @@ class Profile extends React.Component {
             <small>This is publicly visible</small>
           </div>
           <div style={{display: "flex", justifyContent: "center" }}>
-              <Button bsStyle="prime"
-                      onClick={onHandleLogout}>
-                  Log Out
-              </Button>
+              <button
+                className="btn-prime"
+                onClick={onHandleLogout}>
+                Log Out
+              </button>
           </div>
-        </Col>
-        <Col sm={12} md={6} lg={8} style={{padding: "20px 25px 0px 25px", height: "520px"}}>
+        </div>
+        <div style={{backgroundColor: "var(--reverse-color)", display: "flex", flexDirection: "column", justifyContent: "space-between", flex: "2", padding: "1rem", height: "520px"}}>
+          <div style={{alignItems: "center"}}>
           <h3>Feedback and Comments</h3><br />
           <Panel header={panelTitle} style={{padding: "0px", borderColor: "var(--border-color)"}}>
             <ListGroup fill>
             <FormGroup controlId="formControlsTextarea" style={{marginBottom: '0px'}}>
-              <FormControl value={this.props.feedback} onChange={this.props.feedbackChange} componentClass="textarea" style={{height: "250px", color: "var(--text-color-dark)", padding: "20px", borderRadius: '0px'}} placeholder="Leave us your feedback!" />
+              <FormControl value={this.props.feedback} onChange={this.props.feedbackChange} componentClass="textarea" style={{height: "200px", color: "var(--text-color-dark)", padding: "20px", borderRadius: '0px'}} placeholder="Leave us your feedback!" />
             </FormGroup>
-            <Button onClick={this.props.submitFeedback} bsStyle="prime" style={{width: '100%', margin: "0"}}>
+            <button
+              className="btn-prime"
+              style={{width: '100%', margin: "0"}}
+              onClick={this.props.submitFeedback}>
               Submit
-            </Button>
+            </button>
             </ListGroup>
           </Panel>
-        </Col>
-      </Row>
+          </div>
+          <div style={{display: "flex", justifyContent: "flex-end"}}>
+            <button
+              className="btn-second"
+              onClick={goToProjectsTab}>
+              Next&nbsp;&nbsp;
+              <Glyphicon glyph="share-alt" />
+            </button>
+          </div>
+        </div>
     </div>
     );
   }

--- a/src/js/containers/ApplicationModalContainer.js
+++ b/src/js/containers/ApplicationModalContainer.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { connect  } from 'react-redux';
 import { Tabs, Tab } from 'react-bootstrap/lib';
 // components
-import Login from '../components/core/login/Login.js';
+import Login from '../components/core/login/Login';
 import Profile from '../components/core/login/Profile';
-import Licenses from '../components/core/licenses/Licenses.js'
+import Licenses from '../components/core/licenses/Licenses';
 // Actions
-import * as LoginActions from '../actions/LoginActions.js';
-import * as SettingsActions from '../actions/SettingsActions.js';
+import * as LoginActions from '../actions/LoginActions';
+import * as SettingsActions from '../actions/SettingsActions';
+import * as modalActions from '../actions/modalActions';
 
 class ApplicationModalContainer extends React.Component {
 
@@ -69,7 +70,10 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     },
     loginLocalUser: (localUsername) => {
       dispatch(LoginActions.loginLocalUser(localUsername));
-    }
+    },
+    goToProjectsTab: () => {
+      dispatch(modalActions.selectModalTab(2, 1, true));
+    },
   };
 };
 

--- a/src/js/containers/ApplicationModalContainer.js
+++ b/src/js/containers/ApplicationModalContainer.js
@@ -8,7 +8,7 @@ import Licenses from '../components/core/licenses/Licenses';
 // Actions
 import * as LoginActions from '../actions/LoginActions';
 import * as SettingsActions from '../actions/SettingsActions';
-import * as modalActions from '../actions/modalActions';
+import * as modalActions from '../actions/ModalActions';
 
 class ApplicationModalContainer extends React.Component {
 

--- a/src/js/containers/ModalContainer.js
+++ b/src/js/containers/ModalContainer.js
@@ -30,7 +30,12 @@ class ModalContainer extends React.Component {
                       </div>;
     return (
       <Modal bsSize="large" show={visible} onHide={hide}>
-        <Modal.Body style={{height: "600px", padding: "0px", backgroundColor: "var(--reverse-color)" }}>
+              <Glyphicon
+                onClick={() => hide()}
+                glyph={"remove"}
+                style={{color: "#ffffff", cursor: "pointer", fontSize: "16px", float: "right", zIndex: "9999", margin: "10px"}}
+              />
+        <Modal.Body style={{height: "550px", padding: "0px", backgroundColor: "var(--reverse-color)" }}>
           <Tabs activeKey={currentTab}
                 onSelect={(e) => selectModalTab(e, 1, true)}
                 id="tabs"
@@ -50,11 +55,8 @@ class ModalContainer extends React.Component {
             </Tab>
           </Tabs>
         </Modal.Body>
-        <Modal.Footer style={{padding: "10px", backgroundColor: "var(--reverse-color)", borderTop: "1px solid var(--border-color)"}}>
-          <Button bsStyle="second" style={{float: "right"}} onClick={() => hide()}>Close</Button>
-        </Modal.Footer>
       </Modal>
-    )
+    );
   }
 }
 
@@ -69,8 +71,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     hide: () => {
       dispatch(modalActions.showModalContainer(false));
     },
-    selectModalTab: (e, section, visible) => {
-      dispatch(modalActions.selectModalTab(e, section, visible));
+    selectModalTab: (tabKey, sectionKey, visible) => {
+      dispatch(modalActions.selectModalTab(tabKey, sectionKey, visible));
     },
     selectSectionTab: (tabKey, sectionKey) => {
       dispatch(modalActions.selectSectionTab(tabKey, sectionKey));


### PR DESCRIPTION
###This pull request addresses:

#1502 #1473 

- [x] Add "Next" button to the Profile Screen. 
- [x] Move "Close" to an "x" in the top right
- [x] The Main modal flows below bottom causing scroll bar on far right. Using that scroll bar scrolls the entire modal up and down. The entire modal should fit in this screen size.

### How to test this pull request:

- Verify that all the issues above are fixed.
- Open the modal login to either local user or door43 account.
- Verify there's a `next` button on the far right that when clicked opens the projects tab.
- Change the app screen size and make sure the main modal is always visible no matter the size of the app window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1534)
<!-- Reviewable:end -->
