### PR TITLE
Fix Verbage and Error Handling For CSV

### DIFF
--- a/src/js/actions/RecentProjectsActions.js
+++ b/src/js/actions/RecentProjectsActions.js
@@ -100,7 +100,7 @@ export function exportToCSV(projectPath) {
     dispatch(getDataActions.clearPreviousData());
 
     let toolPaths = getToolFolderNames(projectPath);
-    if (!toolPaths) dispatch(AlertModalActions.openAlertDialog('Project Has No Checkdata'));
+    if (!toolPaths) dispatch(AlertModalActions.openAlertDialog('No checks have been performed in this project.'));
     let dataFolder = path.join(projectPath, 'apps', 'translationCore');
     var fn = function (newPaths) {
       saveAllCSVDataByToolName(newPaths[0], dataFolder, params, (result) => {
@@ -110,8 +110,9 @@ export function exportToCSV(projectPath) {
         else {
           saveDialog(dataFolder, projectName, (result) => {
             fs.remove(path.join(dataFolder, 'output'));
-            if (loadedSuccessfully) dispatch(AlertModalActions.openAlertDialog('Data Exported Successfully To CSV'));
-            else dispatch(AlertModalActions.openAlertDialog('Failed To Export To CSV'));
+            if (loadedSuccessfully && result) dispatch(AlertModalActions.openAlertDialog('Export Successful'));
+            else if (!result) dispatch(AlertModalActions.openAlertDialog('Export Cancelled'));
+            else dispatch(AlertModalActions.openAlertDialog('Failed To Export'));
           })
         }
       })
@@ -138,7 +139,7 @@ export function saveVerseEditsToCSV(obj, dataFolder, toolName) {
         addContextIdToCSV(currentRowArray, currentRow.contextId)
         csvString += currentRowArray.join(',') + "\n";
       }
-      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'verseEditsData.csv'), csvString);
+      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'VerseEdits.csv'), csvString);
     } catch (e) { reject(false) };
     resolve(true);
   });
@@ -160,7 +161,7 @@ export function saveCommentsToCSV(obj, dataFolder, toolName) {
         addContextIdToCSV(currentRowArray, currentRow.contextId)
         csvString += currentRowArray.join(',') + "\n";
       }
-      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'commentsData.csv'), csvString);
+      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'Comments.csv'), csvString);
     } catch (e) { reject(false) };
     resolve(true);
   });
@@ -186,7 +187,7 @@ export function saveSelectionsToCSV(obj, dataFolder, toolName) {
           csvString += currentRowArray.join(',') + "\n";
         }
       }
-      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'selectionsData.csv'), csvString);
+      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'Selections.csv'), csvString);
     } catch (e) { reject(false) };
     resolve(true);
   });
@@ -208,7 +209,7 @@ export function saveRemindersToCSV(obj, dataFolder, toolName) {
         addContextIdToCSV(currentRowArray, currentRow.contextId)
         csvString += currentRowArray.join(',') + "\n";
       }
-      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'remindersData.csv'), csvString);
+      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'Reminders.csv'), csvString);
     } catch (e) { reject(false) };
     resolve(true);
   });
@@ -233,7 +234,7 @@ export function saveGroupsCSVToFs(obj, dataFolder, toolName) {
           csvString += currentRowArray.join(',') + "\n";
         }
       }
-      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'groupsData.csv'), csvString);
+      fs.outputFileSync(path.join(dataFolder, 'output', toolName, 'CheckInformation.csv'), csvString);
     } catch (e) { reject(false) };
     resolve(true);
   });


### PR DESCRIPTION
#### This pull request addresses:
This PR changes the display message when the user cancels a csv export and also changes when there is no check data


#### How to test this pull request:
Try exporting with and without checkdata and also try cancelling before you finish with the export.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1555)
<!-- Reviewable:end -->
