### PR TITLE
Add error handling for projects with no valid manifest

### DIFF
--- a/src/js/actions/GetDataActions.js
+++ b/src/js/actions/GetDataActions.js
@@ -73,6 +73,13 @@ export function openProject(projectPath, projectLink, exporting = false) {
       // No USFM detected, initiating 'standard' loading process
       projectPath = LoadHelpers.correctSaveLocation(projectPath);
       let manifest = LoadHelpers.loadFile(projectPath, 'manifest.json');
+
+      if (!manifest) {
+        dispatch(AlertModalActions.openAlertDialog("Oops! The project you are trying to load does not have a valid manifest and cannot be opened! Please contact Help Desk (help@door43.org) for assistance."));
+        dispatch(clearPreviousData());
+        return;
+      }
+
       manifest = LoadHelpers.verifyChunks(projectPath, manifest);
       LoadHelpers.migrateAppsToDotApps(projectPath);
       let conflictsFound = LoadHelpers.findMergeConflicts(manifest.finished_chunks, projectPath);


### PR DESCRIPTION
#### This pull request addresses:

If something happens to the manifest file in a project and then you try to load it, there were uncaught errors.  This has been fixed.



#### How to test this pull request:

Go to an existing project in your folder and delete the manifest, or put something in your project folder that isn't even a project.  Then try to select that broken project.  You should get an error message in the alert dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1662)
<!-- Reviewable:end -->
