### PR TITLE
Fixed verse edit bug which wouldn't render verse edits to on the Select pane.

### DIFF
--- a/src/js/helpers/editTargetVerseSource.js
+++ b/src/js/helpers/editTargetVerseSource.js
@@ -15,7 +15,9 @@ export function editTargetVerseSource(state, editedText) {
     chapter = "0" + chapter;
   }
   let writeFolder = path.join(saveLocation, chapter);
-  let contents = fs.readdirSync(writeFolder);
+  let contents = fs.readdirSync(writeFolder).filter(file => {
+    return file !== "title.txt";
+  });
   let writeFile = null;
   for (let i = 0; i < contents.length; i++) {
     let chunk = contents[i];
@@ -30,7 +32,7 @@ export function editTargetVerseSource(state, editedText) {
   for (let i = 0; i < tokenizedFile.length; i++) {
     let item = tokenizedFile[i];
     let trimmedItem = item.trim();
-    let currentVerse = parseInt(trimmedItem.split(' ')[0]);
+    let currentVerse = parseInt(trimmedItem.split(' ')[0], 10);
     if (currentVerse === verse) {
       tokenizedFile[i] = " " + verse + " " + editedText + " ";
       break;


### PR DESCRIPTION
#### This pull request addresses:

#1618

#### How to test this pull request:

- Import a clean project from Door43 (https://git.door43.org/pjoakes/fr_eph_text_ulb)
- Navigate to Metaphor and Eph 2:19
- Make an Edit adding some text to the verse.
- Click on the Save button and it should close the edit pane and add the edited text to the Select pane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1638)
<!-- Reviewable:end -->
