### PR TITLE
QA issues for 1548

### DIFF
--- a/src/js/components/core/login/Door43Login.js
+++ b/src/js/components/core/login/Door43Login.js
@@ -16,7 +16,9 @@ class Door43Login extends React.Component {
 
   render() {
     let { displayLogin, showPopover } = this.props;
-    let disabledButton = this.state.username == null || this.state.password == null
+    let u = this.state.username
+    let p = this.state.password
+    let disabledButton = (u == null || u == "") || (p == null || p == "")
     if (!displayLogin) {
       return (
         <Col md={12} sm={12} xs={12} style={{ marginTop: "50px" }}>

--- a/src/js/components/core/login/pages/CreativeCommonsPage.js
+++ b/src/js/components/core/login/pages/CreativeCommonsPage.js
@@ -12,6 +12,14 @@ class CreativeCommonsPage extends Component {
           Go Back
         </button>
         <div style={{color: "var(--reverse-color)", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center"}}>
+          <h4><b>Creative Commons Attribution-ShareAlike 4.0 License</b></h4>
+          <p style={{padding: "15px"}}>
+            This is a human-readable summary of (and not a substitute for) the&nbsp;
+            <a style={{color: "var(--reverse-color)",cursor: "pointer", textDecoration: "underline"}}
+              href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">
+              license
+            </a>
+          </p>
           <h4><b>You are free to:</b></h4>
           <p>
             <b>Share</b> — copy and redistribute the material in any medium or format.

--- a/src/js/components/core/login/pages/TermsAndConditionsPage.js
+++ b/src/js/components/core/login/pages/TermsAndConditionsPage.js
@@ -14,16 +14,6 @@ class TermsAndConditionsPage extends Component {
         <div style={{color: "var(--reverse-color)", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center"}}>
           <h4 style={{marginTop: "40px"}}><b>Terms and Conditions</b></h4>
           <div>
-          <p style={{padding: "15px"}}>
-            Creative Commons Attribution-ShareAlike 4.0 License
-          </p>
-          <p style={{padding: "15px"}}>
-            This is a human-readable summary of (and not a substitute for) the&nbsp;
-            <a style={{color: "var(--reverse-color)",cursor: "pointer", textDecoration: "underline"}}
-              href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">
-              license
-            </a>
-          </p>
             <p style={{padding: "15px"}}>
               By creating a Door43 account, you affirm that you have read
               and understand the terms and conditions and agree to:


### PR DESCRIPTION
#### This pull request addresses:

Addresses QA issues for https://github.com/unfoldingWord-dev/translationCore/issues/1548



#### How to test this pull request:

On the door 43 login page, the login button should now be disabled if either field is blank.
Click "Terms and Conditions" link on the localLogin side and then click on the "Creative Commons...." link on the bottom, There should be a new title and paragraph on top now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1632)
<!-- Reviewable:end -->
