### PR TITLE
Change styling of secondary tabs in modal

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -78,37 +78,29 @@ body {
 }
 
 /*
-The following .nav, .nav-tabs classes hanlde the styling for the tabs in the
-tools. they basically override bootstrap styling for this components
+The following .nav-tabs and .nav-pills classes handle the styling for the tabs in the
+main modal. They basically override bootstrap styling for these components
 */
 
 .nav-tabs {
-  border-bottom: none;
+  border-bottom: 1px solid var(--accent-color-dark);
 }
 
-.nav>li>a:hover {
-  background-color: var(--accent-color-dark);
-  border: none;
-  border-radius: 0;
-  outline: none;
-}
-
-.nav-tabs>li>a {
+.nav-tabs>li>a, .nav-tabs>li>a:focus, .nav-tabs>li>a:hover {
   color: var(--reverse-color);
   background-color: var(--accent-color-dark);
   width: 150px;
   height: 40px;
+  outline: none;
   border: none;
   border-radius: 0;
 }
 
 .nav-tabs>li.active>a, .nav-tabs>li.active>a:focus, .nav-tabs>li.active>a:hover{
   color: var(--accent-color-dark);
-  cursor: default;
   background-color: var(--reverse-color);
-  outline: none;
-  border: none;
-  border-radius: 0;
+  cursor: default;
+  font-weight: bold;
 }
 
 .nav-pills {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -104,35 +104,23 @@ main modal. They basically override bootstrap styling for these components
 }
 
 .nav-pills {
-  border-bottom: 1px solid var(--border-color);
+  border: none;
 }
 
-.nav-pills>li>a {
-  position: relative;
-  display: block;
-  width: 250px;
+.nav-pills>li>a, .nav-pills>li>a:focus, .nav-pills>li>a:hover {
+  color: var(--reverse-color);
+  background-color: var(--accent-color);
+  width: 225px;
   height: 40px;
-  color: var(--text-color-light);
-  background-color: var(--reverse-color);
   outline: none;
   border-radius: 0;
 }
 
-.nav-pills>li>a:hover {
-  background-color: var(--reverse-color);
-  border: none;
-  border-radius: 0;
-}
-
-.nav-pills>li.active>a {
-  font-weight: 600;
-}
-
 .nav-pills>li.active>a, .nav-pills>li.active>a:focus, .nav-pills>li.active>a:hover {
-  color: var(--accent-color-dark);
+  color: var(--accent-color);
   background-color: var(--reverse-color);
-  border-radius: 0;
-  box-sizing: border-box;
+  cursor: default;
+  font-weight: bold;
 }
 
 #table td:nth-child(n+3):nth-child(-n+5) {

--- a/src/js/actions/ImportOnlineActions.js
+++ b/src/js/actions/ImportOnlineActions.js
@@ -49,6 +49,10 @@ export function importOnlineProject(link) {
 
                 if (err.toString().includes("fatal: unable to access")) {
                     errmessage = "Unable to connect to the server. Please check your Internet connection.";
+                } else if (err.toString().includes("fatal: The remote end hung up")) {
+                    errmessage = "Unable to connect to the server. Please check your Internet connection.";
+                } else if (err.toString().includes("Failed to load")) {
+                    errmessage = "Unable to connect to the server. Please check your Internet connection.";
                 } else if (err.toString().includes("fatal: repository")) {
                     errmessage = "The URL does not reference a valid project";
                 } else if (err.type && err.type === "custom") {

--- a/src/js/components/core/SwitchCheck.js
+++ b/src/js/components/core/SwitchCheck.js
@@ -8,14 +8,16 @@ class SwitchCheck extends React.Component {
     let buttons = [];
     if (toolsMetadatas.length == 0 ) {
       return (
-          <div style={{color: "var(--reverse-color)"}}>No tC default tools found.</div>
+          <div style={{backgroundColor: "var(--reverse-color)", textAlign: "center", verticalAlign: "middle", height: "520px"}}>No tC default tools found.</div>
       );
     } else if (!this.props.projectSaveLocation || !this.props.manifest) {
       return (
+      <div style={{backgroundColor: "var(--reverse-color)", padding: "10px", height: "520px"}}>
         <h3 style={{marginTop: "0px", textAlign: 'center', fontWeight: 'bold', padding: '55px 0'}}>
           Please <span onClick={this.props.showLoad} style={{cursor: 'pointer', color: 'var(--accent-color)'}}>
           load a project </span> before choosing a tool
         </h3>
+      </div>
       );
     } else {
       for (let i in toolsMetadatas) {
@@ -30,7 +32,7 @@ class SwitchCheck extends React.Component {
       }
     }
     return (
-      <div style={{padding: "10px", height: "520px", overflowY: "auto"}}>
+      <div style={{backgroundColor: "var(--reverse-color)", padding: "10px", height: "520px", overflowY: "auto"}}>
           {buttons}
       </div>
     );

--- a/src/js/containers/ApplicationModalContainer.js
+++ b/src/js/containers/ApplicationModalContainer.js
@@ -24,7 +24,7 @@ class ApplicationModalContainer extends React.Component {
       <div>
         <Tabs defaultActiveKey={1} id="uncontrolled-tab-example"
               bsStyle="pills"
-              style={{borderBottom: "none", backgroundColor: "var(--reverse-color)", color: 'var(--text-color)', width: "100%"}}>
+              style={{borderBottom: "none", backgroundColor: "var(--accent-color)", color: 'var(--text-color)', width: "100%"}}>
           <Tab eventKey={1} title="Account">
               {accountDisplay}
           </Tab>

--- a/src/js/containers/ImportOnlineContainer.js
+++ b/src/js/containers/ImportOnlineContainer.js
@@ -73,7 +73,7 @@ class ImportOnlineContainer extends React.Component {
     let {handleOnlineChange, loadProjectFromLink} = this.props.actions;
     let {importLink, showLoadingCircle} = this.props.importOnlineReducer;
     return (
-      <div style={{height: "520px"}}>
+      <div style={{height: "520px", backgroundColor: "var(--reverse-color)"}}>
         <Projects {...this.props} onlineProjects={onlineProjects} showLoadingCircle={showLoadingCircle}/>
         <div style={{display: "flex", flexDirection: "column", alignItems: "center"}}>
           <div style={{fontSize: "18px", fontWeight: "bold", margin: "15px 0 10px"}}>

--- a/src/js/containers/LoadModalContainer.js
+++ b/src/js/containers/LoadModalContainer.js
@@ -22,7 +22,7 @@ class LoadModalContainer extends React.Component {
           activeKey={this.props.currentSection}
           onSelect={(e) => selectSectionTab(2, e)}
           bsStyle="pills"
-          style={{ borderBottom: "none", backgroundColor: "var(--reverse-color)", color: 'var(--text-color)', width: "100%" }}>
+          style={{ borderBottom: "none", backgroundColor: "var(--accent-color)", color: 'var(--text-color)', width: "100%" }}>
           <Tab eventKey={1} title="My Projects">
             <RecentProjectsContainer />
           </Tab>

--- a/src/js/containers/ModalContainer.js
+++ b/src/js/containers/ModalContainer.js
@@ -34,9 +34,9 @@ class ModalContainer extends React.Component {
               <Glyphicon
                 onClick={() => hide()}
                 glyph={"remove"}
-                style={{color: "#ffffff", cursor: "pointer", fontSize: "16px", float: "right", zIndex: "9999", margin: "10px"}}
+                style={{color: "var(--reverse-color)", cursor: "pointer", fontSize: "16px", float: "right", zIndex: "9999", margin: "10px"}}
               />
-        <Modal.Body style={{height: "550px", padding: "0px", backgroundColor: "var(--reverse-color)" }}>
+        <Modal.Body style={{height: "550px", padding: "0px", backgroundColor: "var(--accent-color-dark)" }}>
           <Tabs activeKey={currentTab}
                 onSelect={(e) => selectModalTab(this.props.loginReducer.loggedInUser, e, 1, true)}
                 id="tabs"

--- a/src/js/containers/RecentProjectsContainer.js
+++ b/src/js/containers/RecentProjectsContainer.js
@@ -92,7 +92,7 @@ class RecentProjectsContainer extends React.Component {
     let recentProjectsData = this.getRecentProjects();
 
     return (
-      <div>
+      <div style={{ backgroundColor: "var(--reverse-color)" }}>
         <RecentProjects.Component data={recentProjectsData} />
       </div>
     )

--- a/src/js/containers/ToolsModalContainer.js
+++ b/src/js/containers/ToolsModalContainer.js
@@ -19,7 +19,7 @@ class ToolsModalContainer extends React.Component {
       <div>
         <Tabs defaultActiveKey={1} id="uncontrolled-tab-example"
               bsStyle="pills"
-              style={{borderBottom: "none", backgroundColor: "var(--reverse-color)", color: 'var(--text-color)', width: "100%"}}>
+              style={{borderBottom: "none", backgroundColor: "var(--accent-color)", color: 'var(--text-color)', width: "100%"}}>
           <Tab eventKey={1} title="Available Tools">
             <SwitchCheck {...this.props}/>
           </Tab>


### PR DESCRIPTION
#### This pull request addresses:

issue #1406 and some additional error handling for importing related to issue #1373 in QA



#### How to test this pull request:

Open up main modal.  The secondary tabs should be formatted with the lighter blue in the same style the upper tabs are (colored background when not selected, white background when selected).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1543)
<!-- Reviewable:end -->
