### PR TITLE
fixed reference to door43 in Terms

### DIFF
--- a/src/js/components/core/login/pages/CreativeCommonsPage.js
+++ b/src/js/components/core/login/pages/CreativeCommonsPage.js
@@ -35,7 +35,7 @@ class CreativeCommonsPage extends Component {
           <h4><b>Under the following terms:</b></h4>
           <p>
             <b>Attribution</b> —  You must attribute the work as follows: "Original work available&nbsp;
-            at https://door43.org/." Attribution statements in derivative works should not in any way&nbsp;
+            at https://git.door43.org/." Attribution statements in derivative works should not in any way&nbsp;
             suggest that we endorse you or your use of this work
           </p>
           <p>


### PR DESCRIPTION
#### This pull request addresses:

Updated reference to git.door43



#### How to test this pull request:

Look at the Creative Commons page under Terms and Conditions, and verify the reference under Attribution is to git.door43.org

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1669)
<!-- Reviewable:end -->
