### PR TITLE
fixed error path of logo image in the loader modal (builds)

### DIFF
--- a/src/js/components/core/loader/Loader.js
+++ b/src/js/components/core/loader/Loader.js
@@ -11,7 +11,7 @@ class Loader extends React.Component {
       <MuiThemeProvider>
         <Dialog modal={true} open={show}>
           <div style={{height: "500px", display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', padding: "20px"}}>
-            <img className="App-logo" src={path.join(window.__base, "images/TC_icon.png")} alt="logo" style={{height: "350px", margin: "15px"}}/>
+            <img className="App-logo" src={window.__base + "images/TC_icon.png"} alt="logo" style={{height: "350px", margin: "15px"}}/>
             <span style={{margin: "20px"}}>Loading ...</span>
           </div>
         </Dialog>

--- a/src/js/helpers/editTargetVerseSource.js
+++ b/src/js/helpers/editTargetVerseSource.js
@@ -15,7 +15,9 @@ export function editTargetVerseSource(state, editedText) {
     chapter = "0" + chapter;
   }
   let writeFolder = path.join(saveLocation, chapter);
-  let contents = fs.readdirSync(writeFolder);
+  let contents = fs.readdirSync(writeFolder).filter(file => {
+    return file !== "title.txt";
+  });
   let writeFile = null;
   for (let i = 0; i < contents.length; i++) {
     let chunk = contents[i];
@@ -30,7 +32,7 @@ export function editTargetVerseSource(state, editedText) {
   for (let i = 0; i < tokenizedFile.length; i++) {
     let item = tokenizedFile[i];
     let trimmedItem = item.trim();
-    let currentVerse = parseInt(trimmedItem.split(' ')[0]);
+    let currentVerse = parseInt(trimmedItem.split(' ')[0], 10);
     if (currentVerse === verse) {
       tokenizedFile[i] = " " + verse + " " + editedText + " ";
       break;


### PR DESCRIPTION
#### This pull request addresses:

#1176 
This issue appears to only happen in the builds

#### How to test this pull request:

load a project and the spinning logo should render on the modal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1639)
<!-- Reviewable:end -->
