### PR TITLE
No longer use password for Git pushes, use tokens instead

### DIFF
--- a/src/js/actions/RecentProjectsActions.js
+++ b/src/js/actions/RecentProjectsActions.js
@@ -40,7 +40,7 @@ export function uploadProject(projectPath, user) {
     );
 
     gogs(user.token).createRepo(user, projectName).then(repo => {
-      var newRemote = 'https://' + user.username + ":" + user.password + '@git.door43.org/' + repo.full_name + '.git';
+      var newRemote = 'https://' + user.token + '@git.door43.org/' + repo.full_name + '.git';
 
       git(projectPath).save(user, 'Commit before upload', projectPath, err => {
         if(err) {


### PR DESCRIPTION
#### This pull request addresses:

For whatever reason, the way we used to push to git with tokens works, so now we can be secure again.


#### How to test this pull request:

Login, upload a project, see if it actually works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1617)
<!-- Reviewable:end -->
