### PR TITLE
Force users to click to close alerts

### DIFF
--- a/src/js/components/dialogComponents/Alert.js
+++ b/src/js/components/dialogComponents/Alert.js
@@ -35,7 +35,6 @@ class Alert extends Component {
           actions={actions}
           modal={false}
           open={alertDialogVisibility}
-          onRequestClose={closeAlertDialog}
         >
         <CardHeader
             style={{ color: "var(--reverse-color)", backgroundColor: 'var(--accent-color-dark)', padding: '15px', margin: "-44px -24px -24px -24px"}}

--- a/src/js/containers/AlertDialogContainer.js
+++ b/src/js/containers/AlertDialogContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 // components
-import Alert from '../components/core/dialogComponents/Alert'
+import Alert from '../components/dialogComponents/Alert'
 // actions
 import { closeAlertDialog } from '../actions/AlertModalActions'
 


### PR DESCRIPTION
#### This pull request addresses:

An issue found during QA, we now need users to click okay to close the alert, rather than anywhere.


#### How to test this pull request:

Open an alert, try to exit by clicking outside of it. Exit clicking "Ok"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1551)
<!-- Reviewable:end -->
