### PR TITLE
Remove tool tester from dev mode

### DIFF
--- a/src/js/components/core/SwitchCheck.js
+++ b/src/js/components/core/SwitchCheck.js
@@ -24,7 +24,8 @@ class SwitchCheck extends React.Component {
         const metadata = toolsMetadatas[i];
         if (metadata.name == "ToolsTester") {
           if (this.props.currentSettings.developerMode) {
-            buttons.push(<AppDescription key={i} metadata={metadata} {...this.props} />);
+            // Removing tool tester for beta
+            // buttons.push(<AppDescription key={i} metadata={metadata} {...this.props} />);
           }
         } else {
           buttons.push(<AppDescription key={i} metadata={metadata} {...this.props} />);


### PR DESCRIPTION
#### This pull request addresses:

Addresses #1540 by not displaying the tool tester option.

#### How to test this pull request:

Load a project while in developer mode to see if Toolstester is an option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1624)
<!-- Reviewable:end -->
