### PR TITLE
Now dimming the rest of the screen when clicking the project FAB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,6 +1540,11 @@
       "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+    },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
@@ -2914,6 +2919,11 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
       "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
     },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+    },
     "ignore": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
@@ -3151,8 +3161,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-subset": {
       "version": "0.1.1",
@@ -3793,6 +3802,11 @@
       "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
       "dev": true,
       "optional": true
+    },
+    "node-fetch": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -5950,6 +5964,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz",
       "integrity": "sha1-N5CKyViUV20NORh70om8LLtaxt4="
+    },
+    "react-spotlight-clickable": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-spotlight-clickable/-/react-spotlight-clickable-1.0.5.tgz",
+      "integrity": "sha1-4Z7LClQXJlZiLjszM9R9JSIUx5U="
     },
     "react-tap-event-plugin": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-progressbar.js": "^0.2.0",
     "react-redux": "^5.0.1",
     "react-remarkable": "^1.1.1",
+    "react-spotlight-clickable": "^1.0.4",
     "react-tap-event-plugin": "^2.0.1",
     "reactable": "^0.14.1",
     "redux": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-progressbar.js": "^0.2.0",
     "react-redux": "^5.0.1",
     "react-remarkable": "^1.1.1",
-    "react-spotlight-clickable": "^1.0.4",
+    "react-spotlight-clickable": "^1.0.5",
     "react-tap-event-plugin": "^2.0.1",
     "reactable": "^0.14.1",
     "redux": "^3.6.0",

--- a/src/js/components/home/projectsManagement/ProjectsFAB.js
+++ b/src/js/components/home/projectsManagement/ProjectsFAB.js
@@ -4,6 +4,7 @@ import { Glyphicon } from 'react-bootstrap';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 // components
 import FABLabelCard from './FABLabelCard';
+import SpotlightComponent from './SpotlightComponent';
 
 class ProjectFAB extends Component {
 
@@ -30,7 +31,7 @@ class ProjectFAB extends Component {
 
     return (
       <MuiThemeProvider>
-        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "flex-end" }}>
+        <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", alignItems: "flex-end", zIndex: "999" }}>
           {showFABOptions ? (
             <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between"}}>
               <table>
@@ -44,7 +45,7 @@ class ProjectFAB extends Component {
                         <td>
                           <FloatingActionButton
                             onClick={() => {metadata.action()}}
-                            style={{ margin: "5px", alignSelf: "flex-end" }}
+                            style={{ margin: "5px", alignSelf: "flex-end", zIndex: "999" }}
                             backgroundColor={"var(--accent-color-dark)"}
                           >
                             <Glyphicon style={{ fontSize: "26px" }} glyph={metadata.glyph} />
@@ -66,7 +67,7 @@ class ProjectFAB extends Component {
                 <td>
                   <FloatingActionButton
                     onClick={() => this.props.actions.toggleProjectsFAB()}
-                    style={{ margin: "5px", alignSelf: "flex-end" }}
+                    style={{ margin: "5px", alignSelf: "flex-end", zIndex: "999" }}
                     backgroundColor={showFABOptions ? "var(--reverse-color)" : "var(--accent-color-dark)"}
                   >
                     <Glyphicon
@@ -78,6 +79,7 @@ class ProjectFAB extends Component {
                </tr>
             </tbody>
           </table>
+          {showFABOptions ? <SpotlightComponent /> : <div />}
         </div>
       </MuiThemeProvider>
     );

--- a/src/js/components/home/projectsManagement/SpotlightComponent.js
+++ b/src/js/components/home/projectsManagement/SpotlightComponent.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import Spotlight from 'react-spotlight-clickable';
+import PropTypes from 'prop-types';
+
+export default class SpotlightComponent extends Component {
+  render() {
+    return (
+      <div>
+        <Spotlight
+          x={0}
+          y={0}
+          radius={0}
+          color="white"
+          responsive
+          animSpeed={1000}
+          borderColor="#ddd"
+          borderWidth={10}
+          zIndex={0}>
+          {this.props.children}
+        </Spotlight>
+      </div>
+    );
+  }
+}
+
+SpotlightComponent.propTypes = {
+  children: PropTypes.element
+};

--- a/src/js/containers/home/ProjectsManagementContainer.js
+++ b/src/js/containers/home/ProjectsManagementContainer.js
@@ -37,7 +37,7 @@ class ProjectsManagementContainer extends Component {
     return (
       <div>
         <MyProjects myProjects={myProjects} actions={this.props.actions} />
-        <div style={{ position: "absolute", bottom:"50px", right: "50px"}}>
+        <div style={{ position: "absolute", bottom:"50px", right: "50px", zIndex: "2000"}}>
           <ProjectsFAB
             homeScreenReducer={this.props.reducers.homeScreenReducer}
             actions={this.props.actions}


### PR DESCRIPTION
#### This pull request addresses:

Now dimming the rest of the screen when clicking the project FAB


#### How to test this pull request:

- go to my projects card and click the FAB on the far bottom right.
- the rest of the screen should dim white when clicking the FAB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2036)
<!-- Reviewable:end -->
