### PR TITLE
create function to copy bibles from static folder to local user folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "translationCore",
-  "version": "0.7.2",
+  "version": "0.7.1-beta.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {

--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -6,7 +6,7 @@ import * as TargetLanguageActions from './TargetLanguageActions'
 // constant declaraton
 const RESOURCES_DATA_DIR = path.join('.apps', 'translationCore', 'resources');
 const BIBLE_RESOURCES_PATH = path.join(path.homedir(), 'translationCore/resources/bibles');
-const STATIC_RESOURCES_BIBLES_PATH = path.datadir()
+const STATIC_RESOURCES_BIBLES_PATH = './static/resources/bibles';
 
 export const addNewBible = (bibleName, bibleData) => {
   return {
@@ -59,12 +59,16 @@ export function loadBiblesChapter(contextId) {
       dispatch(TargetLanguageActions.loadTargetLanguageChapter(chapter));
   });
 }
+
 // TODO  
 export function getBibleFromStaticPackage(bibleId) {
   return ((dispatch, getState) => {
-    fs.moveSync();
+    let bibleIdNames = fs.readdirSync(STATIC_RESOURCES_BIBLES_PATH);
+    
+    fs.copySync(STATIC_RESOURCES_BIBLES_PATH, BIBLE_RESOURCES_PATH + '/new');
   });
 }
+
 /**
  * @description loads bibles from the filesystem and saves them in the resources reducer.
  */

--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -60,12 +60,19 @@ export function loadBiblesChapter(contextId) {
   });
 }
 
-// TODO  
-export function getBibleFromStaticPackage(bibleId) {
+/**
+ * @description moves all bibles from the static folder to the local user translationCore folder.
+ */
+export function getBibleFromStaticPackage() {
   return ((dispatch, getState) => {
-    let bibleIdNames = fs.readdirSync(STATIC_RESOURCES_BIBLES_PATH);
-    
-    fs.copySync(STATIC_RESOURCES_BIBLES_PATH, BIBLE_RESOURCES_PATH + '/new');
+    let bibleNames = fs.readdirSync(STATIC_RESOURCES_BIBLES_PATH);
+    bibleNames.forEach((bibleName) => {
+      let bibleSourcePath = path.join(STATIC_RESOURCES_BIBLES_PATH, bibleName);
+      let bibleDestinationPath = path.join(BIBLE_RESOURCES_PATH, bibleName);
+      if(!fs.existsSync(bibleDestinationPath)) {
+        fs.copySync(bibleSourcePath, bibleDestinationPath);
+      }
+    });
   });
 }
 

--- a/src/js/actions/TargetLanguageActions.js
+++ b/src/js/actions/TargetLanguageActions.js
@@ -48,7 +48,7 @@ function generateTargetBible(getState, projectPath, targetBiblePath) {
   let manifest = getState().projectDetailsReducer.manifest;
   let entireBook = {};
   let joinedChunk = {};
-  let finishedChunks = getState().projectDetailsReducer.unparsedFinishedChunks;
+  let finishedChunks = getState().projectDetailsReducer.manifest.finished_chunks;
   finishedChunks.forEach((element, index) => {
     let reference = element.split('-');
     let chapterNumber = reference[0];


### PR DESCRIPTION
#### This pull request addresses:

- Finished creating the function to move bibles files to user root folder for tC.
- still need to find an appropriate place in the codebase where to call this function.
- pending approval from @RoyalSix  and @klappy about copying all bible files instead of just one bible for a project selected.


#### How to test this pull request:

Include testing instructions so that other developers know what to look for, and how to make sure that your feature/bugfix/enhancement really works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1864)
<!-- Reviewable:end -->
