### PR TITLE
Fix for bug when extra manifest files

### DIFF
--- a/src/js/components/core/LoadOnline.js
+++ b/src/js/components/core/LoadOnline.js
@@ -67,16 +67,16 @@ module.exports = (function() {
       if (err) {
         fs.removeSync(savePath);
         if (callback)
-          callback(err, null, null);
-        return;
-      }
-      try {
-        fs.readFileSync(path.join(savePath, 'manifest.json'));
-        if (callback)
-          callback(null, savePath, url);
-      } catch (error) {
-        if (callback)
-          callback({type: "custom", text: "Cannot read project manifest file"}, savePath, null);
+          callback({type: "custom", text: "Cannot clone repository"}, savePath, null);
+      } else {
+        try {
+          fs.readFileSync(path.join(savePath, 'manifest.json'));
+          if (callback)
+            callback(null, savePath, url);
+        } catch (error) {
+          if (callback)
+            callback({type: "custom", text: "Cannot read project files"}, savePath, null);
+        }
       }
     });
   }

--- a/src/js/components/core/LoadOnline.js
+++ b/src/js/components/core/LoadOnline.js
@@ -67,7 +67,7 @@ module.exports = (function() {
       if (err) {
         fs.removeSync(savePath);
         if (callback)
-          callback({type: "custom", text: "Cannot clone repository"}, savePath, null);
+          callback({type: "custom", text: "Cannot clone repository"}, null, null);
       } else {
         try {
           fs.readFileSync(path.join(savePath, 'manifest.json'));

--- a/src/js/helpers/LoadHelpers.js
+++ b/src/js/helpers/LoadHelpers.js
@@ -391,12 +391,11 @@ export function createCheckArray(dataObject, moduleFolderName) {
  */
 export function checkMissingVerses(book, projectSaveLocation) {
     let chapterArray = [];
-    let hash = {}
+    let hash = {};
     let chapters = fs.readdirSync(projectSaveLocation);
     for (let chapter of chapters) {
-        let intRepresentation = parseInt(chapter);
-        if (!isNaN(intRepresentation)) {
-            chapterArray[intRepresentation] = chapter;
+        if (chapter.length < 4 && !isNaN(parseInt(chapter))) {
+            chapterArray[parseInt(chapter)] = chapter;
         }
     }
     if (expectedVerses[book]) {

--- a/tests/b.LoadOnline.js
+++ b/tests/b.LoadOnline.js
@@ -22,7 +22,7 @@ describe('loadOnline.openManifest', function() {
     loadOnline('https://git.door43.org/ianhoegen123/id_-cfksl.git', function(err, savePath, url) {
       assert.isNull(savePath);
       assert.isNull(url);
-      assert.isString(err);
+      assert.isString(err.text);
       done();
     });
   });


### PR DESCRIPTION
#### This pull request addresses:

Allows importing and loading of projects with extra files (like manifests) that start with a number in the file name.



#### How to test this pull request:

open app and try importing this url...
https://git.door43.org/Ashley/es-419_eph_text_ulb
It should import and load now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1661)
<!-- Reviewable:end -->
