### PR TITLE
Add new In-Progress dialog to import and refresh

### DIFF
--- a/src/js/actions/ImportOnlineActions.js
+++ b/src/js/actions/ImportOnlineActions.js
@@ -2,7 +2,7 @@ import consts from './CoreActionConsts';
 import Gogs from '../components/core/login/GogsApi';
 import rimraf from 'rimraf';
 import * as getDataActions from './GetDataActions';
-import { openAlertDialog } from '../actions/AlertModalActions'
+import * as AlertModalActions from './AlertModalActions';
 // constant declaration
 const loadOnline = require('../components/core/LoadOnline');
 
@@ -42,7 +42,11 @@ export function updateRepos() {
 
 export function importOnlineProject(link) {
     return ((dispatch) => {
-        dispatch({ type: consts.SHOW_LOADING_CIRCLE });
+
+        dispatch(
+            AlertModalActions.openAlertDialog("Importing " + link + " Please wait...", true)
+        );
+
         loadOnline(link, function (err, savePath, url) {
             if (err) {
                 var errmessage = "An unknown problem occurred during import";
@@ -69,13 +73,12 @@ export function importOnlineProject(link) {
                     } catch (e) {}
                 }
 
-                dispatch(openAlertDialog(errmessage));
+                dispatch(AlertModalActions.openAlertDialog(errmessage));
                 dispatch({ type: "LOADED_ONLINE_FAILED" });
-                dispatch({ type: consts.HIDE_LOADING_CIRCLE });
             } else {
                 dispatch(clearLink());
+                dispatch(AlertModalActions.closeAlertDialog());
                 dispatch(getDataActions.openProject(savePath, url));
-                dispatch({ type: consts.HIDE_LOADING_CIRCLE });
             }
         });
     })

--- a/src/js/actions/ImportOnlineActions.js
+++ b/src/js/actions/ImportOnlineActions.js
@@ -23,14 +23,21 @@ export function updateRepos() {
         var user = getState().loginReducer.userdata;
         if (user) {
             var _this = this;
+
+            dispatch(
+                AlertModalActions.openAlertDialog("Retrieving list of projects...", true)
+            );
+
             Gogs().listRepos(user).then((repos) => {
+                dispatch(AlertModalActions.closeAlertDialog());
                 dispatch({
                     type: consts.RECIEVE_REPOS,
                     repos: repos
                 });
                 dispatch({type: consts.GOGS_SERVER_ERROR, err: null}); //Equivalent of saying "there is no error, successfull fetch"
             }).catch((e)=>{
-              console.log(e)
+              console.log(e);
+              dispatch(AlertModalActions.closeAlertDialog());
               dispatch({
                 type: consts.GOGS_SERVER_ERROR,
                 err: e

--- a/src/js/components/core/login/Projects.js
+++ b/src/js/components/core/login/Projects.js
@@ -1,31 +1,20 @@
 import React from 'react';
-import {Button} from 'react-bootstrap';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import {CircularProgress} from 'material-ui';
 
 class Projects extends React.Component {
   render() {
-    let {showLoadingCircle} = this.props;
     return (
-        <MuiThemeProvider>
-            <div style={{height: '400px', borderBottom: "1px solid var(--border-color)"}}>
-                <div style={{height: "50px", display: "flex", justifyContent: "center", alignItems: "center", borderBottom: "1px solid var(--border-color)"}}>
-                    <span style={{fontSize: '20px', margin: "0 10px"}}>Your Door43 Projects</span>
-                    <div style={{width: "60px", display: "flex", justifyContent: "center"}}>
-                        {showLoadingCircle ?
-                            (<CircularProgress size={30} thickness={4} color={"var(--accent-color-dark)"} />) : ""
-                        }
-                    </div>
-                    <Button bsStyle="second"
-                            onClick={() => this.props.actions.updateRepos()}>
-                        Refresh
-                    </Button>
-                </div>
-                <div style={{height: "350px", overflowY: "auto"}}>
-                    {this.props.onlineProjects}
-                </div>
-            </div>
-        </MuiThemeProvider>
+    <div style={{height: '400px', borderBottom: "1px solid var(--border-color)"}}>
+        <div style={{height: "50px", display: "flex", justifyContent: "center", alignItems: "center", borderBottom: "1px solid var(--border-color)"}}>
+            <span style={{fontSize: '20px', margin: "0 30px"}}>Your Door43 Projects</span>
+            <button className="btn-second"
+                    onClick={() => this.props.actions.updateRepos()}>
+                Refresh
+            </button>
+        </div>
+        <div style={{height: "350px", overflowY: "auto"}}>
+            {this.props.onlineProjects}
+        </div>
+    </div>
     );
   }
 }

--- a/src/js/containers/ImportOnlineContainer.js
+++ b/src/js/containers/ImportOnlineContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import {Button} from 'react-bootstrap/lib';
 // Components
 import Projects from '../components/core/login/Projects';
 import OnlineInput from '../components/core/OnlineInput';
@@ -13,10 +12,10 @@ class ImportOnlineContainer extends React.Component {
     return (
         <div key={p} style={{ width: '100%', padding: "0 80px", display: "flex", justifyContent: "space-between", borderBottom: "1px solid var(--border-color)", alignItems: "center" }}>
             {projectName}
-            <Button bsStyle="prime"
+            <button className="btn-prime"
                     onClick={() => this.props.actions.openOnlineProject(repoName)}>
               Import & Select
-            </Button>
+            </button>
         </div>
     );
   }
@@ -71,10 +70,10 @@ class ImportOnlineContainer extends React.Component {
   render() {
     let onlineProjects = this.makeList(this.props.importOnlineReducer.repos);
     let {handleOnlineChange, loadProjectFromLink} = this.props.actions;
-    let {importLink, showLoadingCircle} = this.props.importOnlineReducer;
+    let {importLink} = this.props.importOnlineReducer;
     return (
       <div style={{height: "520px", backgroundColor: "var(--reverse-color)"}}>
-        <Projects {...this.props} onlineProjects={onlineProjects} showLoadingCircle={showLoadingCircle}/>
+        <Projects {...this.props} onlineProjects={onlineProjects}/>
         <div style={{display: "flex", flexDirection: "column", alignItems: "center"}}>
           <div style={{fontSize: "18px", fontWeight: "bold", margin: "15px 0 10px"}}>
             Select one of your projects above or enter the URL of a project below


### PR DESCRIPTION
#### This pull request addresses:

Fixes issue #1613 to start using new "loading" dialog box when importing instead of spinner wheel.  Also added it to the refresh button.



#### How to test this pull request:

Go to projects Import page and import from your Door43 or from a URL.  The alert dialog should come up indicating progress and then either show an error or close and load the project.  Also, click refresh on your projects list and the dialog should pop up briefly while updating the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1644)
<!-- Reviewable:end -->
