### PR TITLE
Basic Layout and design of ProjectsManagement page. #969

### DIFF
--- a/src/js/components/home/TemplateCard.js
+++ b/src/js/components/home/TemplateCard.js
@@ -41,7 +41,7 @@ class TemplateCard extends Component {
     const { emptyMessage, emptyButtonLabel, emptyButtonOnClick, disabled } = this.props;
     const emptyContent = this.emptyContent(emptyMessage, emptyButtonLabel, emptyButtonOnClick, disabled);
     const content = this.props.content ? this.props.content : emptyContent;
-    const cardStyle = { marginTop: '5px', height: '110px' }
+    const cardStyle = { marginTop: '5px' }
     cardStyle.background = (disabled) ? 'var(--background-color-light)' : 'white';
     return (
       <div style={{flex:1}}>
@@ -59,10 +59,10 @@ class TemplateCard extends Component {
 TemplateCard.propTypes = {
   heading: PropTypes.object.isRequired,
   content: PropTypes.element,
-  emptyMessage: PropTypes.string.isRequired,
-  emptyButtonLabel: PropTypes.string.isRequired,
-  emptyButtonOnClick: PropTypes.func.isRequired,
+  emptyMessage: PropTypes.string,
+  emptyButtonLabel: PropTypes.string,
+  emptyButtonOnClick: PropTypes.func,
   disabled: PropTypes.bool
-}
+};
 
 export default TemplateCard

--- a/src/js/components/home/overview/ProjectCard.js
+++ b/src/js/components/home/overview/ProjectCard.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 import fs from 'fs-extra';
 import { Glyphicon } from 'react-bootstrap';
 // components
-import TemplateCard from './TemplateCard';
+import TemplateCard from '../TemplateCard';
 
 class ProjectCard extends Component {
 
@@ -44,7 +44,7 @@ class ProjectCard extends Component {
   * @return {component} - component returned
   */
   contentDetails(projectSaveLocation, bookName, params, manifest) {
-    const projectName = projectSaveLocation.split("/").pop();
+    const projectName = path.basename(projectSaveLocation);
     const projectDataLocation = path.join(projectSaveLocation, '.apps', 'translationCore');
     const accessTime = fs.statSync(projectDataLocation).atime;
     const accessTimeAgo = moment().to(accessTime);
@@ -78,7 +78,7 @@ class ProjectCard extends Component {
     const { projectSaveLocation, bookName, params, manifest } = projectDetailsReducer;
     if (projectSaveLocation && params && manifest.target_language) {
       content = (
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '-10px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', margin: '-10px 0 -24px 0' }}>
           {this.contentDetails(projectSaveLocation, bookName, params, manifest)}
           <div style={{ marginRight: '-5px' }}>
             <Glyphicon glyph="option-vertical" style={{ fontSize: "large" }} />
@@ -118,6 +118,6 @@ class ProjectCard extends Component {
 ProjectCard.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired
-}
+};
 
-export default ProjectCard
+export default ProjectCard;

--- a/src/js/components/home/overview/ToolCard.js
+++ b/src/js/components/home/overview/ToolCard.js
@@ -4,7 +4,7 @@ import { Glyphicon } from 'react-bootstrap';
 import { Line } from 'react-progressbar.js';
 import PropTypes from 'prop-types';
 // components
-import TemplateCard from './TemplateCard';
+import TemplateCard from '../TemplateCard';
 
 class ToolCard extends Component {
 
@@ -80,15 +80,13 @@ class ToolCard extends Component {
       let progress = 0;
       if (groupsData) progress = this.progress(groupsData);
       content = (
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '-10px' }}>
-          <div style={{ display: 'flex' }}>
-            <div style={{ width: '100px', height: '110px', color: 'lightgray', margin: '-6px 20px 0 -16px', overflow: 'hidden'}}>
-              <Glyphicon glyph="check" style={{ fontSize: "120px", margin: '-10px 0 0 -25px'}} />
-            </div>
-            <div style={{ width: '400px' }}>
-              <strong style={{ fontSize: 'x-large' }}>{currentToolTitle}</strong>
-              {this.progressBar(progress)}
-            </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', margin: '-10px 0 -24px 0' }}>
+          <div style={{ width: '100px', height: '110px', color: 'lightgray', margin: '-6px 20px 0 -16px', overflow: 'hidden'}}>
+            <Glyphicon glyph="check" style={{ fontSize: "120px", margin: '-10px 0 0 -25px'}} />
+          </div>
+          <div style={{ width: '400px' }}>
+            <strong style={{ fontSize: 'x-large' }}>{currentToolTitle}</strong>
+            {this.progressBar(progress)}
           </div>
         </div>
       );
@@ -125,6 +123,6 @@ class ToolCard extends Component {
 ToolCard.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired
-}
+};
 
 export default ToolCard;

--- a/src/js/components/home/overview/UserCard.js
+++ b/src/js/components/home/overview/UserCard.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Glyphicon } from 'react-bootstrap';
 // components
-import TemplateCard from './TemplateCard';
+import TemplateCard from '../TemplateCard';
 
 class UserCard extends Component {
 
@@ -28,11 +28,11 @@ class UserCard extends Component {
     const { loggedInUser, userdata } = this.props.reducers.loginReducer;
     if (loggedInUser) {
       content = (
-        <div style={{ display: 'flex' }}>
-          <div style={{ width: '100px', height: '110px', color: 'lightgray', margin: '-16px 20px 0 -16px', overflow: 'hidden'}}>
-            <Glyphicon glyph="user" style={{fontSize: "142px", marginLeft: '-23px'}} />
+        <div style={{ display: 'flex', margin: '-10px 0 -24px 0' }}>
+          <div style={{ width: '100px', height: '110px', color: 'lightgray', margin: '-6px 20px -10px -16px', overflow: 'hidden'}}>
+            <Glyphicon glyph="user" style={{fontSize: "100px"}} />
           </div>
-          <div style={{ marginTop: '-10px' }}>
+          <div style={{ width: '400px' }}>
             <strong style={{ fontSize: 'x-large' }}>{userdata.username}</strong>
             <p>{userdata.email ? userdata.email : 'no email address'}</p>
           </div>
@@ -62,6 +62,6 @@ class UserCard extends Component {
 UserCard.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired
-}
+};
 
-export default UserCard
+export default UserCard;

--- a/src/js/components/home/projectsManagement/MyProjects.js
+++ b/src/js/components/home/projectsManagement/MyProjects.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// components
+import ProjectCard from './ProjectCard';
+
+let MyProjects = (props) => {
+  let {myProjects} = props;
+
+  const projects = myProjects.map( (projectDetails, index) =>
+    <ProjectCard key={index} projectDetails={projectDetails} actions={props.actions} />
+  );
+
+  return (
+    <div>
+      Projects
+      {projects}
+    </div>
+  );
+}
+
+MyProjects.propTypes = {
+  myProjects: PropTypes.array.isRequired,
+  actions: PropTypes.object.isRequired
+};
+
+export default MyProjects;

--- a/src/js/components/home/projectsManagement/ProjectCard.js
+++ b/src/js/components/home/projectsManagement/ProjectCard.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Glyphicon } from 'react-bootstrap';
+import path from 'path-extra';
+import moment from 'moment';
+import fs from 'fs-extra';
+// components
+import TemplateCard from '../TemplateCard';
+
+let Project = (props) => {
+  const {projectSaveLocation, bookName, params, manifest} = props.projectDetails;
+  let content = <div />;
+
+  if (projectSaveLocation && bookName && params && manifest) {
+    const projectName = path.basename(projectSaveLocation);
+    const projectDataLocation = path.join(projectSaveLocation, '.apps', 'translationCore');
+    const accessTime = fs.statSync(projectDataLocation).atime;
+    const accessTimeAgo = moment().to(accessTime);
+    const { bookAbbr } = params;
+    const { target_language } = manifest;
+
+    /**
+    * @description generates a detail for the contentDetails
+    * @param {string} glyph - name of the glyph to be used
+    * @param {string} text - text used for the detail
+    * @return {component} - component returned
+    */
+    const detail = (glyph, text) => {
+      return (
+        <div>
+          <Glyphicon glyph={glyph} style={{ marginRight: '5px', top: '2px' }} />
+          <span>{text}</span>
+        </div>
+      );
+    }
+
+    // content
+    content = (
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '-10px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
+          <strong style={{ fontSize: 'x-large' }}>{projectName}</strong>
+          <div style={{ display: 'flex', justifyContent: 'space-between', width: '410px', marginBottom: '6px' }}>
+            {detail('time', accessTimeAgo)}
+            {detail('book', bookName + ' (' + bookAbbr + ')')}
+            {detail('globe', target_language.name + ' (' + target_language.id + ')')}
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', textAlign: 'right', marginRight: '-6px' }}>
+          <div>
+            <Glyphicon glyph="option-vertical" style={{ fontSize: "large" }} />
+          </div>
+          <div>
+            <button className='btn-prime' disabled={true} onClick={()=>{}} style={{ width: '90px', marginBottom: '0' }}>
+              Select
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+
+  }
+
+  // heading
+  const heading = (
+    <span></span>
+  );
+
+  return (
+    <TemplateCard
+      heading={heading}
+      content={content}
+    />
+  );
+}
+
+Project.propTypes = {
+  projectDetails: PropTypes.object.isRequired,
+  actions: PropTypes.object.isRequired
+};
+
+export default Project;

--- a/src/js/components/home/projectsManagement/ProjectsFAB.js
+++ b/src/js/components/home/projectsManagement/ProjectsFAB.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {Glyphicon} from 'react-bootstrap';
+
+let ProjectFAB = (props) => {
+  return (
+    <div>
+      ProjectFAB
+    </div>
+  );
+}
+
+export default ProjectFAB;

--- a/src/js/containers/home/ProjectsManagementContainer.js
+++ b/src/js/containers/home/ProjectsManagementContainer.js
@@ -1,30 +1,44 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux'
+import PropTypes from 'prop-types';
 // components
-import MyProjects from '../../components/home/projectsManagement/MyProjects'
-import ProjectsFAB from '../../components/home/projectsManagement/ProjectsFAB'
-import OnlineImportModal from '../../components/home/projectsManagement/OnlineImportModal'
+import MyProjects from '../../components/home/projectsManagement/MyProjects';
+import ProjectsFAB from '../../components/home/projectsManagement/ProjectsFAB';
+// import OnlineImportModal from '../../components/home/projectsManagement/OnlineImportModal'
 // actions
-// import {actionCreator} from 'actionCreatorPath'
+import * as BodyUIActions from '../../actions/BodyUIActions';
 
 class ProjectsManagementContainer extends Component {
 
   componentWillMount() {
-    let instructions = <div>ProjectsManagementInstructions</div>;
+    let instructions = this.instructions();
     if (this.props.reducers.homeScreenReducer.homeInstructions !== instructions) {
       this.props.actions.changeHomeInstructions(instructions);
     }
   }
 
-  render() {
+  instructions() {
     return (
       <div>
-        ProjectsManagementContainer
-        {/*
-        <MyProjects />
+        <p>Select a project from the list.</p>
+        <p>To import a project, click (=)</p>
+        <p>Only projects that have been saved with the latest version of translationStudio can be opened in translationCore at this time.</p>
+      </div>
+    );
+  }
+
+  render() {
+    const {projectDetailsReducer} = this.props.reducers;
+    const myProjects = [];
+    if (projectDetailsReducer.projectSaveLocation) {
+      myProjects.push(projectDetailsReducer);
+      myProjects.push(projectDetailsReducer);
+    }
+
+    return (
+      <div>
+        <MyProjects myProjects={myProjects} actions={this.props.actions} />
         <ProjectsFAB />
-        <OnlineImportModal />
-        */}
       </div>
     );
   }
@@ -32,16 +46,26 @@ class ProjectsManagementContainer extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    prop: state.prop
-  }
-}
+    reducers: {
+      projectDetailsReducer: state.projectDetailsReducer,
+      homeScreenReducer: state.homeScreenReducer
+    }
+  };
+};
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    dispatch1: () => {
-      // dispatch(actionCreator)
+    actions: {
+      changeHomeInstructions: (instructions) => {
+        dispatch(BodyUIActions.changeHomeInstructions(instructions));
+      }
     }
-  }
-}
+  };
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectsManagementContainer)
+ProjectsManagementContainer.propTypes = {
+  reducers: PropTypes.object.isRequired,
+  actions: PropTypes.object.isRequired
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProjectsManagementContainer);


### PR DESCRIPTION
#### This pull request addresses:

Basic Layout and design of ProjectsManagement page.
Temporarily, no real projects from your folder, just using current project twice to simulate list.
No functionality like select or 3dot menu yet.

#### How to test this pull request:

- Use the next button on the homescreen to get to the projects page.
- Open a project from the modal and close modal.
- Review basic layout/design and see if it looks close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2020)
<!-- Reviewable:end -->
