### PR TITLE
Fixed bug with lost menu Progress 

### DIFF
--- a/src/js/actions/GetDataActions.js
+++ b/src/js/actions/GetDataActions.js
@@ -397,6 +397,7 @@ function loadGroupDataFromFS(dispatch, dataDirectory, toolName, params) {
         i++;
       }
       dispatch(GroupsDataActions.loadGroupsDataFromFS(allGroupsObjects));
+      dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
       console.log('Loaded group data from fs');
       resolve("success");
     } else {
@@ -485,8 +486,12 @@ export function startModuleFetchData() {
       .then(() => {
         // TODO: this action may stay here temporary until the home screen implementation.
         dispatch(BodyUIActions.toggleHomeView(false));
+        resolve();
+      })
+      .then(() => {
+        dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+        resolve();
       });
-      resolve("success");
     });
   });
 }

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -5,10 +5,10 @@ import path from 'path-extra';
 const CHECKDATA_DIRECTORY = path.join('.apps', 'translationCore', 'checkData');
 
 /**
- * @description This action adds a groupName as a property to the
+ * @description This action adds a groupId as a property to the
  *  groups object and assigns payload as its value.
- * @param {string} groupName - groupName of object ex. figs_metaphor.
- * @param {array} groupData - array of objects containing group data.
+ * @param {string} groupId - groupId of object ex. figs_metaphor.
+ * @param {array} groupsData - array of objects containing group data.
  * @return {object} action object.
  */
 export const addGroupData = (groupId, groupsData) => {
@@ -19,7 +19,7 @@ export const addGroupData = (groupId, groupsData) => {
   };
 };
 
-export const loadGroupsDataFromFS = (allGroupsData) => {
+export const loadGroupsDataFromFS = allGroupsData => {
   return {
     type: consts.LOAD_GROUPS_DATA_FROM_FS,
     allGroupsData
@@ -121,7 +121,7 @@ function toggleGroupDataItems(label, fileObject, dispatch) {
       });
       break;
     default:
-      console.warn("undefined label in toggleGroupDataItems switch");
+      console.warn("Undefined label in toggleGroupDataItems switch");
       break;
   }
 }


### PR DESCRIPTION
#### This pull request addresses:

- Fixed bug where checking work was not reflected by menu progress and glypicans.

#### How to test this pull request:
1. Open tW or tN make a selection or leave a comment.
2. In your projects folder  go to .apps/translationCore/index/translationWords/eph (**book abbreviation**)
3. Find the group data name that you made your selection or comment. 
4. if you made a selection and wrote a comment your group data should look as follow.
```
{
    "priority": 1,
    "comments": true,
    "reminders": false,
    "selections": true,
    "verseEdits": false,
    "contextId": {
      "reference": {
        "bookId": "eph",
        "chapter": 1,
        "verse": 5
      },
      "tool": "translationWords",
      "groupId": "adoption",
      "quote": "adoption",
      "occurrence": 1
    }
  }
```
but to test this PR you need to change comments and selections to false.

5. then refresh your app and come back to this file or just see it on the screen that both comments and selections were changed back to true.

6. The second test scenario would be in your project go to .apps/translationCore/ and delete the index folder and refresh the app and it should generate the data again with comments and selections being equal to true for that check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1635)
<!-- Reviewable:end -->
