### PR TITLE
Created actions and/or helpers to load all bibles manifest files

### DIFF
--- a/src/js/actions/GetDataActions.js
+++ b/src/js/actions/GetDataActions.js
@@ -162,7 +162,7 @@ function loadProjectDataFromFileSystem(toolName) {
       let { projectSaveLocation, params } = projectDetailsReducer;
       const dataDirectory = Path.join(projectSaveLocation, '.apps', 'translationCore', 'index', toolName);
 
-      dispatch(TargetLanguageActions.generateAndLoadTargetLangBible(projectSaveLocation));
+      dispatch(TargetLanguageActions.generateTargetBible(projectSaveLocation));
       getGroupsIndex(dispatch, toolName, dataDirectory)
         .then((successMessage) => {
           getGroupData(dispatch, dataDirectory, toolName, params)

--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -7,11 +7,15 @@ import * as AlertModalActions from './AlertModalActions';
 // helpers
 import * as ResourcesHelpers from '../helpers/ResourcesHelpers';
 // constant declaraton
-const RESOURCES_DATA_DIR = path.join('.apps', 'translationCore', 'resources');
 const USER_RESOURCES_DIR = path.join(path.homedir(), 'translationCore/resources');
 const BIBLE_RESOURCES_PATH = path.join(USER_RESOURCES_DIR, 'bibles');
 const TRANSLATIONHELPS_RESOURCES_PATH = path.join(USER_RESOURCES_DIR, '/translationHelps');
 
+/**
+ * @description adds a bible to the resoiurces reducer' bibles property.
+ * @param {string} bibleName - name/label for bible.
+ * @param {object} bibleData - data being saved in the bible property.
+ */
 export const addNewBible = (bibleName, bibleData) => {
   return {
     type: consts.ADD_NEW_BIBLE_TO_RESOURCES,
@@ -20,6 +24,10 @@ export const addNewBible = (bibleName, bibleData) => {
   };
 };
 
+/**
+ * @description loads a bibles chapter based on contextId
+ * @param {object} contextId - object with all data for current check.
+ */
 export const loadBiblesChapter = (contextId) => {
   return ((dispatch, getState) => {
       let bookId = contextId.reference.bookId; // bible book abbreviation.
@@ -38,6 +46,10 @@ export const loadBiblesChapter = (contextId) => {
           let bibleChapterData = fs.readJsonSync(path.join(bibleVersionPath, bookId, fileName));
           let bibleData = {};
           bibleData[chapter] = bibleChapterData;
+          // get bibles manifest file
+          let bibleManifest = ResourcesHelpers.getBibleManifest(bibleVersionPath, bibleID);
+          // save manifest dat in bibleData object to then be saved in reducer.
+          bibleData["manifest"] = bibleManifest;
           dispatch({
             type: consts.ADD_NEW_BIBLE_TO_RESOURCES,
             bibleName: bibleID,
@@ -67,7 +79,9 @@ export const loadResourceArticle = (resourceType, articleId) => {
     });
   });
 }
-
+/**
+ * @description gets the resources from the static folder located in the tC codebase.
+ */
 export const getResourcesFromStaticPackage = () => {
   return ((dispatch, getState) => {
     ResourcesHelpers.getBibleFromStaticPackage();

--- a/src/js/actions/TargetLanguageActions.js
+++ b/src/js/actions/TargetLanguageActions.js
@@ -24,6 +24,7 @@ export function loadTargetLanguageChapter(chapterNumber) {
     }
     let bibleData = {};
     bibleData[chapterNumber] = targetLanguageChapter;
+    bibleData['manifest'] = fs.readJsonSync(path.join(targetBiblePath, "manifest.json"));
     dispatch({
       type: consts.ADD_NEW_BIBLE_TO_RESOURCES,
       bibleName,
@@ -32,48 +33,46 @@ export function loadTargetLanguageChapter(chapterNumber) {
   });
 }
 
-export function generateAndLoadTargetLangBible(projectPath) {
+/**
+ * @description generates a target language bible and saves it in the filesystem devided into chapters.
+ * @param {string} projectPath - path where the project is located in the filesystem.
+ */
+export function generateTargetBible(projectPath) {
   return ((dispatch, getState) => {
     let bookAbbreviation = getState().projectDetailsReducer.params.bookAbbr;
+    let manifest = getState().projectDetailsReducer.manifest;
     let targetBiblePath = path.join(projectPath, bookAbbreviation);
-    generateTargetBible(getState, projectPath, targetBiblePath);
-    dispatch(loadTargetLanguageChapter('1'));
-  })
-}
-
-/**
- * @description generates a target language bible saves it in the filesystem devided into chapters.
- */
-function generateTargetBible(getState, projectPath, targetBiblePath) {
-  let manifest = getState().projectDetailsReducer.manifest;
-  let entireBook = {};
-  let joinedChunk = {};
-  let finishedChunks = getState().projectDetailsReducer.manifest.finished_chunks;
-  finishedChunks.forEach((element, index) => {
-    let reference = element.split('-');
-    let chapterNumber = reference[0];
-    let fileName = reference[1] + ".txt";
-    let filePath = path.join(projectPath, chapterNumber, fileName);
-    if (fs.existsSync(filePath)) {
-      let text = fs.readFileSync(filePath);
-      let currentChunk = parseTargetLanguage(text.toString());
-      Object.keys(currentChunk.verses).forEach(function (key) {
-        if (parseInt(key) === 1) joinedChunk = {};
-        joinedChunk[key] = currentChunk.verses[key];
-        entireBook[parseInt(chapterNumber)] = joinedChunk;
-      });
+    let entireBook = {};
+    let joinedChunk = {};
+    let finishedChunks = getState().projectDetailsReducer.manifest.finished_chunks;
+    finishedChunks.forEach((element, index) => {
+      let reference = element.split('-');
+      let chapterNumber = reference[0];
+      let fileName = reference[1] + ".txt";
+      let filePath = path.join(projectPath, chapterNumber, fileName);
+      if (fs.existsSync(filePath)) {
+        let text = fs.readFileSync(filePath);
+        let currentChunk = parseTargetLanguage(text.toString());
+        Object.keys(currentChunk.verses).forEach(function (key) {
+          if (parseInt(key) === 1) joinedChunk = {};
+          joinedChunk[key] = currentChunk.verses[key];
+          entireBook[parseInt(chapterNumber)] = joinedChunk;
+        });
+      }
+    });
+    for (var chapter in entireBook) {
+      let fileName = chapter + '.json';
+      fs.outputJsonSync(path.join(targetBiblePath, fileName), entireBook[chapter]);
     }
+    // generating and saving manifest file for target language bible.
+    generateTartgetLangManifest(manifest, targetBiblePath);
+    // Move bible source files from project's root folder to '.apps/translationCore/importedSource'
+    archiveSourceFiles(finishedChunks, projectPath);
   });
-  for (var chapter in entireBook) {
-    let fileName = chapter + '.json';
-    fs.outputJsonSync(path.join(targetBiblePath, fileName), entireBook[chapter]);
-  }
-  // Move bible source files from project's root folder to '.apps/translationCore/importedSource'
-  archiveSourceFiles(finishedChunks, projectPath);
 }
 
 /**
- * @description parses an usfm chunk and returns an object of verses.
+ * @description helper function that parses an usfm chunk and returns an object of verses.
  * @param {string} usfm - bible chunk.
  */
 function parseTargetLanguage(usfm) {
@@ -101,8 +100,26 @@ function parseTargetLanguage(usfm) {
   }
   return chapData;
 }
+
 /**
- * @description Moves bible source files from project's root folder to '.apps/translationCore/importedSource'.
+ * @description helper function to generate a manifest file for a target language bible.
+ * @param {object} projectManifest - projects manifest file.
+ * @param {string} targetBiblePath - path where the target language bible is saved in the file system.
+ */
+function generateTartgetLangManifest(projectManifest, targetBiblePath) {
+  let bibleManifest = {};
+  bibleManifest.language_name = projectManifest.target_language.name;
+  bibleManifest.resource_id = "targetLanguage";
+  bibleManifest.resource_name = "";
+  bibleManifest.direction = projectManifest.target_language.direction;
+  bibleManifest.language_description = "Target Language";
+  // savings target language bible manifest file in project target language bible path.
+  let fileName = "manifest.json";
+  fs.outputJsonSync(path.join(targetBiblePath, fileName), bibleManifest);
+}
+
+/**
+ * @description helper function that Moves bible source files from project's root folder to '.apps/translationCore/importedSource'.
  * @param {array} finishedChunks - list of all finished chunks.
  * @param {string} projectPath - project save location / path.
  */

--- a/src/js/actions/TargetLanguageActions.js
+++ b/src/js/actions/TargetLanguageActions.js
@@ -108,11 +108,15 @@ function parseTargetLanguage(usfm) {
  */
 function generateTartgetLangManifest(projectManifest, targetBiblePath) {
   let bibleManifest = {};
-  bibleManifest.language_name = projectManifest.target_language.name;
-  bibleManifest.resource_id = "targetLanguage";
-  bibleManifest.resource_name = "";
-  bibleManifest.direction = projectManifest.target_language.direction;
-  bibleManifest.language_description = "Target Language";
+  let manifestLanguage = {};
+  manifestLanguage.identifier = projectManifest.target_language.id;
+  manifestLanguage.title = projectManifest.target_language.name;
+  manifestLanguage.direction = projectManifest.target_language.direction;
+  bibleManifest.language = manifestLanguage;
+  bibleManifest.subject = "Bible";
+  bibleManifest.identifier = "targetLanguage";
+  bibleManifest.title = "";
+  bibleManifest.description = "Target Language";
   // savings target language bible manifest file in project target language bible path.
   let fileName = "manifest.json";
   fs.outputJsonSync(path.join(targetBiblePath, fileName), bibleManifest);

--- a/src/js/actions/TargetLanguageActions.js
+++ b/src/js/actions/TargetLanguageActions.js
@@ -65,7 +65,7 @@ export function generateTargetBible(projectPath) {
       fs.outputJsonSync(path.join(targetBiblePath, fileName), entireBook[chapter]);
     }
     // generating and saving manifest file for target language bible.
-    generateTartgetLangManifest(manifest, targetBiblePath);
+    generateTartgetLanguageManifest(manifest, targetBiblePath);
     // Move bible source files from project's root folder to '.apps/translationCore/importedSource'
     archiveSourceFiles(finishedChunks, projectPath);
   });
@@ -106,7 +106,7 @@ function parseTargetLanguage(usfm) {
  * @param {object} projectManifest - projects manifest file.
  * @param {string} targetBiblePath - path where the target language bible is saved in the file system.
  */
-function generateTartgetLangManifest(projectManifest, targetBiblePath) {
+function generateTartgetLanguageManifest(projectManifest, targetBiblePath) {
   let bibleManifest = {};
   let manifestLanguage = {};
   manifestLanguage.identifier = projectManifest.target_language.id;

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -54,3 +54,20 @@ export function copyGroupsDataToProjectResources(toolName, groupsDataDirectory, 
     console.log("translationHelps resources path was not found, " + groupsDataSourcePath);
   }
 }
+
+/**
+ * @description Helper function to get a bibles manifest file from the bible resources folder.
+ * @param {string} bibleVersionPath - path to a bibles version folder.
+ * @param {string} bibleID - bible name. ex. ugnt, uhb, udb-en, ulb-en.
+ */
+export function getBibleManifest(bibleVersionPath, bibleID) {
+  let fileName = 'manifest.json';
+  let bibleManifestPath = path.join(bibleVersionPath, fileName);
+  let manifest;
+  if(fs.existsSync(bibleManifestPath)) {
+    manifest = fs.readJsonSync(bibleManifestPath);
+  } else {
+    console.error("Could not find manifest for " + bibleID)
+  }
+  return manifest;
+}

--- a/static/resources/bibles/udb-en/v9/manifest.json
+++ b/static/resources/bibles/udb-en/v9/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "English",
-  "resource_id": "udb-en",
-  "resource_name": "Unlocked Dynamic Bible",
-  "direction": "ltr",
-  "language_description": "Gateway Language"
+  "language": {
+    "identifier": "en",
+    "title": "English",
+    "direction": "ltr"
+  },
+  "subject": "Bible",
+  "identifier": "udb-en",
+  "title": "Unlocked Dynamic Bible",
+  "description": "Gateway Language"
 }

--- a/static/resources/bibles/udb-en/v9/manifest.json
+++ b/static/resources/bibles/udb-en/v9/manifest.json
@@ -1,10 +1,7 @@
 {
-  "sourceName": "UDB",
-  "dir": "ltr",
-  "heading": {
-    "headingDescription": "Gateway Language",
-    "language_name": "English",
-    "resource_id": "udb-en",
-    "resource_name": "Unlocked Dynamic Bible"
-  }
+  "language_name": "English",
+  "resource_id": "udb-en",
+  "resource_name": "Unlocked Dynamic Bible",
+  "direction": "ltr",
+  "language_description": "Gateway Language"
 }

--- a/static/resources/bibles/ugnt/v0.0/manifest.json
+++ b/static/resources/bibles/ugnt/v0.0/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "Greek",
-  "resource_id": "ugnt",
-  "resource_name": "Unlocked Greek New Testament",
-  "direction": "ltr",
-  "language_description": "Original Language"
+  "language": {
+    "identifier": "el",
+    "title": "Greek",
+    "direction": "ltr"
+  },
+  "subject": "Bible",
+  "identifier": "ugnt",
+  "title": "Unlocked Greek New Testament",
+  "description": "Original Language"
 }

--- a/static/resources/bibles/ugnt/v0.0/manifest.json
+++ b/static/resources/bibles/ugnt/v0.0/manifest.json
@@ -1,10 +1,7 @@
 {
-  "sourceName": "originalLanguage",
-  "dir": "ltr",
-  "heading": {
-    "headingDescription": "Original Language",
-    "language_name": "Greek",
-    "resource_id": "ugnt",
-    "resource_name": "Unlocked Greek New Testament"
-  }
+  "language_name": "Greek",
+  "resource_id": "ugnt",
+  "resource_name": "Unlocked Greek New Testament",
+  "direction": "ltr",
+  "language_description": "Original Language"
 }

--- a/static/resources/bibles/ugnt/v0/manifest.json
+++ b/static/resources/bibles/ugnt/v0/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "Greek",
-  "resource_id": "ugnt",
-  "resource_name": "Unlocked Greek New Testament",
-  "direction": "ltr",
-  "language_description": "Original Language"
+  "language": {
+    "identifier": "el",
+    "title": "Greek",
+    "direction": "ltr"
+  },
+  "subject": "Bible",
+  "identifier": "ugnt",
+  "title": "Unlocked Greek New Testament",
+  "description": "Original Language"
 }

--- a/static/resources/bibles/ugnt/v0/manifest.json
+++ b/static/resources/bibles/ugnt/v0/manifest.json
@@ -1,10 +1,7 @@
 {
-  "sourceName": "originalLanguage",
-  "dir": "ltr",
-  "heading": {
-    "headingDescription": "Original Language",
-    "language_name": "Greek",
-    "resource_id": "ugnt",
-    "resource_name": "Unlocked Greek New Testament"
-  }
+  "language_name": "Greek",
+  "resource_id": "ugnt",
+  "resource_name": "Unlocked Greek New Testament",
+  "direction": "ltr",
+  "language_description": "Original Language"
 }

--- a/static/resources/bibles/uhb/v0.0/manifest.json
+++ b/static/resources/bibles/uhb/v0.0/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "Hebrew",
-  "resource_id": "uhb",
-  "resource_name": "Unlocked Hebrew Bible",
-  "direction": "ltr",
-  "language_description": "Original Language"
+  "language": {
+    "identifier": "he",
+    "title": "Hebrew",
+    "direction": "rtl"
+  },
+  "subject": "Bible",
+  "identifier": "uhb",
+  "title": "Unlocked Hebrew Bible",
+  "description": "Original Language"
 }

--- a/static/resources/bibles/uhb/v0.0/manifest.json
+++ b/static/resources/bibles/uhb/v0.0/manifest.json
@@ -1,0 +1,7 @@
+{
+  "language_name": "Hebrew",
+  "resource_id": "uhb",
+  "resource_name": "Unlocked Hebrew Bible",
+  "direction": "ltr",
+  "language_description": "Original Language"
+}

--- a/static/resources/bibles/uhb/v0/manifest.json
+++ b/static/resources/bibles/uhb/v0/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "Hebrew",
-  "resource_id": "uhb",
-  "resource_name": "Unlocked Hebrew Bible",
-  "direction": "ltr",
-  "language_description": "Original Language"
+  "language": {
+    "identifier": "he",
+    "title": "Hebrew",
+    "direction": "rtl"
+  },
+  "subject": "Bible",
+  "identifier": "uhb",
+  "title": "Unlocked Hebrew Bible",
+  "description": "Original Language"
 }

--- a/static/resources/bibles/uhb/v0/manifest.json
+++ b/static/resources/bibles/uhb/v0/manifest.json
@@ -1,0 +1,7 @@
+{
+  "language_name": "Hebrew",
+  "resource_id": "uhb",
+  "resource_name": "Unlocked Hebrew Bible",
+  "direction": "ltr",
+  "language_description": "Original Language"
+}

--- a/static/resources/bibles/ulb-en/v6/manifest.json
+++ b/static/resources/bibles/ulb-en/v6/manifest.json
@@ -1,7 +1,11 @@
 {
-  "language_name": "English",
-  "resource_id": "ulb-en",
-  "resource_name": "Unlocked Literal Bible",
-  "direction": "ltr",
-  "language_description": "Gateway Language"
+  "language": {
+    "identifier": "en",
+    "title": "English",
+    "direction": "ltr"
+  },
+  "subject": "Bible",
+  "identifier": "ulb-en",
+  "title": "Unlocked Literal Bible",
+  "description": "Gateway Language"
 }

--- a/static/resources/bibles/ulb-en/v6/manifest.json
+++ b/static/resources/bibles/ulb-en/v6/manifest.json
@@ -1,0 +1,7 @@
+{
+  "language_name": "English",
+  "resource_id": "ulb-en",
+  "resource_name": "Unlocked Literal Bible",
+  "direction": "ltr",
+  "language_description": "Gateway Language"
+}


### PR DESCRIPTION
#### This pull request addresses:

- For now it's loading the data necessary to get rid of the current implementation of the scripture pane settings.

- Still need to make changes to the scripture pane to use this new data.

#### How to test this pull request:

- Delete your local user resources folder.
- add `console.log(this.props.resourcesReducer.bibles)` to app.js
- Open a fresh project
- check that it logged the bibles and that the bibles have the current chapter Bible loaded as well as the bibles manifest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1939)
<!-- Reviewable:end -->
