### PR TITLE
fixed bug with action that makes sure check data is reflected correctly in the menu

### DIFF
--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -53,17 +53,25 @@ export function verifyGroupDataMatchesWithFs() {
           verses = filterAndSort(verses);
           verses.forEach(verseFolder => {
             let filePath = path.join(dataPath, chapterFolder, verseFolder);
-            let latestFile = loadFile(filePath);
-            if (latestFile.contextId.tool === state.currentToolReducer.toolName) {
-              toggleGroupDataItems(folderName, latestFile, dispatch);
-            }
+            let latestObjects = getUniqueObjectsFromFolder(filePath);
+            latestObjects.forEach(object => {
+              if (object.contextId.tool === state.currentToolReducer.toolName) {
+                toggleGroupDataItems(folderName, object, dispatch);
+              }
+            });
           });
         });
       });
     }
   });
 }
-
+/**
+ * @description generates a path to a check data item.
+ * @param {object} state - redux store state.
+ * @param {string} PROJECT_SAVE_LOCATION - project path/directory.
+ * @param {string} checkDataName - comments, reminders, selections and verseEdits folders.
+ * @return {string} path/directory to be use to load a file.
+ */
 function generatePathToDataItems(state, PROJECT_SAVE_LOCATION, checkDataName) {
   if (PROJECT_SAVE_LOCATION && state) {
     let bookAbbreviation = state.projectDetailsReducer.params.bookAbbr;
@@ -76,7 +84,11 @@ function generatePathToDataItems(state, PROJECT_SAVE_LOCATION, checkDataName) {
     return loadPath;
   }
 }
-
+/**
+ * @description filters and sorts an array.
+ * @param {array} array - array to be filtered and sorted.
+ * @return {array} filtered and sorted array.
+ */
 function filterAndSort(array) {
   let filteredArray = array.filter(folder => {
     return folder !== ".DS_Store";
@@ -87,19 +99,68 @@ function filterAndSort(array) {
   });
   return filteredArray;
 }
-
-function loadFile(loadPath) {
+/**
+ * @description gets the objects with the latest timestamp and a unique groupID.
+ * @param {string} loadPath - path or directory where check data is saved.
+ * @return {array} array of check data objects with latest timestamp and a unique groupID.
+ */
+function getUniqueObjectsFromFolder(loadPath) {
   let files = fs.readdirSync(loadPath);
+  let uniqueCheckDataObjects = [];
 
   files = files.filter(file => { // filter the filenames to only use .json
     return path.extname(file) === '.json';
   });
 
   let sorted = files.sort().reverse(); // sort the files to use latest
-  let readPath = path.join(loadPath, sorted[0]);
-  return fs.readJsonSync(readPath);
+  let checkDataObjects = sorted.map(file => {
+    // get the json of all files
+    try {
+      let readPath = path.join(loadPath, file)
+      let _checkDataObject = fs.readJsonSync(readPath)
+      return _checkDataObject;
+    } catch (err) {
+      console.warn('File exists but could not be loaded \n', err);
+      return undefined;
+    }
+  });
+
+  checkDataObjects.forEach(element => {
+    let checkDataObjectsWithSameGroupId = checkDataObjects.filter(_checkDataObject => {
+      // filter the checkDataObjects to unique grouId array
+      let keep = _checkDataObject.contextId.groupId === element.contextId.groupId && !contains(_checkDataObject, uniqueCheckDataObjects);
+      return keep;
+    });
+    if (checkDataObjectsWithSameGroupId[0]) {
+      // return the first one since it is the latest modified one
+      uniqueCheckDataObjects.push(checkDataObjectsWithSameGroupId[0]);
+    }
+    // filter out all checkDataObjects that are already in checkDataObjectsWithSameGroupId.
+    checkDataObjects = checkDataObjects.filter(_checkDataObject => {
+      return _checkDataObject.contextId.groupId !== element.contextId.groupId;
+    });
+    // clearing checkDataObjectsWithSameGroupId in order to reuse it for next checkdata object
+    checkDataObjectsWithSameGroupId = [];
+  });
+  return uniqueCheckDataObjects;
+}
+/**
+ * @description returns boolean indicating if object was found in the array (arrayToBeChecked).
+ * @param {object} object - obect to check if is included in array.
+ * @param {array} arrayToBeChecked - array compare against if object is included.
+ * @return {boolean} - true/false: is it included or not.
+ */
+function contains(object, arrayToBeChecked) {
+  let included = arrayToBeChecked.indexOf(object);
+  return included >= 0 ? true : false;
 }
 
+/**
+ * @description dispatches appropiate action based on label string.
+ * @param {string} label - string to be use to determine which action to dispatch.
+ * @param {object} fileObject - checkdata object.
+ * @param {function} dispatch - redux action dispatcher.
+ */
 function toggleGroupDataItems(label, fileObject, dispatch) {
   switch (label) {
     case "comments":

--- a/src/js/actions/checkDataLoadActions.js
+++ b/src/js/actions/checkDataLoadActions.js
@@ -42,6 +42,7 @@ function generateLoadPath(state, checkDataName) {
 /**
  * @description loads checkdata beased on given.
  * @param {string} loadPath - load path.
+ * @param {object} contextId - groupData unique context Id.
  * @return {object} returns the object loaded from the file system.
  */
 function loadCheckData(loadPath, contextId) {
@@ -54,7 +55,7 @@ function loadCheckData(loadPath, contextId) {
       return path.extname(file) === '.json'
     })
     let sorted = files.sort().reverse() // sort the files to use latest
-    let checkDataObjects = sorted.map( file => {
+    let checkDataObjects = sorted.map(file => {
       // get the json of all files to later filter by contextId
       try {
         let readPath = path.join(loadPath, file)
@@ -65,7 +66,7 @@ function loadCheckData(loadPath, contextId) {
         return undefined;
       }
     })
-    checkDataObjects = checkDataObjects.filter( _checkDataObject => {
+    checkDataObjects = checkDataObjects.filter(_checkDataObject => {
       // filter the checkDataObjects to only use the ones that match the current contextId
       let keep = _checkDataObject &&
                 _checkDataObject.contextId.groupId === contextId.groupId &&


### PR DESCRIPTION
#### This pull request addresses:

Two Group IDs are writing files to the same chapter and verse.  In this case 2:16. 
**figs_metonymy **
```
{
    "priority": 1,
    "comments": false,
    "reminders": false,
    "selections": true,
    "verseEdits": false,
    "contextId": {
      "information": "The cross here represents Christ's death on the cross. AT: \"by means of Christ's death on the cross\" (See: [[:en:ta:vol2:translate:figs_metonymy]])\n  ",
      "reference": {
        "bookId": "eph",
        "chapter": 2,
        "verse": 16
      },
      "tool": "translationNotes",
      "groupId": "figs_metonymy",
      "quote": "through the cross",
      "occurrence": 1
    }
  }
```
**figs_metaphor**
```
{
    "priority": 1,
    "comments": false,
    "reminders": false,
    "selections": false,
    "verseEdits": true,
    "contextId": {
      "information": "Stopping their hostility is spoken of as if he killed their hostility. By dying on the cross Jesus eliminated the reason for Jews and Gentiles to be hostile toward each other. Neither are now required to live according to the law of Moses. AT: \"stopping them from hating one another\" (See: [[:en:ta:vol1:translate:figs_metaphor]])\n",
      "reference": {
        "bookId": "eph",
        "chapter": 2,
        "verse": 16
      },
      "tool": "translationNotes",
      "groupId": "figs_metaphor",
      "quote": "putting to death the hostility",
      "occurrence": 1
    }
  }
```

The script that verifies that the menu reflects the check data in the filesystem basically was only reading the file with the latest timestamp and didnt get to the other file that in this case is for **group id figs_metaphor** in other words it didnt dynamically read all files for all group ids in the folder.


#### How to test this pull request:
- download the following project [fr_eph_text_ulb.zip](https://github.com/unfoldingWord-dev/translationCore/files/1014545/fr_eph_text_ulb.zip)
- dont delete the .apps folder
- opent he project in tN
- verify that metaphor 2:16 and metonymy 2:16 have the check mark in the menu to reflect a selection.

![image](https://cloud.githubusercontent.com/assets/8171759/26252197/2edc35de-3c75-11e7-819d-70be0a212214.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1670)
<!-- Reviewable:end -->
