### PR TITLE
Use appropriate git based on arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_deploy:
     sudo add-apt-repository --yes ppa:arx/release ;
     sudo apt-get update -d ;
     sudo apt-get install -y -q innoextract wine python-software-properties ;
+    mkdir installers ;
+    curl -L https://github.com/git-for-windows/git/releases/download/v2.9.2.windows.1/Git-2.9.2-32-bit.exe > ./installers/GitInstaller-32.exe ;
+    curl -L https://github.com/git-for-windows/git/releases/download/v2.9.2.windows.1/Git-2.9.2-64-bit.exe > ./installers/GitInstaller-64.exe ;
     chmod +x ./scripts/inno/InnoInstall.sh ;
     "./scripts/inno/InnoInstall.sh" ;
     cd /home/travis/build/unfoldingWord-dev/translationCore ;

--- a/main.js
+++ b/main.js
@@ -19,14 +19,17 @@ function createMainWindow () {
   mainWindow = new BrowserWindow({icon: 'images/TC_Icon.png', autoHideMenuBar: true, minWidth: 1100, minHeight: 650, center: true, useContentSize: true, show: false});
 
   //mainWindow.webContents.openDevTools();
-
-  let installerLocation = path.join(path.datadir('translationCore'), 'GitInstaller.exe');
+  var gitFile = 'GitInstaller-32.exe';
+  if (process.env.PROCESSOR_ARCHITECTURE === "AMD64") {
+    gitFile = 'GitInstaller-64.exe';
+  }
+  let installerLocation = path.join(path.datadir('translationCore'), gitFile);
   exec('git', (err, data) => {
     if (!data) {
       if (process.platform == 'win32') {
         dialog.showErrorBox('Startup Failed', 'You must have Git installed and on your path in order to use translationCore. \nClick OK to install Git now.');
-        fs.copySync(__dirname + '/installers/GitInstaller.exe', installerLocation);
-        exec('GitInstaller.exe /SILENT /COMPONENTS="assoc"', {cwd: path.datadir('translationCore')}, function(err, data) {
+        fs.copySync(__dirname + '/installers/' + gitFile, installerLocation);
+        exec(gitFile + ' /SILENT /COMPONENTS="assoc"', {cwd: path.datadir('translationCore')}, function(err, data) {
           if (err) {
             console.log(err);
             dialog.showErrorBox('Git Installation Failed', 'The git installation failed.');


### PR DESCRIPTION
#### This pull request addresses:

Previously, we only installed the 32 bit version of git, so if a system was 64 bit and had git, there were 2 copies. Now we install the appropriate git based on system arch. 


#### How to test this pull request:

##### Windows Only
Have git 64 bit installed on a windows machine, version 2.9.2. Make sure that git is not on the path. Start tC, click yes to install git. When it is complete, look at programs and features to make sure that only 1 version of git exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1634)
<!-- Reviewable:end -->
