### PR TITLE
UserCard with giant Glyph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "translationCore",
-  "version": "0.7.1-beta.1",
+  "version": "0.7.1-beta.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {

--- a/src/js/components/home/overview/TemplateCard.js
+++ b/src/js/components/home/overview/TemplateCard.js
@@ -24,7 +24,7 @@ class UserCard extends Component {
     let { emptyMessage, emptyButtonLabel, emptyButtonOnClick, disabled } = this.props;
     let emptyContent = this.emptyContent(emptyMessage, emptyButtonLabel, emptyButtonOnClick, disabled);
     let content = this.props.content ? this.props.content : emptyContent;
-    let cardStyle = { marginTop: '5px' }
+    let cardStyle = { marginTop: '5px', height: '110px' }
     cardStyle.background = (disabled) ? 'var(--background-color-light)' : 'white';
     return (
       <div style={{ padding: '0 0 20px 0' }}>

--- a/src/js/components/home/overview/UserCard.js
+++ b/src/js/components/home/overview/UserCard.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Glyphicon } from 'react-bootstrap';
 import TemplateCard from './TemplateCard'
 
 class UserCard extends Component {
@@ -15,9 +16,14 @@ class UserCard extends Component {
     let { loggedInUser, userdata } = this.props.reducers.loginReducer;
     if (loggedInUser) {
       content = (
-        <div>
-          <strong>{userdata.username}</strong>
-          <p>{userdata.email ? userdata.email : 'no email address'}</p>
+        <div style={{ display: 'flex' }}>
+          <div style={{ width: '100px', height: '110px', color: 'lightgray', margin: '-16px 20px 0 -16px', overflow: 'hidden'}}>
+            <Glyphicon glyph="user" style={{fontSize: "142px", marginLeft: '-23px'}} />
+          </div>
+          <div style={{ marginTop: '-10px' }}>
+            <strong style={{ fontSize: 'x-large' }}>{userdata.username}</strong>
+            <p>{userdata.email ? userdata.email : 'no email address'}</p>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
#### This pull request addresses:

Styled UserCard with giant Glyph

#### How to test this pull request:

- Open tC, view HomeScreen Overview.
- Click on user from the menu and log in. 
- Close the modal.
- View the User Card.

Does it look close enough to the mockup? The mockups use a different image for all user/profile. I am using the same Glyph as the rest of the app for user, which is the equivalent swap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/1944)
<!-- Reviewable:end -->
