### PR TITLE
Refresh user projects when switching tabs

### DIFF
--- a/src/js/containers/RecentProjectsContainer.js
+++ b/src/js/containers/RecentProjectsContainer.js
@@ -20,6 +20,12 @@ class RecentProjectsContainer extends React.Component {
     this.props.getProjectsFromFolder();
   }
 
+  componentWillReceiveProps(newProps) {
+    if (newProps.modalReducer.currentSection === 1 && newProps.modalReducer.currentTab === 2 && (newProps.modalReducer.currentTab !== this.props.modalReducer.currentTab || newProps.modalReducer.currentSection !== this.props.modalReducer.currentSection)) {
+      this.props.getProjectsFromFolder();
+    }
+  }
+
   generateButton(projectPath, manifest) {
     return (
       <span>
@@ -104,7 +110,8 @@ const mapStateToProps = state => {
     ...state.recentProjectsReducer,
     manifest: state.projectDetailsReducer.manifest,
     loggedInUser: state.loginReducer.loggedInUser,
-    userdata: state.loginReducer.userdata
+    userdata: state.loginReducer.userdata,
+    modalReducer: state.newModalReducer
   };
 };
 


### PR DESCRIPTION
#### This pull request addresses:

This pull request addresses #1472. What it does is refreshes the local projects list when going to the recent projects tab. 

#### How to test this pull request:

Look at the recent projects tab. Delete a project, switch tabs and go back. Import an online project, then look at the recent projects tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1550)
<!-- Reviewable:end -->
