### PR TITLE
Add openOptionDialog and closeAlertDialog to ToolsContainer #1818

### DIFF
--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -14,7 +14,7 @@ import {setModuleSettings, changeModuleSettings} from '../actions/ModulesSetting
 import { sendProgressForKey } from '../actions/LoaderActions';
 import { setProjectDetail } from '../actions/projectDetailsActions';
 import { setDataFetched } from '../actions/currentToolActions';
-import { openAlertDialog } from '../actions/AlertModalActions';
+import { openAlertDialog, openOptionDialog, closeAlertDialog } from '../actions/AlertModalActions';
 import { selectModalTab } from '../actions/ModalActions';
 
 class ToolsContainer extends React.Component {
@@ -138,6 +138,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       },
       openAlertDialog: (message) => {
         dispatch(openAlertDialog(message));
+      },
+      openOptionDialog: (alertMessage, callback, button1Text, button2Text) => {
+        dispatch(openOptionDialog(alertMessage, callback, button1Text, button2Text));
+      },
+      closeAlertDialog: () => {
+        dispatch(closeAlertDialog());
       }
     }
   };


### PR DESCRIPTION
#### This pull request addresses:

Adds needed actions to Tools for OptionDialog and CloseAlert


#### How to test this pull request:

Test alongside of other PR in VerseCheck for #1818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1858)
<!-- Reviewable:end -->
