### PR TITLE
USFM Exporting Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "translationCore",
   "version": "0.7.1-beta.41",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@paulcbetts/mime-db": {
       "version": "1.22.4",
@@ -12,39 +11,19 @@
     "@paulcbetts/mime-types": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@paulcbetts/mime-types/-/mime-types-2.1.10.tgz",
-      "integrity": "sha1-iqUx8faPrICELnmu/4Z5fDCSJ90=",
-      "requires": {
-        "@paulcbetts/mime-db": "1.22.4"
-      }
+      "integrity": "sha1-iqUx8faPrICELnmu/4Z5fDCSJ90="
     },
     "@paulcbetts/vueify": {
       "version": "9.4.3",
       "resolved": "https://registry.npmjs.org/@paulcbetts/vueify/-/vueify-9.4.3.tgz",
       "integrity": "sha1-NuLSO9fAGeit5I/IV/WjdkMeKlQ=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "convert-source-map": "1.5.0",
-        "cssnano": "3.10.0",
-        "hash-sum": "1.0.2",
-        "lru-cache": "4.1.1",
-        "object-assign": "4.1.1",
-        "source-map": "0.5.6",
-        "through": "2.3.8",
-        "vue-hot-reload-api": "2.1.0",
-        "vue-template-compiler": "2.4.1",
-        "vue-template-es2015-compiler": "1.5.3"
-      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
+          "dev": true
         }
       }
     },
@@ -81,9 +60,6 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
-      "requires": {
-        "acorn": "2.7.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -98,9 +74,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -118,11 +91,7 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -134,12 +103,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -173,11 +137,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "optional": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
-      }
+      "optional": true
     },
     "aproba": {
       "version": "1.1.2",
@@ -189,25 +149,11 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
       "integrity": "sha1-mBd9p6bAGSt/J5jzDNbquKvXZpA=",
-      "requires": {
-        "async": "0.9.2",
-        "buffer-crc32": "0.2.13",
-        "glob": "3.2.11",
-        "lazystream": "0.1.0",
-        "lodash": "2.4.2",
-        "readable-stream": "1.0.34",
-        "tar-stream": "0.4.7",
-        "zip-stream": "0.4.1"
-      },
       "dependencies": {
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
-          }
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0="
         },
         "lodash": {
           "version": "2.4.2",
@@ -217,22 +163,12 @@
         "minimatch": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     },
@@ -241,10 +177,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "optional": true,
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -256,16 +188,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "optional": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -276,10 +199,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "optional": true
         }
       }
     },
@@ -287,10 +207,6 @@
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
       "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-      "requires": {
-        "underscore": "1.7.0",
-        "underscore.string": "2.4.0"
-      },
       "dependencies": {
         "underscore": {
           "version": "1.7.0",
@@ -303,10 +219,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "optional": true,
-      "requires": {
-        "arr-flatten": "1.0.3"
-      }
+      "optional": true
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -324,10 +237,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -393,24 +303,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000700",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true,
-          "requires": {
-            "caniuse-db": "1.0.30000700",
-            "electron-to-chromium": "1.3.15"
-          }
+          "dev": true
         }
       }
     },
@@ -427,239 +325,103 @@
     "axios": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
-      "requires": {
-        "follow-redirects": "1.2.4",
-        "is-buffer": "1.1.5"
-      }
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0="
     },
     "babel-cli": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
-      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "requires": {
-        "babel-core": "6.24.1",
-        "babel-polyfill": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "chokidar": "1.7.0",
-        "commander": "2.9.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.6",
-        "v8flags": "2.1.1"
-      }
+      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM="
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
-      }
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.24.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.2",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM="
     },
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.2"
-      }
+      "dev": true
     },
     "babel-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
-      }
+      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ="
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "esutils": "2.0.2"
-      }
+      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw="
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA="
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo="
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg="
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-array-includes": {
       "version": "2.0.3",
@@ -670,10 +432,7 @@
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -714,483 +473,218 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY="
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4="
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos="
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4="
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1"
-      }
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.24.1",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
-      }
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4="
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
-      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc=",
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc="
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-      "requires": {
-        "babel-helper-builder-react-jsx": "6.24.1",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM="
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24="
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY="
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1"
-      }
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0="
     },
     "babel-preset-env": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1",
-        "browserslist": "2.1.5",
-        "invariant": "2.2.2",
-        "semver": "5.3.0"
-      }
+      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew=="
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk="
     },
     "babel-preset-es2016-node5": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/babel-preset-es2016-node5/-/babel-preset-es2016-node5-1.1.2.tgz",
       "integrity": "sha1-XsQ9LYv0HVMVgEdAzDjw3eqyaYY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1"
-      }
+      "dev": true
     },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-      "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
-      }
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0="
     },
     "babel-preset-react": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.23.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
-      }
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A="
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "requires": {
-        "babel-core": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
-      }
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118="
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      }
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.24.1",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.2",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
     },
     "babel-traverse": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "babylon": "6.17.2",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
+      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
     },
     "babel-types": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
+      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
     },
     "babylon": {
       "version": "6.17.2",
@@ -1206,10 +700,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -1221,30 +712,18 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -1255,10 +734,7 @@
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "bowser": {
       "version": "1.7.0",
@@ -1268,22 +744,13 @@
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-      "requires": {
-        "balanced-match": "0.4.2",
-        "concat-map": "0.0.1"
-      }
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "optional": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "optional": true
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -1294,11 +761,7 @@
     "browserslist": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.5.tgz",
-      "integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE=",
-      "requires": {
-        "caniuse-lite": "1.0.30000700",
-        "electron-to-chromium": "1.3.15"
-      }
+      "integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE="
     },
     "btoa": {
       "version": "1.1.2",
@@ -1319,10 +782,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsites": {
       "version": "0.2.0",
@@ -1340,33 +800,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      }
+      "dev": true
     },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000700",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
-      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true,
-          "requires": {
-            "caniuse-db": "1.0.30000700",
-            "electron-to-chromium": "1.3.15"
-          }
+          "dev": true
         }
       }
     },
@@ -1390,34 +836,18 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "dev": true
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      }
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "change-emitter": {
       "version": "0.1.6",
@@ -1434,32 +864,13 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
-      "dev": true,
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "jsdom": "7.2.2",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "optional": true,
-      "requires": {
-        "anymatch": "1.3.0",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
+      "optional": true
     },
     "circular-json": {
       "version": "0.3.1",
@@ -1471,10 +882,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
+      "dev": true
     },
     "classnames": {
       "version": "2.2.5",
@@ -1486,28 +894,18 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
       "integrity": "sha1-re91sxwWD/pdcvTeZ5ZuJmDBolU=",
       "dev": true,
-      "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1515,10 +913,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "1.0.1"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "2.1.0",
@@ -1529,12 +924,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      }
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
     },
     "clone": {
       "version": "1.0.2",
@@ -1551,10 +941,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1571,21 +958,13 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.2",
-        "color-convert": "1.9.0",
-        "color-string": "0.3.0"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.2"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.2",
@@ -1597,21 +976,13 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.2"
-      }
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true,
-      "requires": {
-        "color": "0.11.4",
-        "css-color-names": "0.0.4",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -1622,39 +993,22 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
     },
     "compress-commons": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
       "integrity": "sha1-DHQIcP3ljLpRbwrAyCLjOguF36M=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "0.3.4",
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     },
@@ -1668,11 +1022,6 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
-        "typedarray": "0.0.6"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1684,25 +1033,13 @@
           "version": "2.2.11",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
           "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.0.1",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1716,9 +1053,6 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
       "integrity": "sha1-S5RdmTeQe82Y7ldRIsOBdRZUQUE=",
       "dev": true,
-      "requires": {
-        "acorn": "2.7.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -1747,21 +1081,11 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
       "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     },
@@ -1769,11 +1093,6 @@
       "version": "15.5.3",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.5.3.tgz",
       "integrity": "sha1-+w98rnkznpoXnhlO9Gbvo5I4IP4=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -1783,24 +1102,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -1812,10 +1119,7 @@
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "crypto-js": {
       "version": "3.1.8",
@@ -1826,33 +1130,19 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/cson/-/cson-3.0.2.tgz",
       "integrity": "sha1-g+6Qids8JUvsHpjkmNmqzxGtzFQ=",
-      "dev": true,
-      "requires": {
-        "coffee-script": "1.12.6",
-        "cson-parser": "1.3.5",
-        "extract-opts": "3.3.1",
-        "requirefresh": "2.1.0",
-        "safefs": "4.1.0"
-      }
+      "dev": true
     },
     "cson-parser": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
-      "dev": true,
-      "requires": {
-        "coffee-script": "1.12.6"
-      }
+      "dev": true
     },
     "css": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
       "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
-      "dev": true,
-      "requires": {
-        "css-parse": "1.0.4",
-        "css-stringify": "1.0.5"
-      }
+      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -1863,10 +1153,7 @@
     "css-in-js-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz",
-      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU=",
-      "requires": {
-        "hyphenate-style-name": "1.0.2"
-      }
+      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU="
     },
     "css-parse": {
       "version": "1.0.4",
@@ -1878,13 +1165,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
-        "domutils": "1.5.1",
-        "nth-check": "1.0.1"
-      }
+      "dev": true
     },
     "css-stringify": {
       "version": "1.0.5",
@@ -1902,51 +1183,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
-      }
+      "dev": true
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true,
-      "requires": {
-        "clap": "1.2.0",
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -1959,36 +1202,24 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "cssom": "0.3.2"
-      }
+      "optional": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "dev": true
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2006,10 +1237,7 @@
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2021,9 +1249,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -2054,16 +1279,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
-      }
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2079,30 +1295,19 @@
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
     },
     "detective-less": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.0.tgz",
       "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.2.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -2117,20 +1322,12 @@
       "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-2.0.0.tgz",
       "integrity": "sha1-CvGKxjnIw26dN9sadOK/hJ8KVI4=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.2.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -2145,20 +1342,12 @@
       "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-1.0.0.tgz",
       "integrity": "sha1-owEFIV5fy8JhMuPGuVyNgpkYWJE=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.2.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -2185,10 +1374,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2208,10 +1393,6 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -2231,39 +1412,25 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "eachr": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
       "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-      "dev": true,
-      "requires": {
-        "editions": "1.3.3",
-        "typechecker": "4.4.1"
-      }
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "editions": {
       "version": "1.3.3",
@@ -2275,39 +1442,17 @@
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.11.tgz",
       "integrity": "sha1-vnnA69zv7bW/KBF0CYAPpTus7/o=",
-      "dev": true,
-      "requires": {
-        "@types/node": "7.0.32",
-        "electron-download": "3.3.0",
-        "extract-zip": "1.6.5"
-      }
+      "dev": true
     },
     "electron-compile": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/electron-compile/-/electron-compile-6.4.1.tgz",
       "integrity": "sha1-P4mRjXL5vTuLjpfXklEdacreCIQ=",
-      "requires": {
-        "@paulcbetts/mime-types": "2.1.10",
-        "@types/node": "7.0.32",
-        "btoa": "1.1.2",
-        "debug": "2.6.8",
-        "lru-cache": "4.1.1",
-        "mkdirp": "0.5.1",
-        "pify": "2.3.0",
-        "rimraf": "2.6.1",
-        "rxjs": "5.4.2",
-        "spawn-rx": "2.0.11",
-        "yargs": "4.8.1"
-      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
         }
       }
     },
@@ -2315,80 +1460,24 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/electron-compilers/-/electron-compilers-5.9.0.tgz",
       "integrity": "sha1-lT3BTiT7FbN9XpDeLDnXU/P4FA4=",
-      "dev": true,
-      "requires": {
-        "@paulcbetts/mime-types": "2.1.10",
-        "@paulcbetts/vueify": "9.4.3",
-        "babel-core": "6.24.1",
-        "babel-preset-env": "1.6.0",
-        "btoa": "1.1.2",
-        "cheerio": "0.20.0",
-        "coffee-script": "1.12.6",
-        "cson": "3.0.2",
-        "debug": "2.6.8",
-        "detective-less": "1.0.0",
-        "detective-sass": "2.0.0",
-        "detective-scss": "1.0.0",
-        "detective-stylus": "1.0.0",
-        "graphql": "0.9.6",
-        "graphql-tag": "2.4.2",
-        "istanbul": "0.4.5",
-        "jade": "1.11.0",
-        "js-string-escape": "1.0.1",
-        "less": "2.7.2",
-        "mkdirp": "0.5.1",
-        "nib": "1.1.2",
-        "resolve": "1.3.3",
-        "rimraf": "2.6.1",
-        "sass-lookup": "1.0.2",
-        "sass.js": "0.10.5",
-        "sorcery": "0.10.0",
-        "stylus": "0.54.5",
-        "stylus-lookup": "1.0.1",
-        "toutsuite": "0.6.0",
-        "typescript": "2.4.1"
-      }
+      "dev": true
     },
     "electron-devtools-installer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz",
-      "integrity": "sha1-mBPmgRr81p3co8rlQW23Lqfs+2o=",
-      "requires": {
-        "7zip": "0.0.6",
-        "cross-unzip": "0.0.2",
-        "rimraf": "2.6.1",
-        "semver": "5.3.0"
-      }
+      "integrity": "sha1-mBPmgRr81p3co8rlQW23Lqfs+2o="
     },
     "electron-download": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
       "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "fs-extra": "0.30.0",
-        "home-path": "1.0.5",
-        "minimist": "1.2.0",
-        "nugget": "2.0.1",
-        "path-exists": "2.1.0",
-        "rc": "1.2.1",
-        "semver": "5.3.0",
-        "sumchecker": "1.3.1"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -2402,30 +1491,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-4.0.0.tgz",
       "integrity": "sha512-N/A3P7S/fDu0d4TfFnOUFhNCITAT8TUJgM070RE7lQVjfyu+m9JvVgEmALFXPj7zTanmT2eKqthNrd5qxeQxbw==",
-      "dev": true,
-      "requires": {
-        "commander": "2.9.0",
-        "electron-window": "0.8.1",
-        "fs-extra": "3.0.1",
-        "mocha": "3.4.2",
-        "which": "1.2.14"
-      }
+      "dev": true
     },
     "electron-prebuilt-compile": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/electron-prebuilt-compile/-/electron-prebuilt-compile-1.6.11.tgz",
       "integrity": "sha1-J3vrHY/8/0ppt55eWPOcO6RqmNo=",
       "dev": true,
-      "requires": {
-        "babel-plugin-array-includes": "2.0.3",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-preset-es2016-node5": "1.1.2",
-        "babel-preset-react": "6.24.1",
-        "electron": "1.6.11",
-        "electron-compile": "6.4.1",
-        "electron-compilers": "5.9.0",
-        "yargs": "6.6.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -2437,31 +1509,13 @@
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
+          "dev": true
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2474,26 +1528,17 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
       "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
-      "dev": true,
-      "requires": {
-        "is-electron-renderer": "2.0.1"
-      }
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.18"
-      }
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "requires": {
-        "once": "1.4.0"
-      }
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
     },
     "entities": {
       "version": "1.1.1",
@@ -2506,53 +1551,30 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "prr": "0.0.0"
-      }
+      "optional": true
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-promise": {
       "version": "4.1.1",
@@ -2564,36 +1586,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2605,13 +1610,6 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
-      "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -2630,10 +1628,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -2641,54 +1636,13 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "eslint": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "es6-map": "0.1.5",
-        "escope": "3.6.0",
-        "espree": "3.4.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "optionator": "0.8.2",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.6.1",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      },
       "dependencies": {
         "strip-json-comments": {
           "version": "1.0.4",
@@ -2700,10 +1654,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -2712,21 +1663,12 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz",
       "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
       "dev": true,
-      "requires": {
-        "doctrine": "2.0.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1"
-      },
       "dependencies": {
         "doctrine": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
           "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -2740,11 +1682,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true,
-      "requires": {
-        "acorn": "5.0.3",
-        "acorn-jsx": "3.0.1"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "3.1.3",
@@ -2757,10 +1695,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
-      "requires": {
-        "estraverse": "4.1.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -2785,11 +1719,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -2801,19 +1731,13 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "optional": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "optional": true
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "optional": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "optional": true
     },
     "extend": {
       "version": "3.0.1",
@@ -2824,51 +1748,31 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "optional": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "optional": true
     },
     "extract-opts": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
       "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
-      "dev": true,
-      "requires": {
-        "eachr": "3.2.0",
-        "editions": "1.3.3",
-        "typechecker": "4.4.1"
-      }
+      "dev": true
     },
     "extract-zip": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
       "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
       "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "debug": "2.2.0",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -2893,30 +1797,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
-      "requires": {
-        "pend": "1.2.0"
-      }
+      "dev": true
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2928,35 +1821,18 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "optional": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.6",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "optional": true
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.1",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "flatten": {
       "version": "1.0.2",
@@ -2967,10 +1843,7 @@
     "follow-redirects": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
-      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
-      "requires": {
-        "debug": "2.6.8"
-      }
+      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2982,10 +1855,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "optional": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "optional": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2995,30 +1865,17 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
-      }
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
     },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.0",
-        "universalify": "0.1.0"
-      },
       "dependencies": {
         "jsonfile": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
-          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A="
         }
       }
     },
@@ -3037,10 +1894,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
       "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
       "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -3090,26 +1943,17 @@
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -3124,10 +1968,7 @@
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3147,18 +1988,12 @@
         "cryptiles": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
         },
         "dashdash": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3180,10 +2015,7 @@
         "ecc-jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -3203,12 +2035,7 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -3223,13 +2050,7 @@
         "hawk": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
         },
         "hoek": {
           "version": "2.16.3",
@@ -3239,21 +2060,12 @@
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.1"
-          }
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
         },
         "inherits": {
           "version": "2.0.3",
@@ -3268,10 +2080,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -3291,10 +2100,7 @@
         "jodid25519": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc="
         },
         "jsbn": {
           "version": "0.1.1",
@@ -3319,10 +2125,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -3342,10 +2145,7 @@
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -3380,20 +2180,12 @@
         "sntp": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
         },
         "stringstream": {
           "version": "0.0.5",
@@ -3403,10 +2195,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -3416,20 +2205,12 @@
         "tar": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -3454,10 +2235,7 @@
         "verror": {
           "version": "1.3.6",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
         },
         "wrappy": {
           "version": "1.0.2",
@@ -3469,24 +2247,13 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
     },
     "fstream-ignore": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "optional": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.0",
@@ -3498,17 +2265,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true,
-      "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
+      "optional": true
     },
     "generate-function": {
       "version": "2.0.0",
@@ -3520,10 +2277,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
+      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -3540,9 +2294,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3554,33 +2305,18 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "optional": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
     },
     "globals": {
       "version": "9.18.0",
@@ -3591,15 +2327,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "gogs-client": {
       "version": "0.5.2",
@@ -3611,9 +2339,6 @@
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
       "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
-      "requires": {
-        "minimist": "1.1.3"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
@@ -3637,10 +2362,7 @@
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.9.6.tgz",
       "integrity": "sha1-UUQh6dIlwp38j9MFRZq65YgV7yw=",
-      "dev": true,
-      "requires": {
-        "iterall": "1.1.1"
-      }
+      "dev": true
     },
     "graphql-tag": {
       "version": "2.4.2",
@@ -3659,12 +2381,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -3676,10 +2392,7 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3691,28 +2404,18 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.0"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-flag": {
       "version": "1.0.0",
@@ -3735,13 +2438,7 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "he": {
       "version": "1.1.1",
@@ -3762,11 +2459,7 @@
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
     },
     "home-path": {
       "version": "1.0.5",
@@ -3790,13 +2483,6 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
-      },
       "dependencies": {
         "entities": {
           "version": "1.0.0",
@@ -3809,12 +2495,7 @@
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
-      }
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "hyphenate-style-name": {
       "version": "1.0.2",
@@ -3849,10 +2530,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -3863,11 +2541,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -3882,40 +2556,18 @@
     "inline-style-prefixer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.5.tgz",
-      "integrity": "sha1-AJKIGzourfG9YZ3ENyZVcxb3YEI=",
-      "requires": {
-        "bowser": "1.7.0",
-        "css-in-js-utils": "1.0.3"
-      }
+      "integrity": "sha1-AJKIGzourfG9YZ3ENyZVcxb3YEI="
     },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3937,10 +2589,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "1.8.0"
-      }
+      "optional": true
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -3950,10 +2599,7 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -3971,10 +2617,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "optional": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "optional": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3990,46 +2633,28 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -4041,19 +2666,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.0"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -4094,10 +2713,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4108,10 +2724,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true,
-      "requires": {
-        "html-comment-regex": "1.1.1"
-      }
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4139,9 +2752,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "optional": true,
-      "requires": {
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4154,11 +2764,7 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.1",
-        "whatwg-fetch": "2.0.3"
-      }
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
     },
     "isstream": {
       "version": "0.1.2",
@@ -4170,22 +2776,6 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.10",
-        "js-yaml": "3.8.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.2.14",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -4203,14 +2793,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "resolve": {
           "version": "1.1.7",
@@ -4222,10 +2805,7 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -4240,18 +2820,6 @@
       "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
       "integrity": "sha1-nIDlOMEtP7lcjZu5VZ+gzAQEBf0=",
       "dev": true,
-      "requires": {
-        "character-parser": "1.2.1",
-        "clean-css": "3.4.27",
-        "commander": "2.6.0",
-        "constantinople": "3.0.2",
-        "jstransformer": "0.0.2",
-        "mkdirp": "0.5.1",
-        "transformers": "2.1.0",
-        "uglify-js": "2.8.29",
-        "void-elements": "2.0.1",
-        "with": "4.0.3"
-      },
       "dependencies": {
         "commander": {
           "version": "2.6.0",
@@ -4283,19 +2851,12 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "3.1.3"
-      },
       "dependencies": {
         "argparse": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
+          "dev": true
         }
       }
     },
@@ -4311,23 +2872,6 @@
       "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "abab": "1.0.3",
-        "acorn": "2.7.0",
-        "acorn-globals": "1.0.9",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.8.1",
-        "nwmatcher": "1.4.1",
-        "parse5": "1.5.1",
-        "request": "2.81.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.2",
-        "webidl-conversions": "2.0.1",
-        "whatwg-url-compat": "0.6.5",
-        "xml-name-validator": "2.0.1"
-      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -4351,10 +2895,7 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4376,10 +2917,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4396,12 +2934,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4414,11 +2946,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
       "integrity": "sha1-eq4pqQPRls+glz2IXT5HlH7Ndqs=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0",
-        "promise": "6.1.0"
-      }
+      "dev": true
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
@@ -4434,19 +2962,13 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "konami-code-js": {
       "version": "0.8.0",
@@ -4463,56 +2985,31 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "less": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
       "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.5.4",
-        "mime": "1.3.6",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.81.0",
-        "source-map": "0.5.6"
-      },
       "dependencies": {
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "optional": true
         }
       }
     },
@@ -4520,23 +3017,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      }
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
     },
     "lodash": {
       "version": "4.17.4",
@@ -4552,11 +3038,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -4591,12 +3073,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4619,12 +3096,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -4657,20 +3129,13 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.1"
-      }
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -4692,21 +3157,7 @@
     "material-ui": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.17.4.tgz",
-      "integrity": "sha1-GTmZ7LScPsFa4Ku06Q/fmnvTQ+A=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "inline-style-prefixer": "3.0.5",
-        "keycode": "2.1.9",
-        "lodash.merge": "4.6.0",
-        "lodash.throttle": "4.1.1",
-        "prop-types": "15.5.10",
-        "react-addons-create-fragment": "15.5.4",
-        "react-addons-transition-group": "15.5.2",
-        "react-event-listener": "0.4.5",
-        "recompose": "0.23.5",
-        "simple-assign": "0.1.0",
-        "warning": "3.0.0"
-      }
+      "integrity": "sha1-GTmZ7LScPsFa4Ku06Q/fmnvTQ+A="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -4719,18 +3170,6 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.3.8",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -4744,22 +3183,7 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "optional": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
-      }
+      "optional": true
     },
     "mime": {
       "version": "1.3.6",
@@ -4776,18 +3200,12 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "requires": {
-        "mime-db": "1.27.0"
-      }
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.7"
-      }
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "0.0.8",
@@ -4797,52 +3215,25 @@
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.0",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -4854,10 +3245,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -4887,46 +3275,24 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
       "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "dev": true,
-      "requires": {
-        "stylus": "0.54.5"
-      }
+      "dev": true
     },
     "node-fetch": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
     },
     "node-pre-gyp": {
       "version": "0.6.36",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
       "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
       "optional": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.1",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.0"
-      },
       "dependencies": {
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "optional": true,
-          "requires": {
-            "abbrev": "1.0.9",
-            "osenv": "0.1.4"
-          }
+          "optional": true
         }
       }
     },
@@ -4934,39 +3300,24 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.1.tgz",
       "integrity": "sha1-Ersbmj+xhz94XEp1R7YDT5U/Zp8=",
-      "dev": true,
-      "requires": {
-        "babylon": "6.17.2"
-      }
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9"
-      }
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "requires": {
-        "hosted-git-info": "2.4.2",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "optional": true,
-      "requires": {
-        "remove-trailing-separator": "1.0.2"
-      }
+      "optional": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4978,117 +3329,12 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
-      }
+      "dev": true
     },
     "npm": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.2.0.tgz",
       "integrity": "sha512-6Ud8G7qNoB7958zepigRCvii28AFKFAhHhyW9t9817ecRtQXoTObNgvoUXfbWtg1aHTSnVrH4kJSrD2UWtphBA==",
-      "requires": {
-        "abbrev": "1.1.0",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.1.2",
-        "archy": "1.0.0",
-        "bluebird": "3.5.0",
-        "cacache": "9.2.9",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "fstream": "1.0.11",
-        "fstream-npm": "1.2.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.4",
-        "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
-        "lazy-property": "1.0.0",
-        "libnpx": "9.0.3",
-        "lockfile": "1.0.3",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-package-arg": "5.1.2",
-        "npm-registry-client": "8.4.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.4",
-        "pacote": "2.7.38",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.10",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.3",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.81.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.1",
-        "safe-buffer": "5.1.1",
-        "semver": "5.3.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "4.1.6",
-        "strip-ansi": "4.0.0",
-        "tar": "2.2.1",
-        "text-table": "0.2.0",
-        "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.2.0",
-        "uuid": "3.1.0",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.2.14",
-        "worker-farm": "1.4.1",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.1.0"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -5121,29 +3367,10 @@
         "cacache": {
           "version": "9.2.9",
           "bundled": true,
-          "requires": {
-            "bluebird": "3.5.0",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
-            "mississippi": "1.3.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.1",
-            "ssri": "4.1.6",
-            "unique-filename": "1.1.0",
-            "y18n": "3.2.1"
-          },
           "dependencies": {
             "lru-cache": {
               "version": "4.1.1",
               "bundled": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              },
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
@@ -5171,26 +3398,15 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
-          }
+          "bundled": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
-          "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
-          },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5201,16 +3417,10 @@
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
-              "requires": {
-                "defaults": "1.0.3"
-              },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
-                  "requires": {
-                    "clone": "1.0.2"
-                  },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
@@ -5225,10 +3435,6 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
-          "requires": {
-            "ini": "1.3.4",
-            "proto-list": "1.2.4"
-          },
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
@@ -5247,10 +3453,6 @@
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
-          "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
-          },
           "dependencies": {
             "asap": {
               "version": "2.0.5",
@@ -5264,64 +3466,31 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.1"
-          }
+          "bundled": true
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.3"
-          }
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
+          "bundled": true
         },
         "fstream-npm": {
           "version": "1.2.1",
           "bundled": true,
-          "requires": {
-            "fstream-ignore": "1.0.5",
-            "inherits": "2.0.3"
-          },
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
               "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.8"
-                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
@@ -5342,14 +3511,6 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -5358,17 +3519,10 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -5410,11 +3564,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "bundled": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -5427,33 +3577,16 @@
         "init-package-json": {
           "version": "1.10.1",
           "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.10",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0"
-          },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1.0.7"
-              }
+              "bundled": true
             }
           }
         },
         "JSONStream": {
           "version": "1.3.1",
           "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
@@ -5472,23 +3605,10 @@
         "libnpx": {
           "version": "9.0.3",
           "bundled": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
-            "rimraf": "2.6.1",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.2.0",
-            "which": "1.2.14",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
-          },
           "dependencies": {
             "ansi-align": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "2.1.0"
-              }
+              "bundled": true
             },
             "ansi-regex": {
               "version": "3.0.0",
@@ -5504,24 +3624,11 @@
             },
             "boxen": {
               "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "1.1.3",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.0",
-                "term-size": "0.1.1",
-                "widest-line": "1.0.0"
-              }
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
+              "bundled": true
             },
             "builtin-modules": {
               "version": "1.1.1",
@@ -5542,13 +3649,6 @@
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5556,10 +3656,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -5570,11 +3667,6 @@
             "cliui": {
               "version": "3.2.0",
               "bundled": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5582,26 +3674,15 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  }
+                  "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
+                  "bundled": true
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -5615,38 +3696,19 @@
             },
             "configstore": {
               "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "4.1.1",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
-                "xdg-basedir": "3.0.0"
-              }
+              "bundled": true
             },
             "create-error-class": {
               "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "capture-stack-trace": "1.0.0"
-              }
+              "bundled": true
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.2.14"
-              }
+              "bundled": true
             },
             "cross-spawn-async": {
               "version": "2.2.5",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.2.14"
-              }
+              "bundled": true
             },
             "crypto-random-string": {
               "version": "1.0.0",
@@ -5662,10 +3724,7 @@
             },
             "dot-prop": {
               "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "is-obj": "1.0.1"
-              }
+              "bundled": true
             },
             "dotenv": {
               "version": "4.0.0",
@@ -5677,10 +3736,7 @@
             },
             "error-ex": {
               "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "is-arrayish": "0.2.1"
-              }
+              "bundled": true
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -5688,22 +3744,11 @@
             },
             "execa": {
               "version": "0.4.0",
-              "bundled": true,
-              "requires": {
-                "cross-spawn-async": "2.2.5",
-                "is-stream": "1.1.0",
-                "npm-run-path": "1.0.0",
-                "object-assign": "4.1.1",
-                "path-key": "1.0.0",
-                "strip-eof": "1.0.0"
-              }
+              "bundled": true
             },
             "find-up": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "2.0.0"
-              }
+              "bundled": true
             },
             "fs.realpath": {
               "version": "1.0.0",
@@ -5719,32 +3764,11 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
+              "bundled": true
             },
             "got": {
               "version": "6.7.1",
-              "bundled": true,
-              "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
-              }
+              "bundled": true
             },
             "graceful-fs": {
               "version": "4.1.11",
@@ -5753,9 +3777,6 @@
             "has-ansi": {
               "version": "2.0.0",
               "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -5777,11 +3798,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
+              "bundled": true
             },
             "inherits": {
               "version": "2.0.3",
@@ -5801,10 +3818,7 @@
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              }
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
@@ -5836,35 +3850,19 @@
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "4.0.1"
-              }
+              "bundled": true
             },
             "lcid": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "1.0.0"
-              }
+              "bundled": true
             },
             "load-json-file": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
-              }
+              "bundled": true
             },
             "locate-path": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
-              }
+              "bundled": true
             },
             "lowercase-keys": {
               "version": "1.0.0",
@@ -5872,25 +3870,15 @@
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              }
+              "bundled": true
             },
             "make-dir": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "pify": "2.3.0"
-              }
+              "bundled": true
             },
             "mem": {
               "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "1.1.0"
-              }
+              "bundled": true
             },
             "mimic-fn": {
               "version": "1.1.0",
@@ -5898,10 +3886,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
+              "bundled": true
             },
             "minimist": {
               "version": "1.2.0",
@@ -5909,30 +3894,15 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
-              }
+              "bundled": true
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.4",
-                "semver": "5.3.0",
-                "validate-npm-package-name": "3.0.0"
-              }
+              "bundled": true
             },
             "npm-run-path": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "path-key": "1.0.0"
-              }
+              "bundled": true
             },
             "number-is-nan": {
               "version": "1.0.1",
@@ -5944,10 +3914,7 @@
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
+              "bundled": true
             },
             "os-homedir": {
               "version": "1.0.2",
@@ -5956,39 +3923,18 @@
             "os-locale": {
               "version": "2.0.0",
               "bundled": true,
-              "requires": {
-                "execa": "0.5.1",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
-              },
               "dependencies": {
                 "execa": {
                   "version": "0.5.1",
-                  "bundled": true,
-                  "requires": {
-                    "cross-spawn": "4.0.2",
-                    "get-stream": "2.3.1",
-                    "is-stream": "1.1.0",
-                    "npm-run-path": "2.0.2",
-                    "p-finally": "1.0.0",
-                    "signal-exit": "3.0.2",
-                    "strip-eof": "1.0.0"
-                  }
+                  "bundled": true
                 },
                 "get-stream": {
                   "version": "2.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "object-assign": "4.1.1",
-                    "pinkie-promise": "2.0.1"
-                  }
+                  "bundled": true
                 },
                 "npm-run-path": {
                   "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "path-key": "2.0.1"
-                  }
+                  "bundled": true
                 },
                 "path-key": {
                   "version": "2.0.1",
@@ -6002,11 +3948,7 @@
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              }
+              "bundled": true
             },
             "p-finally": {
               "version": "1.0.0",
@@ -6018,27 +3960,15 @@
             },
             "p-locate": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "1.1.0"
-              }
+              "bundled": true
             },
             "package-json": {
               "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.1",
-                "registry-url": "3.1.0",
-                "semver": "5.3.0"
-              }
+              "bundled": true
             },
             "parse-json": {
               "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "1.3.1"
-              }
+              "bundled": true
             },
             "path-exists": {
               "version": "3.0.0",
@@ -6054,10 +3984,7 @@
             },
             "path-type": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "pify": "2.3.0"
-              }
+              "bundled": true
             },
             "pify": {
               "version": "2.3.0",
@@ -6069,10 +3996,7 @@
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
+              "bundled": true
             },
             "prepend-http": {
               "version": "1.0.4",
@@ -6084,45 +4008,23 @@
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
-              "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              }
+              "bundled": true
             },
             "read-pkg": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "2.0.0"
-              }
+              "bundled": true
             },
             "read-pkg-up": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
-              }
+              "bundled": true
             },
             "registry-auth-token": {
               "version": "3.3.1",
-              "bundled": true,
-              "requires": {
-                "rc": "1.2.1",
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             },
             "registry-url": {
               "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "rc": "1.2.1"
-              }
+              "bundled": true
             },
             "require-directory": {
               "version": "2.1.1",
@@ -6134,10 +4036,7 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
+              "bundled": true
             },
             "safe-buffer": {
               "version": "5.1.1",
@@ -6149,10 +4048,7 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.3.0"
-              }
+              "bundled": true
             },
             "set-blocking": {
               "version": "2.0.0",
@@ -6168,10 +4064,7 @@
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              }
+              "bundled": true
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
@@ -6183,18 +4076,11 @@
             },
             "string-width": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
+              "bundled": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
+              "bundled": true
             },
             "strip-bom": {
               "version": "3.0.0",
@@ -6214,10 +4100,7 @@
             },
             "term-size": {
               "version": "0.1.1",
-              "bundled": true,
-              "requires": {
-                "execa": "0.4.0"
-              }
+              "bundled": true
             },
             "timed-out": {
               "version": "4.0.1",
@@ -6225,10 +4108,7 @@
             },
             "unique-string": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "crypto-random-string": "1.0.0"
-              }
+              "bundled": true
             },
             "unzip-response": {
               "version": "2.0.1",
@@ -6236,46 +4116,23 @@
             },
             "update-notifier": {
               "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "boxen": "1.1.0",
-                "chalk": "1.1.3",
-                "configstore": "3.1.0",
-                "import-lazy": "2.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
-              }
+              "bundled": true
             },
             "url-parse-lax": {
               "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "prepend-http": "1.0.4"
-              }
+              "bundled": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
-              }
+              "bundled": true
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "builtins": "1.0.3"
-              }
+              "bundled": true
             },
             "which": {
               "version": "1.2.14",
-              "bundled": true,
-              "requires": {
-                "isexe": "2.0.0"
-              }
+              "bundled": true
             },
             "which-module": {
               "version": "2.0.0",
@@ -6284,9 +4141,6 @@
             "widest-line": {
               "version": "1.0.0",
               "bundled": true,
-              "requires": {
-                "string-width": "1.0.2"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -6294,36 +4148,21 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  }
+                  "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
+                  "bundled": true
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
+                  "bundled": true
                 }
               }
             },
             "wrap-ansi": {
               "version": "2.1.0",
               "bundled": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
-              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -6331,26 +4170,15 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  }
+                  "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
+                  "bundled": true
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -6360,12 +4188,7 @@
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
-              }
+              "bundled": true
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -6381,29 +4204,11 @@
             },
             "yargs": {
               "version": "8.0.2",
-              "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.0.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.0",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
-              }
+              "bundled": true
             },
             "yargs-parser": {
               "version": "7.0.0",
-              "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0"
-              }
+              "bundled": true
             }
           }
         },
@@ -6418,10 +4223,6 @@
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
-          "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
-          },
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
@@ -6443,10 +4244,7 @@
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "3.9.1"
-          }
+          "bundled": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
@@ -6475,10 +4273,6 @@
         "lru-cache": {
           "version": "4.1.1",
           "bundled": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          },
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -6493,27 +4287,10 @@
         "mississippi": {
           "version": "1.3.0",
           "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.0",
-            "end-of-stream": "1.4.0",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "1.0.2",
-            "pumpify": "1.3.5",
-            "stream-each": "1.2.0",
-            "through2": "2.0.3"
-          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
-              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -6524,26 +4301,14 @@
             "duplexify": {
               "version": "3.5.0",
               "bundled": true,
-              "requires": {
-                "end-of-stream": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "once": "1.3.3"
-                  },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      }
+                      "bundled": true
                     }
                   }
                 },
@@ -6555,35 +4320,19 @@
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0"
-              }
+              "bundled": true
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
+              "bundled": true
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              }
+              "bundled": true
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
-              "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-              },
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
@@ -6593,28 +4342,15 @@
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.0",
-                "once": "1.4.0"
-              }
+              "bundled": true
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true,
-              "requires": {
-                "duplexify": "3.5.0",
-                "inherits": "2.0.3",
-                "pump": "1.0.2"
-              }
+              "bundled": true
             },
             "stream-each": {
               "version": "1.2.0",
               "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.0",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -6625,10 +4361,6 @@
             "through2": {
               "version": "2.0.3",
               "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
-              },
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
@@ -6641,9 +4373,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -6654,69 +4383,28 @@
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
-          "requires": {
-            "aproba": "1.1.2",
-            "copy-concurrently": "1.0.3",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
-            "run-queue": "1.0.3"
-          },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.1.2",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
-                "run-queue": "1.0.3"
-              }
+              "bundled": true
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.1.2"
-              }
+              "bundled": true
             }
           }
         },
         "node-gyp": {
           "version": "3.6.2",
           "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.4",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.2.14"
-          },
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -6732,37 +4420,21 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1.1.0"
-              }
+              "bundled": true
             }
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+          "bundled": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1"
-          },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
@@ -6778,46 +4450,19 @@
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "semver": "5.3.0"
-          }
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "osenv": "0.1.4",
-            "semver": "5.3.0",
-            "validate-npm-package-name": "3.0.0"
-          }
+          "bundled": true
         },
         "npm-registry-client": {
           "version": "8.4.0",
           "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.81.0",
-            "retry": "0.10.1",
-            "semver": "5.3.0",
-            "slide": "1.1.6",
-            "ssri": "4.1.6"
-          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
-              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -6834,20 +4479,10 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
-              },
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
@@ -6862,16 +4497,6 @@
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "requires": {
-                "aproba": "1.1.2",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              },
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
@@ -6884,11 +4509,6 @@
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -6897,9 +4517,6 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -6912,9 +4529,6 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -6924,10 +4538,7 @@
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  }
+                  "bundled": true
                 }
               }
             },
@@ -6939,10 +4550,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "bundled": true
         },
         "opener": {
           "version": "1.4.3",
@@ -6951,10 +4559,6 @@
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
@@ -6969,60 +4573,18 @@
         "pacote": {
           "version": "2.7.38",
           "bundled": true,
-          "requires": {
-            "bluebird": "3.5.0",
-            "cacache": "9.2.9",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.4.13",
-            "minimatch": "3.0.4",
-            "mississippi": "1.3.0",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npm-pick-manifest": "1.0.4",
-            "osenv": "0.1.4",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "4.0.0",
-            "safe-buffer": "5.1.1",
-            "semver": "5.3.0",
-            "ssri": "4.1.6",
-            "tar-fs": "1.15.3",
-            "tar-stream": "1.5.4",
-            "unique-filename": "1.1.0",
-            "which": "1.2.14"
-          },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.4.13",
               "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "9.2.9",
-                "http-cache-semantics": "3.7.3",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.0.0",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.0",
-                "node-fetch-npm": "2.0.1",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.0",
-                "ssri": "4.1.6"
-              },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -7039,24 +4601,14 @@
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.0",
-                    "debug": "2.6.8"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -7069,9 +4621,6 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -7084,24 +4633,14 @@
                 "https-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.0",
-                    "debug": "2.6.8"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -7114,9 +4653,6 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -7129,18 +4665,10 @@
                 "node-fetch-npm": {
                   "version": "2.0.1",
                   "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-helpfulerror": "1.0.3",
-                    "safe-buffer": "5.1.1"
-                  },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.18"
-                      },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.18",
@@ -7151,9 +4679,6 @@
                     "json-parse-helpfulerror": {
                       "version": "1.0.3",
                       "bundled": true,
-                      "requires": {
-                        "jju": "1.3.0"
-                      },
                       "dependencies": {
                         "jju": {
                           "version": "1.3.0",
@@ -7166,24 +4691,14 @@
                 "socks-proxy-agent": {
                   "version": "3.0.0",
                   "bundled": true,
-                  "requires": {
-                    "agent-base": "4.1.0",
-                    "socks": "1.1.10"
-                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -7196,10 +4711,6 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
@@ -7218,17 +4729,10 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -7244,19 +4748,11 @@
             },
             "npm-pick-manifest": {
               "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.3.0"
-              }
+              "bundled": true
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
-              "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
-              },
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
@@ -7267,9 +4763,6 @@
             "protoduck": {
               "version": "4.0.0",
               "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
@@ -7280,27 +4773,14 @@
             "tar-fs": {
               "version": "1.15.3",
               "bundled": true,
-              "requires": {
-                "chownr": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pump": "1.0.2",
-                "tar-stream": "1.5.4"
-              },
               "dependencies": {
                 "pump": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.0",
-                    "once": "1.4.0"
-                  },
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "once": "1.4.0"
-                      }
+                      "bundled": true
                     }
                   }
                 }
@@ -7309,26 +4789,14 @@
             "tar-stream": {
               "version": "1.5.4",
               "bundled": true,
-              "requires": {
-                "bl": "1.2.1",
-                "end-of-stream": "1.4.0",
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
-              },
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "2.3.3"
-                  }
+                  "bundled": true
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "1.4.0"
-                  }
+                  "bundled": true
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -7349,9 +4817,6 @@
         "read": {
           "version": "1.0.7",
           "bundled": true,
-          "requires": {
-            "mute-stream": "0.0.7"
-          },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
@@ -7361,23 +4826,11 @@
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
+          "bundled": true
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.10",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.3.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
-          },
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
@@ -7388,19 +4841,10 @@
         "read-package-json": {
           "version": "2.0.10",
           "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.4.0"
-          },
           "dependencies": {
             "json-parse-helpfulerror": {
               "version": "1.0.3",
               "bundled": true,
-              "requires": {
-                "jju": "1.3.0"
-              },
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
@@ -7412,27 +4856,11 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.10",
-            "readdir-scoped-modules": "1.0.2"
-          }
+          "bundled": true
         },
         "readable-stream": {
           "version": "2.3.3",
           "bundled": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -7448,10 +4876,7 @@
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -7461,41 +4886,11 @@
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
-          }
+          "bundled": true
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -7512,9 +4907,6 @@
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -7533,11 +4925,6 @@
             "form-data": {
               "version": "2.1.4",
               "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
-              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
@@ -7548,18 +4935,10 @@
             "har-validator": {
               "version": "4.2.1",
               "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
-              },
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
                   "bundled": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
-                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -7568,9 +4947,6 @@
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "requires": {
-                        "jsonify": "0.0.0"
-                      },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
@@ -7589,26 +4965,14 @@
             "hawk": {
               "version": "3.1.3",
               "bundled": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
+                  "bundled": true
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "2.10.1"
-                  }
+                  "bundled": true
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -7616,21 +4980,13 @@
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
+                  "bundled": true
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
               "bundled": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
-              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
@@ -7639,12 +4995,6 @@
                 "jsprim": {
                   "version": "1.4.0",
                   "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.3",
-                    "verror": "1.3.6"
-                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
@@ -7660,26 +5010,13 @@
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "bundled": true,
-                      "requires": {
-                        "extsprintf": "1.0.2"
-                      }
+                      "bundled": true
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.13.1",
                   "bundled": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -7692,32 +5029,20 @@
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
+                      "optional": true
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
+                      "bundled": true
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
+                      "optional": true
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
+                      "bundled": true
                     },
                     "jsbn": {
                       "version": "0.1.1",
@@ -7748,9 +5073,6 @@
             "mime-types": {
               "version": "2.1.15",
               "bundled": true,
-              "requires": {
-                "mime-db": "1.27.0"
-              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
@@ -7777,9 +5099,6 @@
             "tough-cookie": {
               "version": "2.3.2",
               "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -7789,10 +5108,7 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
+              "bundled": true
             }
           }
         },
@@ -7802,10 +5118,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "bundled": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -7817,11 +5130,7 @@
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.3"
-          }
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
@@ -7834,28 +5143,14 @@
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
-          "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
-          },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
-              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
-                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -7876,10 +5171,6 @@
             "stream-iterate": {
               "version": "1.2.0",
               "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
-              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -7891,17 +5182,11 @@
         },
         "ssri": {
           "version": "4.1.6",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "bundled": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
@@ -7912,18 +5197,10 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          },
           "dependencies": {
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
+              "bundled": true
             }
           }
         },
@@ -7942,16 +5219,10 @@
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
-          "requires": {
-            "unique-slug": "2.0.0"
-          },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "0.1.4"
-              }
+              "bundled": true
             }
           }
         },
@@ -7962,36 +5233,14 @@
         "update-notifier": {
           "version": "2.2.0",
           "bundled": true,
-          "requires": {
-            "boxen": "1.1.0",
-            "chalk": "1.1.3",
-            "configstore": "3.1.0",
-            "import-lazy": "2.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          },
           "dependencies": {
             "boxen": {
               "version": "1.1.0",
               "bundled": true,
-              "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "1.1.3",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.0",
-                "term-size": "0.1.1",
-                "widest-line": "1.0.0"
-              },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.0"
-                  }
+                  "bundled": true
                 },
                 "camelcase": {
                   "version": "4.1.0",
@@ -8004,10 +5253,6 @@
                 "string-width": {
                   "version": "2.1.0",
                   "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -8015,39 +5260,21 @@
                     },
                     "strip-ansi": {
                       "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
+                      "bundled": true
                     }
                   }
                 },
                 "term-size": {
                   "version": "0.1.1",
                   "bundled": true,
-                  "requires": {
-                    "execa": "0.4.0"
-                  },
                   "dependencies": {
                     "execa": {
                       "version": "0.4.0",
                       "bundled": true,
-                      "requires": {
-                        "cross-spawn-async": "2.2.5",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "1.0.0",
-                        "object-assign": "4.1.1",
-                        "path-key": "1.0.0",
-                        "strip-eof": "1.0.0"
-                      },
                       "dependencies": {
                         "cross-spawn-async": {
                           "version": "2.2.5",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "which": "1.2.14"
-                          }
+                          "bundled": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
@@ -8055,10 +5282,7 @@
                         },
                         "npm-run-path": {
                           "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "1.0.0"
-                          }
+                          "bundled": true
                         },
                         "object-assign": {
                           "version": "4.1.1",
@@ -8079,18 +5303,10 @@
                 "widest-line": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -8099,9 +5315,6 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -8112,9 +5325,6 @@
                         "strip-ansi": {
                           "version": "3.0.1",
                           "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
@@ -8131,13 +5341,6 @@
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -8150,9 +5353,6 @@
                 "has-ansi": {
                   "version": "2.0.0",
                   "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -8163,9 +5363,6 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -8182,21 +5379,10 @@
             "configstore": {
               "version": "3.1.0",
               "bundled": true,
-              "requires": {
-                "dot-prop": "4.1.1",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
-                "xdg-basedir": "3.0.0"
-              },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.1.1",
                   "bundled": true,
-                  "requires": {
-                    "is-obj": "1.0.1"
-                  },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
@@ -8207,9 +5393,6 @@
                 "make-dir": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "pify": "2.3.0"
-                  },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
@@ -8220,9 +5403,6 @@
                 "unique-string": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "1.0.0"
-                  },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
@@ -8243,43 +5423,18 @@
             "latest-version": {
               "version": "3.1.0",
               "bundled": true,
-              "requires": {
-                "package-json": "4.0.1"
-              },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
-                  "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
-                    "registry-url": "3.1.0",
-                    "semver": "5.3.0"
-                  },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
-                      "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
-                      },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "1.0.0"
-                          },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
@@ -8322,9 +5477,6 @@
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "bundled": true,
-                          "requires": {
-                            "prepend-http": "1.0.4"
-                          },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
@@ -8337,20 +5489,10 @@
                     "registry-auth-token": {
                       "version": "3.3.1",
                       "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
-                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -8371,19 +5513,10 @@
                     "registry-url": {
                       "version": "3.1.0",
                       "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1"
-                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -8407,10 +5540,7 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.3.0"
-              }
+              "bundled": true
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -8425,17 +5555,10 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          },
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
@@ -8452,9 +5575,6 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
-          "requires": {
-            "builtins": "1.0.3"
-          },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
@@ -8465,9 +5585,6 @@
         "which": {
           "version": "1.2.14",
           "bundled": true,
-          "requires": {
-            "isexe": "2.0.0"
-          },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
@@ -8478,17 +5595,10 @@
         "worker-farm": {
           "version": "1.4.1",
           "bundled": true,
-          "requires": {
-            "errno": "0.1.4",
-            "xtend": "4.0.1"
-          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
               "bundled": true,
-              "requires": {
-                "prr": "0.0.0"
-              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
@@ -8508,12 +5618,7 @@
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
+          "bundled": true
         }
       }
     },
@@ -8521,37 +5626,19 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
+      "optional": true
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0"
-      }
+      "dev": true
     },
     "nugget": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "minimist": "1.2.0",
-        "pretty-bytes": "1.0.4",
-        "progress-stream": "1.2.0",
-        "request": "2.81.0",
-        "single-line-log": "1.1.2",
-        "throttleit": "0.0.2"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -8604,19 +5691,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "optional": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "optional": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "onetime": {
       "version": "1.1.0",
@@ -8629,10 +5709,6 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -8646,15 +5722,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
+      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -8664,10 +5732,7 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -8678,41 +5743,23 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "optional": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "optional": true
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY="
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "optional": true
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "parse5": {
       "version": "1.5.1",
@@ -8724,10 +5771,7 @@
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
     },
     "path-extra": {
       "version": "3.0.0",
@@ -8754,12 +5798,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
     },
     "pend": {
       "version": "1.2.0",
@@ -8785,10 +5824,7 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
     },
     "pluralize": {
       "version": "1.2.1",
@@ -8801,21 +5837,12 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.1.9",
-        "source-map": "0.5.6",
-        "supports-color": "3.2.3"
-      },
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -8823,132 +5850,79 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
-      }
+      "dev": true
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true,
-      "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqid": "4.1.1"
-      }
+      "dev": true
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
-      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true,
-          "requires": {
-            "caniuse-db": "1.0.30000700",
-            "electron-to-chromium": "1.3.15"
-          }
+          "dev": true
         }
       }
     },
@@ -8962,141 +5936,79 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3"
-      }
+      "dev": true
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true,
-      "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true,
-      "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true,
-      "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
-      }
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -9108,12 +6020,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9137,11 +6044,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
-      }
+      "dev": true
     },
     "private": {
       "version": "0.1.7",
@@ -9163,28 +6066,18 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-      "dev": true,
-      "requires": {
-        "speedometer": "0.1.4",
-        "through2": "0.2.3"
-      }
+      "dev": true
     },
     "progressbar.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/progressbar.js/-/progressbar.js-1.0.1.tgz",
-      "integrity": "sha1-9/v8GVJA/guzL2972y5/9ADqcfk=",
-      "requires": {
-        "shifty": "1.5.4"
-      }
+      "integrity": "sha1-9/v8GVJA/guzL2972y5/9ADqcfk="
     },
     "promise": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
       "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
       "dev": true,
-      "requires": {
-        "asap": "1.0.0"
-      },
       "dependencies": {
         "asap": {
           "version": "1.0.0",
@@ -9198,10 +6091,6 @@
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9211,24 +6100,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9264,32 +6141,18 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
+      "dev": true
     },
     "randomatic": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "optional": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "kind-of": "3.2.2"
-      }
+      "optional": true
     },
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -9302,11 +6165,6 @@
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
       "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9316,24 +6174,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9341,11 +6187,6 @@
       "version": "15.5.4",
       "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.5.4.tgz",
       "integrity": "sha1-BIrLLzMqP0UL6uC+ZoJO2R5m4SI=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9355,24 +6196,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9381,10 +6210,6 @@
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
       "integrity": "sha1-k7yqcY/K5zYNQuj7HAl1bMNjAqI=",
       "dev": true,
-      "requires": {
-        "fbjs": "0.8.12",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9396,25 +6221,13 @@
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
           "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "dev": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "dev": true
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true,
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "dev": true
         }
       }
     },
@@ -9422,10 +6235,6 @@
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.5.2.tgz",
       "integrity": "sha1-2mmJ2c/+J9/6yu3IYgAP+wmuIgY=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9435,53 +6244,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
     "react-bootstrap": {
       "version": "0.30.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.10.tgz",
-      "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "classnames": "2.2.5",
-        "dom-helpers": "3.2.1",
-        "invariant": "2.2.2",
-        "keycode": "2.1.9",
-        "prop-types": "15.5.10",
-        "react-overlays": "0.6.12",
-        "react-prop-types": "0.4.0",
-        "uncontrollable": "4.1.0",
-        "warning": "3.0.0"
-      }
+      "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag="
     },
     "react-dom": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
       "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9491,24 +6271,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9516,12 +6284,6 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
       "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "fbjs": "0.8.12",
-        "prop-types": "15.5.10",
-        "warning": "3.0.0"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9531,94 +6293,49 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
     "react-overlays": {
       "version": "0.6.12",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
-      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=",
-      "requires": {
-        "classnames": "2.2.5",
-        "dom-helpers": "3.2.1",
-        "react-prop-types": "0.4.0",
-        "warning": "3.0.0"
-      }
+      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM="
     },
     "react-progressbar.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-progressbar.js/-/react-progressbar.js-0.2.0.tgz",
-      "integrity": "sha1-/5bw+r2PD31EEbNjCx0gFsON9iU=",
-      "requires": {
-        "lodash.isequal": "4.5.0",
-        "progressbar.js": "1.0.1",
-        "react": "15.4.2",
-        "react-dom": "15.4.2"
-      }
+      "integrity": "sha1-/5bw+r2PD31EEbNjCx0gFsON9iU="
     },
     "react-prop-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
-      "requires": {
-        "warning": "3.0.0"
-      }
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A="
     },
     "react-redux": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
-      "requires": {
-        "create-react-class": "15.5.3",
-        "hoist-non-react-statics": "1.2.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
-      }
+      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
     },
     "react-remarkable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz",
-      "integrity": "sha1-N5CKyViUV20NORh70om8LLtaxt4=",
-      "requires": {
-        "remarkable": "1.7.1"
-      }
+      "integrity": "sha1-N5CKyViUV20NORh70om8LLtaxt4="
     },
     "react-spotlight-clickable": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-spotlight-clickable/-/react-spotlight-clickable-1.0.5.tgz",
-      "integrity": "sha1-4Z7LClQXJlZiLjszM9R9JSIUx5U=",
-      "requires": {
-        "prop-types": "15.5.10"
-      }
+      "integrity": "sha1-4Z7LClQXJlZiLjszM9R9JSIUx5U="
     },
     "react-tap-event-plugin": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz",
       "integrity": "sha1-MWvrO8ZVbinshppyk+icgmqQdNI=",
-      "requires": {
-        "fbjs": "0.8.12"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9628,24 +6345,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9657,44 +6362,23 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.3.8",
-        "path-type": "1.1.0"
-      }
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
     },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "optional": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.2.11",
-        "set-immediate-shim": "1.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -9706,25 +6390,13 @@
           "version": "2.2.11",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
           "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.0.1",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "optional": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -9732,23 +6404,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
+      "dev": true
     },
     "recompose": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.23.5.tgz",
       "integrity": "sha1-cqyCYSRr7DeCNdGHRn0CpyHosd4=",
-      "requires": {
-        "change-emitter": "0.1.6",
-        "fbjs": "0.8.12",
-        "hoist-non-react-statics": "1.2.0",
-        "symbol-observable": "1.0.4"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -9758,24 +6419,12 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.13"
-          }
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.5"
-          }
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
         }
       }
     },
@@ -9783,42 +6432,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "dev": true
     },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
-      }
+      "dev": true
     },
     "reduce-function-call": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2"
-      }
+      "dev": true
     },
     "redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
-      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0=",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
-      }
+      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
     },
     "redux-mock-store": {
       "version": "1.2.3",
@@ -9829,10 +6460,7 @@
     "redux-subscriptions": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/redux-subscriptions/-/redux-subscriptions-0.2.0.tgz",
-      "integrity": "sha1-GrATXK428nzpoQvG0cDZo9MQMyM=",
-      "requires": {
-        "object-difference": "0.1.0"
-      }
+      "integrity": "sha1-GrATXK428nzpoQvG0cDZo9MQMyM="
     },
     "redux-test-utils": {
       "version": "0.1.2",
@@ -9858,32 +6486,18 @@
     "regenerator-transform": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.24.1",
-        "private": "0.1.7"
-      }
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM="
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "optional": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
-      }
+      "optional": true
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -9894,9 +6508,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -9908,11 +6519,7 @@
     "remarkable": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
-      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
-      "requires": {
-        "argparse": "0.1.16",
-        "autolinker": "0.15.3"
-      }
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y="
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -9933,39 +6540,12 @@
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.0.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.0.1"
-      }
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -9981,29 +6561,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "requirefresh": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz",
       "integrity": "sha1-dC3Mwg86lpGNZsbxWX3I/+vE9vU=",
-      "dev": true,
-      "requires": {
-        "editions": "1.3.3"
-      }
+      "dev": true
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -10015,37 +6585,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
-      }
+      "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -10056,10 +6613,7 @@
     "rxjs": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
-      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
-      "requires": {
-        "symbol-observable": "1.0.4"
-      }
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc="
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -10070,23 +6624,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
       "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-      "dev": true,
-      "requires": {
-        "editions": "1.3.3",
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
       "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
       "dev": true,
-      "requires": {
-        "es6-promise": "3.3.1",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      },
       "dependencies": {
         "es6-promise": {
           "version": "3.3.1",
@@ -10101,19 +6645,12 @@
       "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-1.0.2.tgz",
       "integrity": "sha1-wVxPcmHcKtsRs9WRLe1rCKFLIcg=",
       "dev": true,
-      "requires": {
-        "commander": "2.8.1",
-        "is-relative-path": "1.0.1"
-      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -10185,10 +6722,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
@@ -10204,22 +6738,13 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
     "sorcery": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
       "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
       "dev": true,
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "minimist": "1.2.0",
-        "sander": "0.5.1",
-        "sourcemap-codec": "1.3.1"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -10233,10 +6758,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
+      "dev": true
     },
     "source-map": {
       "version": "0.5.6",
@@ -10246,37 +6768,23 @@
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
     },
     "sourcemap-codec": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz",
       "integrity": "sha1-mtb5vb1pGTEBbjCTnbyGhnMyMUY=",
-      "dev": true,
-      "requires": {
-        "vlq": "0.2.2"
-      }
+      "dev": true
     },
     "spawn-rx": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.11.tgz",
-      "integrity": "sha1-ZUUa1lZigB2up1VJgyp4LeAEjb8=",
-      "requires": {
-        "debug": "2.6.8",
-        "lodash.assign": "4.2.0",
-        "rxjs": "5.4.2"
-      }
+      "integrity": "sha1-ZUUa1lZigB2up1VJgyp4LeAEjb8="
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -10304,16 +6812,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -10336,12 +6834,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -10351,27 +6844,18 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -10383,14 +6867,6 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
-      "requires": {
-        "css-parse": "1.7.0",
-        "debug": "2.6.8",
-        "glob": "7.0.6",
-        "mkdirp": "0.5.1",
-        "sax": "0.5.8",
-        "source-map": "0.1.43"
-      },
       "dependencies": {
         "css-parse": {
           "version": "1.7.0",
@@ -10402,15 +6878,7 @@
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "sax": {
           "version": "0.5.8",
@@ -10422,10 +6890,7 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -10434,29 +6899,18 @@
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-1.0.1.tgz",
       "integrity": "sha1-qMvC4NLYcVdMN/Dim0axjcmfHWk=",
       "dev": true,
-      "requires": {
-        "commander": "2.8.1",
-        "debug": "2.2.0",
-        "is-relative-path": "1.0.1"
-      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -10475,11 +6929,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
       "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "es6-promise": "4.1.1"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
@@ -10491,24 +6941,12 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
-      "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
-      },
       "dependencies": {
         "argparse": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
+          "dev": true
         },
         "esprima": {
           "version": "2.7.3",
@@ -10520,11 +6958,7 @@
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
+          "dev": true
         }
       }
     },
@@ -10551,14 +6985,6 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -10570,39 +6996,20 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
     },
     "tar-pack": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
       "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
       "optional": true,
-      "requires": {
-        "debug": "2.6.8",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.1",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -10614,16 +7021,7 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "optional": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -10634,23 +7032,14 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "optional": true
         }
       }
     },
     "tar-stream": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
-      "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0=",
-      "requires": {
-        "bl": "0.9.5",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
-      }
+      "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0="
     },
     "text-table": {
       "version": "0.2.0",
@@ -10675,19 +7064,12 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14",
-        "xtend": "2.1.2"
-      },
       "dependencies": {
         "xtend": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
+          "dev": true
         }
       }
     },
@@ -10699,20 +7081,13 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
     },
     "toutsuite": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/toutsuite/-/toutsuite-0.6.0.tgz",
       "integrity": "sha1-+tK0RTcsy7gxYJ1OeAP885K+1M4=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "synchronous-promise": "1.0.12"
-      }
+      "dev": true
     },
     "tr46": {
       "version": "0.0.3",
@@ -10726,11 +7101,6 @@
       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
       "integrity": "sha1-XSPLNVYd2F3Gf7hIIwm0fVPM6ac=",
       "dev": true,
-      "requires": {
-        "css": "1.0.8",
-        "promise": "2.0.0",
-        "uglify-js": "2.2.5"
-      },
       "dependencies": {
         "is-promise": {
           "version": "1.0.1",
@@ -10742,38 +7112,25 @@
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true,
-          "requires": {
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         },
         "promise": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
           "integrity": "sha1-RmSKqdYFr10ucMMCS/WUNtoCuA4=",
-          "dev": true,
-          "requires": {
-            "is-promise": "1.0.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         },
         "uglify-js": {
           "version": "2.2.5",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
           "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          }
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -10803,10 +7160,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -10818,10 +7172,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
@@ -10833,10 +7184,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz",
       "integrity": "sha1-+XuV9RsDhBchLWd9RaNz7nvO1+Y=",
-      "dev": true,
-      "requires": {
-        "editions": "1.3.3"
-      }
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -10860,11 +7208,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
-      "requires": {
-        "source-map": "0.5.6",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -10876,12 +7219,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
+          "dev": true
         },
         "window-size": {
           "version": "0.1.0",
@@ -10899,13 +7237,7 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+          "dev": true
         }
       }
     },
@@ -10925,10 +7257,7 @@
     "uncontrollable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
-      "requires": {
-        "invariant": "2.2.2"
-      }
+      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak="
     },
     "underscore.string": {
       "version": "2.4.0",
@@ -10945,10 +7274,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
+      "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
@@ -10984,19 +7310,12 @@
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
     },
     "vendors": {
       "version": "1.0.1",
@@ -11007,10 +7326,7 @@
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "requires": {
-        "extsprintf": "1.0.2"
-      }
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "vlq": {
       "version": "0.2.2",
@@ -11034,11 +7350,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.4.1.tgz",
       "integrity": "sha512-DE7D9qpgT8ExbWwnzDeakZjmi2tEP1auxq4sD1R2L10A6PFTvo+R0r3bpxPAReGJBqxS4qrjw3kGFzT6Jvb3YQ==",
-      "dev": true,
-      "requires": {
-        "de-indent": "1.0.2",
-        "he": "1.1.1"
-      }
+      "dev": true
     },
     "vue-template-es2015-compiler": {
       "version": "1.5.3",
@@ -11049,10 +7361,7 @@
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w="
     },
     "webidl-conversions": {
       "version": "2.0.1",
@@ -11071,10 +7380,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tr46": "0.0.3"
-      }
+      "optional": true
     },
     "whet.extend": {
       "version": "0.9.9",
@@ -11086,10 +7392,7 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "dev": true
     },
     "which-module": {
       "version": "1.0.0",
@@ -11100,10 +7403,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "optional": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
+      "optional": true
     },
     "window-size": {
       "version": "0.2.0",
@@ -11115,10 +7415,6 @@
       "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
       "integrity": "sha1-7v0VTp550sjTQXtkeo8U2f7M4U4=",
       "dev": true,
-      "requires": {
-        "acorn": "1.2.2",
-        "acorn-globals": "1.0.9"
-      },
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
@@ -11137,11 +7433,7 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -11152,10 +7444,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "xml-name-validator": {
       "version": "2.0.1",
@@ -11187,32 +7476,12 @@
     "yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-      "requires": {
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "lodash.assign": "4.2.0",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "2.4.1"
-      }
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA="
     },
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-      "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -11225,28 +7494,17 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
-      "requires": {
-        "fd-slicer": "1.0.1"
-      }
+      "dev": true
     },
     "zip-folder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/zip-folder/-/zip-folder-1.0.0.tgz",
-      "integrity": "sha1-cKd0T9F4mi/rQa00GbMun9h5V7I=",
-      "requires": {
-        "archiver": "0.11.0"
-      }
+      "integrity": "sha1-cKd0T9F4mi/rQa00GbMun9h5V7I="
     },
     "zip-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
       "integrity": "sha1-TqeVqM4Z6fq0mjHR0IdyFBWfA6M=",
-      "requires": {
-        "compress-commons": "0.1.6",
-        "lodash": "2.4.2",
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
@@ -11256,13 +7514,7 @@
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "translationCore",
   "version": "0.7.1-beta.41",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@paulcbetts/mime-db": {
       "version": "1.22.4",
@@ -11,19 +12,39 @@
     "@paulcbetts/mime-types": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@paulcbetts/mime-types/-/mime-types-2.1.10.tgz",
-      "integrity": "sha1-iqUx8faPrICELnmu/4Z5fDCSJ90="
+      "integrity": "sha1-iqUx8faPrICELnmu/4Z5fDCSJ90=",
+      "requires": {
+        "@paulcbetts/mime-db": "1.22.4"
+      }
     },
     "@paulcbetts/vueify": {
       "version": "9.4.3",
       "resolved": "https://registry.npmjs.org/@paulcbetts/vueify/-/vueify-9.4.3.tgz",
       "integrity": "sha1-NuLSO9fAGeit5I/IV/WjdkMeKlQ=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "convert-source-map": "1.5.0",
+        "cssnano": "3.10.0",
+        "hash-sum": "1.0.2",
+        "lru-cache": "4.1.1",
+        "object-assign": "4.1.1",
+        "source-map": "0.5.6",
+        "through": "2.3.8",
+        "vue-hot-reload-api": "2.1.0",
+        "vue-template-compiler": "2.4.1",
+        "vue-template-es2015-compiler": "1.5.3"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         }
       }
     },
@@ -60,6 +81,9 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
+      "requires": {
+        "acorn": "2.7.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -74,6 +98,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -91,7 +118,11 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -103,7 +134,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -137,7 +173,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "aproba": {
       "version": "1.1.2",
@@ -149,11 +189,25 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
       "integrity": "sha1-mBd9p6bAGSt/J5jzDNbquKvXZpA=",
+      "requires": {
+        "async": "0.9.2",
+        "buffer-crc32": "0.2.13",
+        "glob": "3.2.11",
+        "lazystream": "0.1.0",
+        "lodash": "2.4.2",
+        "readable-stream": "1.0.34",
+        "tar-stream": "0.4.7",
+        "zip-stream": "0.4.1"
+      },
       "dependencies": {
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0="
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
         },
         "lodash": {
           "version": "2.4.2",
@@ -163,12 +217,22 @@
         "minimatch": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0="
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -177,6 +241,10 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "optional": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -188,7 +256,16 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -199,7 +276,10 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -207,6 +287,10 @@
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
       "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "requires": {
+        "underscore": "1.7.0",
+        "underscore.string": "2.4.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.7.0",
@@ -219,7 +303,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -237,7 +324,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -303,12 +393,24 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000700",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "caniuse-db": "1.0.30000700",
+            "electron-to-chromium": "1.3.15"
+          }
         }
       }
     },
@@ -325,103 +427,239 @@
     "axios": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0="
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+      "requires": {
+        "follow-redirects": "1.2.4",
+        "is-buffer": "1.1.5"
+      }
     },
     "babel-cli": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
-      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM="
+      "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+      "requires": {
+        "babel-core": "6.24.1",
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.6",
+        "v8flags": "2.1.1"
+      }
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-core": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM="
+      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-generator": "6.24.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      }
     },
     "babel-eslint": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2"
+      }
     },
     "babel-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
+      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ="
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw="
+      "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "esutils": "2.0.2"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA="
+      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo="
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg="
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-array-includes": {
       "version": "2.0.3",
@@ -432,7 +670,10 @@
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -473,218 +714,483 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY="
+      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "6.24.1",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4="
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos="
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4="
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.24.1",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "regexpu-core": "2.0.0"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4="
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988="
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
-      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc="
+      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc=",
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM="
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "requires": {
+        "babel-helper-builder-react-jsx": "6.24.1",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24="
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY="
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg="
+      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+      "requires": {
+        "regenerator-transform": "0.9.11"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1"
+      }
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0="
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-preset-env": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew=="
+      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.24.1",
+        "browserslist": "2.1.5",
+        "invariant": "2.2.2",
+        "semver": "5.3.0"
+      }
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk="
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.24.1"
+      }
     },
     "babel-preset-es2016-node5": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/babel-preset-es2016-node5/-/babel-preset-es2016-node5-1.1.2.tgz",
       "integrity": "sha1-XsQ9LYv0HVMVgEdAzDjw3eqyaYY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1"
+      }
     },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0="
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
+      }
     },
     "babel-preset-react": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A="
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-react-display-name": "6.23.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-preset-flow": "6.23.0"
+      }
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118="
+      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+      "requires": {
+        "babel-core": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.15"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-template": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
+      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.24.1",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
+      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "babylon": "6.17.2",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
+      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.2",
@@ -700,7 +1206,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -712,18 +1221,30 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -734,7 +1255,10 @@
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "bowser": {
       "version": "1.7.0",
@@ -744,13 +1268,22 @@
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -761,7 +1294,11 @@
     "browserslist": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.5.tgz",
-      "integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE="
+      "integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE=",
+      "requires": {
+        "caniuse-lite": "1.0.30000700",
+        "electron-to-chromium": "1.3.15"
+      }
     },
     "btoa": {
       "version": "1.1.2",
@@ -782,7 +1319,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -800,19 +1340,33 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000700",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "caniuse-db": "1.0.30000700",
+            "electron-to-chromium": "1.3.15"
+          }
         }
       }
     },
@@ -836,18 +1390,34 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "change-emitter": {
       "version": "0.1.6",
@@ -864,13 +1434,32 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.8.3",
+        "jsdom": "7.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -882,7 +1471,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "classnames": {
       "version": "2.2.5",
@@ -894,18 +1486,28 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
       "integrity": "sha1-re91sxwWD/pdcvTeZ5ZuJmDBolU=",
       "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "source-map": "0.4.4"
+      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -913,7 +1515,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -924,7 +1529,12 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
     },
     "clone": {
       "version": "1.0.2",
@@ -941,7 +1551,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -958,13 +1571,21 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "color-convert": "1.9.0",
+        "color-string": "0.3.0"
+      }
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "color-name": {
       "version": "1.1.2",
@@ -976,13 +1597,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
     },
     "colors": {
       "version": "1.1.2",
@@ -993,22 +1622,39 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "compress-commons": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
       "integrity": "sha1-DHQIcP3ljLpRbwrAyCLjOguF36M=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "0.3.4",
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -1022,6 +1668,11 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.11",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1033,13 +1684,25 @@
           "version": "2.2.11",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
           "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.0.1",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         }
       }
     },
@@ -1053,6 +1716,9 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
       "integrity": "sha1-S5RdmTeQe82Y7ldRIsOBdRZUQUE=",
       "dev": true,
+      "requires": {
+        "acorn": "2.7.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -1081,11 +1747,21 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
       "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -1093,6 +1769,11 @@
       "version": "15.5.3",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.5.3.tgz",
       "integrity": "sha1-+w98rnkznpoXnhlO9Gbvo5I4IP4=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -1102,12 +1783,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -1119,7 +1812,10 @@
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "crypto-js": {
       "version": "3.1.8",
@@ -1130,19 +1826,33 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/cson/-/cson-3.0.2.tgz",
       "integrity": "sha1-g+6Qids8JUvsHpjkmNmqzxGtzFQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coffee-script": "1.12.6",
+        "cson-parser": "1.3.5",
+        "extract-opts": "3.3.1",
+        "requirefresh": "2.1.0",
+        "safefs": "4.1.0"
+      }
     },
     "cson-parser": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coffee-script": "1.12.6"
+      }
     },
     "css": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
       "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "css-parse": "1.0.4",
+        "css-stringify": "1.0.5"
+      }
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -1153,7 +1863,10 @@
     "css-in-js-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz",
-      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU="
+      "integrity": "sha1-msfgL3Y8+F2UAXZmVl7WiltfMhU=",
+      "requires": {
+        "hyphenate-style-name": "1.0.2"
+      }
     },
     "css-parse": {
       "version": "1.0.4",
@@ -1165,7 +1878,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
     },
     "css-stringify": {
       "version": "1.0.5",
@@ -1183,13 +1902,51 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clap": "1.2.0",
+        "source-map": "0.5.6"
+      }
     },
     "cssom": {
       "version": "0.3.2",
@@ -1202,24 +1959,36 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1237,7 +2006,10 @@
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1249,6 +2021,9 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -1279,7 +2054,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1295,19 +2079,30 @@
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "detective-less": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.0.tgz",
       "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.2.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1322,12 +2117,20 @@
       "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-2.0.0.tgz",
       "integrity": "sha1-CvGKxjnIw26dN9sadOK/hJ8KVI4=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.2.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1342,12 +2145,20 @@
       "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-1.0.0.tgz",
       "integrity": "sha1-owEFIV5fy8JhMuPGuVyNgpkYWJE=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.2.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1374,6 +2185,10 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1393,6 +2208,10 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -1412,25 +2231,39 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "eachr": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
       "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "editions": {
       "version": "1.3.3",
@@ -1442,17 +2275,39 @@
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.11.tgz",
       "integrity": "sha1-vnnA69zv7bW/KBF0CYAPpTus7/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.32",
+        "electron-download": "3.3.0",
+        "extract-zip": "1.6.5"
+      }
     },
     "electron-compile": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/electron-compile/-/electron-compile-6.4.1.tgz",
       "integrity": "sha1-P4mRjXL5vTuLjpfXklEdacreCIQ=",
+      "requires": {
+        "@paulcbetts/mime-types": "2.1.10",
+        "@types/node": "7.0.32",
+        "btoa": "1.1.2",
+        "debug": "2.6.8",
+        "lru-cache": "4.1.1",
+        "mkdirp": "0.5.1",
+        "pify": "2.3.0",
+        "rimraf": "2.6.1",
+        "rxjs": "5.4.2",
+        "spawn-rx": "2.0.11",
+        "yargs": "4.8.1"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         }
       }
     },
@@ -1460,24 +2315,80 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/electron-compilers/-/electron-compilers-5.9.0.tgz",
       "integrity": "sha1-lT3BTiT7FbN9XpDeLDnXU/P4FA4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@paulcbetts/mime-types": "2.1.10",
+        "@paulcbetts/vueify": "9.4.3",
+        "babel-core": "6.24.1",
+        "babel-preset-env": "1.6.0",
+        "btoa": "1.1.2",
+        "cheerio": "0.20.0",
+        "coffee-script": "1.12.6",
+        "cson": "3.0.2",
+        "debug": "2.6.8",
+        "detective-less": "1.0.0",
+        "detective-sass": "2.0.0",
+        "detective-scss": "1.0.0",
+        "detective-stylus": "1.0.0",
+        "graphql": "0.9.6",
+        "graphql-tag": "2.4.2",
+        "istanbul": "0.4.5",
+        "jade": "1.11.0",
+        "js-string-escape": "1.0.1",
+        "less": "2.7.2",
+        "mkdirp": "0.5.1",
+        "nib": "1.1.2",
+        "resolve": "1.3.3",
+        "rimraf": "2.6.1",
+        "sass-lookup": "1.0.2",
+        "sass.js": "0.10.5",
+        "sorcery": "0.10.0",
+        "stylus": "0.54.5",
+        "stylus-lookup": "1.0.1",
+        "toutsuite": "0.6.0",
+        "typescript": "2.4.1"
+      }
     },
     "electron-devtools-installer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz",
-      "integrity": "sha1-mBPmgRr81p3co8rlQW23Lqfs+2o="
+      "integrity": "sha1-mBPmgRr81p3co8rlQW23Lqfs+2o=",
+      "requires": {
+        "7zip": "0.0.6",
+        "cross-unzip": "0.0.2",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0"
+      }
     },
     "electron-download": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
       "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "fs-extra": "0.30.0",
+        "home-path": "1.0.5",
+        "minimist": "1.2.0",
+        "nugget": "2.0.1",
+        "path-exists": "2.1.0",
+        "rc": "1.2.1",
+        "semver": "5.3.0",
+        "sumchecker": "1.3.1"
+      },
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.1"
+          }
         },
         "minimist": {
           "version": "1.2.0",
@@ -1491,13 +2402,30 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-4.0.0.tgz",
       "integrity": "sha512-N/A3P7S/fDu0d4TfFnOUFhNCITAT8TUJgM070RE7lQVjfyu+m9JvVgEmALFXPj7zTanmT2eKqthNrd5qxeQxbw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "electron-window": "0.8.1",
+        "fs-extra": "3.0.1",
+        "mocha": "3.4.2",
+        "which": "1.2.14"
+      }
     },
     "electron-prebuilt-compile": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/electron-prebuilt-compile/-/electron-prebuilt-compile-1.6.11.tgz",
       "integrity": "sha1-J3vrHY/8/0ppt55eWPOcO6RqmNo=",
       "dev": true,
+      "requires": {
+        "babel-plugin-array-includes": "2.0.3",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-preset-es2016-node5": "1.1.2",
+        "babel-preset-react": "6.24.1",
+        "electron": "1.6.11",
+        "electron-compile": "6.4.1",
+        "electron-compilers": "5.9.0",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -1509,13 +2437,31 @@
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -1528,17 +2474,26 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
       "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-electron-renderer": "2.0.1"
+      }
     },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.18"
+      }
     },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY="
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "entities": {
       "version": "1.1.1",
@@ -1551,30 +2506,53 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-promise": {
       "version": "4.1.1",
@@ -1586,19 +2564,36 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1610,6 +2605,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -1628,7 +2630,10 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1636,13 +2641,54 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "strip-json-comments": {
           "version": "1.0.4",
@@ -1654,7 +2700,10 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
       }
     },
@@ -1663,12 +2712,21 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz",
       "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
       "dev": true,
+      "requires": {
+        "doctrine": "2.0.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1"
+      },
       "dependencies": {
         "doctrine": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
           "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -1682,7 +2740,11 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
@@ -1695,6 +2757,10 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -1719,7 +2785,11 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -1731,13 +2801,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -1748,31 +2824,51 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extract-opts": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
       "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eachr": "3.2.0",
+        "editions": "1.3.3",
+        "typechecker": "4.4.1"
+      }
     },
     "extract-zip": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
       "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
       "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "debug": "2.2.0",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "mkdirp": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1797,19 +2893,30 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1821,18 +2928,35 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.6",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "flatten": {
       "version": "1.0.2",
@@ -1843,7 +2967,10 @@
     "follow-redirects": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
-      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw=="
+      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+      "requires": {
+        "debug": "2.6.8"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1855,7 +2982,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1865,17 +2995,30 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.0",
+        "universalify": "0.1.0"
+      },
       "dependencies": {
         "jsonfile": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
-          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A="
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
         }
       }
     },
@@ -1894,6 +3037,10 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
       "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1943,17 +3090,26 @@
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40="
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1968,7 +3124,10 @@
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1988,12 +3147,18 @@
         "cryptiles": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2015,7 +3180,10 @@
         "ecc-jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU="
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -2035,7 +3203,12 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2050,7 +3223,13 @@
         "hawk": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -2060,12 +3239,21 @@
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.1"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -2080,7 +3268,10 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -2100,7 +3291,10 @@
         "jodid25519": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc="
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -2125,7 +3319,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -2145,7 +3342,10 @@
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -2180,12 +3380,20 @@
         "sntp": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -2195,7 +3403,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -2205,12 +3416,20 @@
         "tar": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -2235,7 +3454,10 @@
         "verror": {
           "version": "1.3.6",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -2247,13 +3469,24 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
     },
     "fstream-ignore": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
     },
     "function-bind": {
       "version": "1.1.0",
@@ -2265,7 +3498,17 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "aproba": "1.1.2",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2277,7 +3520,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2294,6 +3540,9 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2305,18 +3554,33 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -2327,7 +3591,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "gogs-client": {
       "version": "0.5.2",
@@ -2339,6 +3611,9 @@
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
       "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
+      "requires": {
+        "minimist": "1.1.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
@@ -2362,7 +3637,10 @@
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.9.6.tgz",
       "integrity": "sha1-UUQh6dIlwp38j9MFRZq65YgV7yw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "iterall": "1.1.1"
+      }
     },
     "graphql-tag": {
       "version": "2.4.2",
@@ -2381,6 +3659,12 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -2392,7 +3676,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -2404,18 +3691,28 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -2438,7 +3735,13 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -2459,7 +3762,11 @@
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "home-path": {
       "version": "1.0.5",
@@ -2483,6 +3790,13 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "entities": {
           "version": "1.0.0",
@@ -2495,7 +3809,12 @@
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.2",
@@ -2530,7 +3849,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -2541,7 +3863,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2556,18 +3882,40 @@
     "inline-style-prefixer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.5.tgz",
-      "integrity": "sha1-AJKIGzourfG9YZ3ENyZVcxb3YEI="
+      "integrity": "sha1-AJKIGzourfG9YZ3ENyZVcxb3YEI=",
+      "requires": {
+        "bowser": "1.7.0",
+        "css-in-js-utils": "1.0.3"
+      }
     },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2589,7 +3937,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -2599,7 +3950,10 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2617,7 +3971,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2633,28 +3990,46 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2666,13 +4041,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -2713,7 +4094,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2724,7 +4108,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2752,6 +4139,9 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "optional": true,
+      "requires": {
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2764,7 +4154,11 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.1",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2776,6 +4170,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.8.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -2793,7 +4203,14 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -2805,7 +4222,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2820,6 +4240,18 @@
       "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
       "integrity": "sha1-nIDlOMEtP7lcjZu5VZ+gzAQEBf0=",
       "dev": true,
+      "requires": {
+        "character-parser": "1.2.1",
+        "clean-css": "3.4.27",
+        "commander": "2.6.0",
+        "constantinople": "3.0.2",
+        "jstransformer": "0.0.2",
+        "mkdirp": "0.5.1",
+        "transformers": "2.1.0",
+        "uglify-js": "2.8.29",
+        "void-elements": "2.0.1",
+        "with": "4.0.3"
+      },
       "dependencies": {
         "commander": {
           "version": "2.6.0",
@@ -2851,12 +4283,19 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      },
       "dependencies": {
         "argparse": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
         }
       }
     },
@@ -2872,6 +4311,23 @@
       "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "abab": "1.0.3",
+        "acorn": "2.7.0",
+        "acorn-globals": "1.0.9",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.8.1",
+        "nwmatcher": "1.4.1",
+        "parse5": "1.5.1",
+        "request": "2.81.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.2",
+        "webidl-conversions": "2.0.1",
+        "whatwg-url-compat": "0.6.5",
+        "xml-name-validator": "2.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
@@ -2895,7 +4351,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2917,7 +4376,10 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2934,6 +4396,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2946,7 +4414,11 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
       "integrity": "sha1-eq4pqQPRls+glz2IXT5HlH7Ndqs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0",
+        "promise": "6.1.0"
+      }
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
@@ -2962,13 +4434,19 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "konami-code-js": {
       "version": "0.8.0",
@@ -2985,31 +4463,56 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "less": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
       "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.4",
+        "mime": "1.3.6",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.81.0",
+        "source-map": "0.5.6"
+      },
       "dependencies": {
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -3017,12 +4520,23 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -3038,7 +4552,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -3073,7 +4591,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -3096,7 +4619,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -3129,13 +4657,20 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -3157,7 +4692,21 @@
     "material-ui": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.17.4.tgz",
-      "integrity": "sha1-GTmZ7LScPsFa4Ku06Q/fmnvTQ+A="
+      "integrity": "sha1-GTmZ7LScPsFa4Ku06Q/fmnvTQ+A=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "inline-style-prefixer": "3.0.5",
+        "keycode": "2.1.9",
+        "lodash.merge": "4.6.0",
+        "lodash.throttle": "4.1.1",
+        "prop-types": "15.5.10",
+        "react-addons-create-fragment": "15.5.4",
+        "react-addons-transition-group": "15.5.2",
+        "react-event-listener": "0.4.5",
+        "recompose": "0.23.5",
+        "simple-assign": "0.1.0",
+        "warning": "3.0.0"
+      }
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -3170,6 +4719,18 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.3.8",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -3183,7 +4744,22 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mime": {
       "version": "1.3.6",
@@ -3200,12 +4776,18 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -3215,25 +4797,52 @@
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -3245,7 +4854,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -3275,24 +4887,46 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
       "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stylus": "0.54.5"
+      }
     },
     "node-fetch": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "node-pre-gyp": {
       "version": "0.6.36",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
       "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
       "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.1",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.0"
+      },
       "dependencies": {
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.0.9",
+            "osenv": "0.1.4"
+          }
         }
       }
     },
@@ -3300,24 +4934,39 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.1.tgz",
       "integrity": "sha1-Ersbmj+xhz94XEp1R7YDT5U/Zp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babylon": "6.17.2"
+      }
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -3329,12 +4978,117 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
     },
     "npm": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.2.0.tgz",
       "integrity": "sha512-6Ud8G7qNoB7958zepigRCvii28AFKFAhHhyW9t9817ecRtQXoTObNgvoUXfbWtg1aHTSnVrH4kJSrD2UWtphBA==",
+      "requires": {
+        "abbrev": "1.1.0",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.1.2",
+        "archy": "1.0.0",
+        "bluebird": "3.5.0",
+        "cacache": "9.2.9",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "fstream": "1.0.11",
+        "fstream-npm": "1.2.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.5.0",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.4",
+        "init-package-json": "1.10.1",
+        "JSONStream": "1.3.1",
+        "lazy-property": "1.0.0",
+        "libnpx": "9.0.3",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-package-arg": "5.1.2",
+        "npm-registry-client": "8.4.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.4",
+        "pacote": "2.7.38",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.10",
+        "read-package-tree": "5.1.6",
+        "readable-stream": "2.3.3",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.81.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.1",
+        "safe-buffer": "5.1.1",
+        "semver": "5.3.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "4.1.6",
+        "strip-ansi": "4.0.0",
+        "tar": "2.2.1",
+        "text-table": "0.2.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.2.0",
+        "uuid": "3.1.0",
+        "validate-npm-package-license": "3.0.1",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.2.14",
+        "worker-farm": "1.4.1",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.1.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -3367,10 +5121,29 @@
         "cacache": {
           "version": "9.2.9",
           "bundled": true,
+          "requires": {
+            "bluebird": "3.5.0",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.1",
+            "mississippi": "1.3.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.1",
+            "ssri": "4.1.6",
+            "unique-filename": "1.1.0",
+            "y18n": "3.2.1"
+          },
           "dependencies": {
             "lru-cache": {
               "version": "4.1.1",
               "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              },
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
@@ -3398,15 +5171,26 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -3417,10 +5201,16 @@
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
@@ -3435,6 +5225,10 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
+          "requires": {
+            "ini": "1.3.4",
+            "proto-list": "1.2.4"
+          },
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
@@ -3453,6 +5247,10 @@
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
           "dependencies": {
             "asap": {
               "version": "2.0.5",
@@ -3466,31 +5264,64 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.1"
+          }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.3"
+          }
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-npm": {
           "version": "1.2.1",
           "bundled": true,
+          "requires": {
+            "fstream-ignore": "1.0.5",
+            "inherits": "2.0.3"
+          },
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
               "bundled": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
@@ -3511,6 +5342,14 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
@@ -3519,10 +5358,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -3564,7 +5410,11 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -3577,16 +5427,33 @@
         "init-package-json": {
           "version": "1.10.1",
           "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "5.1.2",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.10",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0"
+          },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
             }
           }
         },
         "JSONStream": {
           "version": "1.3.1",
           "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
@@ -3605,10 +5472,23 @@
         "libnpx": {
           "version": "9.0.3",
           "bundled": true,
+          "requires": {
+            "dotenv": "4.0.0",
+            "npm-package-arg": "5.1.2",
+            "rimraf": "2.6.1",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.2.0",
+            "which": "1.2.14",
+            "y18n": "3.2.1",
+            "yargs": "8.0.2"
+          },
           "dependencies": {
             "ansi-align": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "string-width": "2.1.0"
+              }
             },
             "ansi-regex": {
               "version": "3.0.0",
@@ -3624,11 +5504,24 @@
             },
             "boxen": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.0",
+                "term-size": "0.1.1",
+                "widest-line": "1.0.0"
+              }
             },
             "brace-expansion": {
               "version": "1.1.8",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
             },
             "builtin-modules": {
               "version": "1.1.1",
@@ -3649,6 +5542,13 @@
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -3656,7 +5556,10 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 }
               }
             },
@@ -3667,6 +5570,11 @@
             "cliui": {
               "version": "3.2.0",
               "bundled": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -3674,15 +5582,26 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 }
               }
             },
@@ -3696,19 +5615,38 @@
             },
             "configstore": {
               "version": "3.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.1.1",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.0.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.1.0",
+                "xdg-basedir": "3.0.0"
+              }
             },
             "create-error-class": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "capture-stack-trace": "1.0.0"
+              }
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "which": "1.2.14"
+              }
             },
             "cross-spawn-async": {
               "version": "2.2.5",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "which": "1.2.14"
+              }
             },
             "crypto-random-string": {
               "version": "1.0.0",
@@ -3724,7 +5662,10 @@
             },
             "dot-prop": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "is-obj": "1.0.1"
+              }
             },
             "dotenv": {
               "version": "4.0.0",
@@ -3736,7 +5677,10 @@
             },
             "error-ex": {
               "version": "1.3.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -3744,11 +5688,22 @@
             },
             "execa": {
               "version": "0.4.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "cross-spawn-async": "2.2.5",
+                "is-stream": "1.1.0",
+                "npm-run-path": "1.0.0",
+                "object-assign": "4.1.1",
+                "path-key": "1.0.0",
+                "strip-eof": "1.0.0"
+              }
             },
             "find-up": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
             },
             "fs.realpath": {
               "version": "1.0.0",
@@ -3764,11 +5719,32 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
             },
             "got": {
               "version": "6.7.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "create-error-class": "3.0.2",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-redirect": "1.0.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "lowercase-keys": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "timed-out": "4.0.1",
+                "unzip-response": "2.0.1",
+                "url-parse-lax": "1.0.0"
+              }
             },
             "graceful-fs": {
               "version": "4.1.11",
@@ -3777,6 +5753,9 @@
             "has-ansi": {
               "version": "2.0.0",
               "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -3798,7 +5777,11 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
             },
             "inherits": {
               "version": "2.0.3",
@@ -3818,7 +5801,10 @@
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
@@ -3850,19 +5836,35 @@
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              }
             },
             "lcid": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
             },
             "load-json-file": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+              }
             },
             "locate-path": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              }
             },
             "lowercase-keys": {
               "version": "1.0.0",
@@ -3870,15 +5872,25 @@
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
             },
             "make-dir": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "pify": "2.3.0"
+              }
             },
             "mem": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
             },
             "mimic-fn": {
               "version": "1.1.0",
@@ -3886,7 +5898,10 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
             },
             "minimist": {
               "version": "1.2.0",
@@ -3894,15 +5909,30 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
+              }
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.3.0",
+                "validate-npm-package-name": "3.0.0"
+              }
             },
             "npm-run-path": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "path-key": "1.0.0"
+              }
             },
             "number-is-nan": {
               "version": "1.0.1",
@@ -3914,7 +5944,10 @@
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
             },
             "os-homedir": {
               "version": "1.0.2",
@@ -3923,18 +5956,39 @@
             "os-locale": {
               "version": "2.0.0",
               "bundled": true,
+              "requires": {
+                "execa": "0.5.1",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              },
               "dependencies": {
                 "execa": {
                   "version": "0.5.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "cross-spawn": "4.0.2",
+                    "get-stream": "2.3.1",
+                    "is-stream": "1.1.0",
+                    "npm-run-path": "2.0.2",
+                    "p-finally": "1.0.0",
+                    "signal-exit": "3.0.2",
+                    "strip-eof": "1.0.0"
+                  }
                 },
                 "get-stream": {
                   "version": "2.3.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "object-assign": "4.1.1",
+                    "pinkie-promise": "2.0.1"
+                  }
                 },
                 "npm-run-path": {
                   "version": "2.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "path-key": "2.0.1"
+                  }
                 },
                 "path-key": {
                   "version": "2.0.1",
@@ -3948,7 +6002,11 @@
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
             },
             "p-finally": {
               "version": "1.0.0",
@@ -3960,15 +6018,27 @@
             },
             "p-locate": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "p-limit": "1.1.0"
+              }
             },
             "package-json": {
               "version": "4.0.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "got": "6.7.1",
+                "registry-auth-token": "3.3.1",
+                "registry-url": "3.1.0",
+                "semver": "5.3.0"
+              }
             },
             "parse-json": {
               "version": "2.2.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
             },
             "path-exists": {
               "version": "3.0.0",
@@ -3984,7 +6054,10 @@
             },
             "path-type": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "pify": "2.3.0"
+              }
             },
             "pify": {
               "version": "2.3.0",
@@ -3996,7 +6069,10 @@
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
             },
             "prepend-http": {
               "version": "1.0.4",
@@ -4008,23 +6084,45 @@
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              }
             },
             "read-pkg": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+              }
             },
             "read-pkg-up": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
             },
             "registry-auth-token": {
               "version": "3.3.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "rc": "1.2.1",
+                "safe-buffer": "5.1.1"
+              }
             },
             "registry-url": {
               "version": "3.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "rc": "1.2.1"
+              }
             },
             "require-directory": {
               "version": "2.1.1",
@@ -4036,7 +6134,10 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
             },
             "safe-buffer": {
               "version": "5.1.1",
@@ -4048,7 +6149,10 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "semver": "5.3.0"
+              }
             },
             "set-blocking": {
               "version": "2.0.0",
@@ -4064,7 +6168,10 @@
             },
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
@@ -4076,11 +6183,18 @@
             },
             "string-width": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              }
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             },
             "strip-bom": {
               "version": "3.0.0",
@@ -4100,7 +6214,10 @@
             },
             "term-size": {
               "version": "0.1.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "execa": "0.4.0"
+              }
             },
             "timed-out": {
               "version": "4.0.1",
@@ -4108,7 +6225,10 @@
             },
             "unique-string": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "crypto-random-string": "1.0.0"
+              }
             },
             "unzip-response": {
               "version": "2.0.1",
@@ -4116,23 +6236,46 @@
             },
             "update-notifier": {
               "version": "2.2.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "boxen": "1.1.0",
+                "chalk": "1.1.3",
+                "configstore": "3.1.0",
+                "import-lazy": "2.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
+              }
             },
             "url-parse-lax": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "prepend-http": "1.0.4"
+              }
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              }
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "builtins": "1.0.3"
+              }
             },
             "which": {
               "version": "1.2.14",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
             },
             "which-module": {
               "version": "2.0.0",
@@ -4141,6 +6284,9 @@
             "widest-line": {
               "version": "1.0.0",
               "bundled": true,
+              "requires": {
+                "string-width": "1.0.2"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -4148,21 +6294,36 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 }
               }
             },
             "wrap-ansi": {
               "version": "2.1.0",
               "bundled": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
@@ -4170,15 +6331,26 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
                 }
               }
             },
@@ -4188,7 +6360,12 @@
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -4204,11 +6381,29 @@
             },
             "yargs": {
               "version": "8.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.0.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.0",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              }
             },
             "yargs-parser": {
               "version": "7.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
             }
           }
         },
@@ -4223,6 +6418,10 @@
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
@@ -4244,7 +6443,10 @@
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
         },
         "lodash._getnative": {
           "version": "3.9.1",
@@ -4273,6 +6475,10 @@
         "lru-cache": {
           "version": "4.1.1",
           "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -4287,10 +6493,27 @@
         "mississippi": {
           "version": "1.3.0",
           "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "duplexify": "3.5.0",
+            "end-of-stream": "1.4.0",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "1.0.2",
+            "pumpify": "1.3.5",
+            "stream-each": "1.2.0",
+            "through2": "2.0.3"
+          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -4301,14 +6524,26 @@
             "duplexify": {
               "version": "3.5.0",
               "bundled": true,
+              "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "once": "1.3.3"
+                  },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      }
                     }
                   }
                 },
@@ -4320,19 +6555,35 @@
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+              }
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+              }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+              },
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
@@ -4342,15 +6593,28 @@
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+              }
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.0",
+                "inherits": "2.0.3",
+                "pump": "1.0.2"
+              }
             },
             "stream-each": {
               "version": "1.2.0",
               "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.0",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -4361,6 +6625,10 @@
             "through2": {
               "version": "2.0.3",
               "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
@@ -4373,6 +6641,9 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -4383,28 +6654,69 @@
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
+          "requires": {
+            "aproba": "1.1.2",
+            "copy-concurrently": "1.0.3",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "run-queue": "1.0.3"
+          },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.2",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "run-queue": "1.0.3"
+              }
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.2"
+              }
             }
           }
         },
         "node-gyp": {
           "version": "3.6.2",
           "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.4",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.2.14"
+          },
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -4420,21 +6732,37 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0"
+              }
             }
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
@@ -4450,19 +6778,46 @@
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "semver": "5.3.0"
+          }
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.4",
+            "semver": "5.3.0",
+            "validate-npm-package-name": "3.0.0"
+          }
         },
         "npm-registry-client": {
           "version": "8.4.0",
           "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "5.1.2",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "semver": "5.3.0",
+            "slide": "1.1.6",
+            "ssri": "4.1.6"
+          },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+              },
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
@@ -4479,10 +6834,20 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
+              },
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
@@ -4497,6 +6862,16 @@
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "requires": {
+                "aproba": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              },
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
@@ -4509,6 +6884,11 @@
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -4517,6 +6897,9 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -4529,6 +6912,9 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -4538,7 +6924,10 @@
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
                 }
               }
             },
@@ -4550,7 +6939,10 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "opener": {
           "version": "1.4.3",
@@ -4559,6 +6951,10 @@
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
@@ -4573,18 +6969,60 @@
         "pacote": {
           "version": "2.7.38",
           "bundled": true,
+          "requires": {
+            "bluebird": "3.5.0",
+            "cacache": "9.2.9",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.1",
+            "make-fetch-happen": "2.4.13",
+            "minimatch": "3.0.4",
+            "mississippi": "1.3.0",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "5.1.2",
+            "npm-pick-manifest": "1.0.4",
+            "osenv": "0.1.4",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "4.0.0",
+            "safe-buffer": "5.1.1",
+            "semver": "5.3.0",
+            "ssri": "4.1.6",
+            "tar-fs": "1.15.3",
+            "tar-stream": "1.5.4",
+            "unique-filename": "1.1.0",
+            "which": "1.2.14"
+          },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.4.13",
               "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "9.2.9",
+                "http-cache-semantics": "3.7.3",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.0.0",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "node-fetch-npm": "2.0.1",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.0",
+                "ssri": "4.1.6"
+              },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -4601,14 +7039,24 @@
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "4.1.0",
+                    "debug": "2.6.8"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.1.1"
+                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -4621,6 +7069,9 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -4633,14 +7084,24 @@
                 "https-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "4.1.0",
+                    "debug": "2.6.8"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.1.1"
+                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -4653,6 +7114,9 @@
                     "debug": {
                       "version": "2.6.8",
                       "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
@@ -4665,10 +7129,18 @@
                 "node-fetch-npm": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-helpfulerror": "1.0.3",
+                    "safe-buffer": "5.1.1"
+                  },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.18"
+                      },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.18",
@@ -4679,6 +7151,9 @@
                     "json-parse-helpfulerror": {
                       "version": "1.0.3",
                       "bundled": true,
+                      "requires": {
+                        "jju": "1.3.0"
+                      },
                       "dependencies": {
                         "jju": {
                           "version": "1.3.0",
@@ -4691,14 +7166,24 @@
                 "socks-proxy-agent": {
                   "version": "3.0.0",
                   "bundled": true,
+                  "requires": {
+                    "agent-base": "4.1.0",
+                    "socks": "1.1.10"
+                  },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
                       "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.1.1"
+                          },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
@@ -4711,6 +7196,10 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
@@ -4729,10 +7218,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
@@ -4748,11 +7244,19 @@
             },
             "npm-pick-manifest": {
               "version": "1.0.4",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "5.1.2",
+                "semver": "5.3.0"
+              }
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
@@ -4763,6 +7267,9 @@
             "protoduck": {
               "version": "4.0.0",
               "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
@@ -4773,14 +7280,27 @@
             "tar-fs": {
               "version": "1.15.3",
               "bundled": true,
+              "requires": {
+                "chownr": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pump": "1.0.2",
+                "tar-stream": "1.5.4"
+              },
               "dependencies": {
                 "pump": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.0",
+                    "once": "1.4.0"
+                  },
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
                     }
                   }
                 }
@@ -4789,14 +7309,26 @@
             "tar-stream": {
               "version": "1.5.4",
               "bundled": true,
+              "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.3"
+                  }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -4817,6 +7349,9 @@
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
@@ -4826,11 +7361,23 @@
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.10",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.3.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
@@ -4841,10 +7388,19 @@
         "read-package-json": {
           "version": "2.0.10",
           "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.4.0"
+          },
           "dependencies": {
             "json-parse-helpfulerror": {
               "version": "1.0.3",
               "bundled": true,
+              "requires": {
+                "jju": "1.3.0"
+              },
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
@@ -4856,11 +7412,27 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.10",
+            "readdir-scoped-modules": "1.0.2"
+          }
         },
         "readable-stream": {
           "version": "2.3.3",
           "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -4876,7 +7448,10 @@
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -4886,11 +7461,41 @@
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -4907,6 +7512,9 @@
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -4925,6 +7533,11 @@
             "form-data": {
               "version": "2.1.4",
               "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
@@ -4935,10 +7548,18 @@
             "har-validator": {
               "version": "4.2.1",
               "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              },
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
                   "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -4947,6 +7568,9 @@
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "bundled": true,
+                      "requires": {
+                        "jsonify": "0.0.0"
+                      },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
@@ -4965,14 +7589,26 @@
             "hawk": {
               "version": "3.1.3",
               "bundled": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -4980,13 +7616,21 @@
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
               "bundled": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.1"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
@@ -4995,6 +7639,12 @@
                 "jsprim": {
                   "version": "1.4.0",
                   "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
@@ -5010,13 +7660,26 @@
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.13.1",
                   "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
@@ -5029,20 +7692,32 @@
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
                       "bundled": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
-                      "optional": true
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
                     },
                     "jsbn": {
                       "version": "0.1.1",
@@ -5073,6 +7748,9 @@
             "mime-types": {
               "version": "2.1.15",
               "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
@@ -5099,6 +7777,9 @@
             "tough-cookie": {
               "version": "2.3.2",
               "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
@@ -5108,7 +7789,10 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
             }
           }
         },
@@ -5118,7 +7802,10 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -5130,7 +7817,11 @@
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.3"
+          }
         },
         "slide": {
           "version": "1.1.6",
@@ -5143,14 +7834,28 @@
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5171,6 +7876,10 @@
             "stream-iterate": {
               "version": "1.2.0",
               "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+              },
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
@@ -5182,11 +7891,17 @@
         },
         "ssri": {
           "version": "4.1.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
@@ -5197,10 +7912,18 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          },
           "dependencies": {
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
             }
           }
         },
@@ -5219,10 +7942,16 @@
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
             }
           }
         },
@@ -5233,14 +7962,36 @@
         "update-notifier": {
           "version": "2.2.0",
           "bundled": true,
+          "requires": {
+            "boxen": "1.1.0",
+            "chalk": "1.1.3",
+            "configstore": "3.1.0",
+            "import-lazy": "2.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
           "dependencies": {
             "boxen": {
               "version": "1.1.0",
               "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.0",
+                "term-size": "0.1.1",
+                "widest-line": "1.0.0"
+              },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.0"
+                  }
                 },
                 "camelcase": {
                   "version": "4.1.0",
@@ -5253,6 +8004,10 @@
                 "string-width": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
@@ -5260,21 +8015,39 @@
                     },
                     "strip-ansi": {
                       "version": "4.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "3.0.0"
+                      }
                     }
                   }
                 },
                 "term-size": {
                   "version": "0.1.1",
                   "bundled": true,
+                  "requires": {
+                    "execa": "0.4.0"
+                  },
                   "dependencies": {
                     "execa": {
                       "version": "0.4.0",
                       "bundled": true,
+                      "requires": {
+                        "cross-spawn-async": "2.2.5",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "path-key": "1.0.0",
+                        "strip-eof": "1.0.0"
+                      },
                       "dependencies": {
                         "cross-spawn-async": {
                           "version": "2.2.5",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.1",
+                            "which": "1.2.14"
+                          }
                         },
                         "is-stream": {
                           "version": "1.1.0",
@@ -5282,7 +8055,10 @@
                         },
                         "npm-run-path": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "1.0.0"
+                          }
                         },
                         "object-assign": {
                           "version": "4.1.1",
@@ -5303,10 +8079,18 @@
                 "widest-line": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -5315,6 +8099,9 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -5325,6 +8112,9 @@
                         "strip-ansi": {
                           "version": "3.0.1",
                           "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
@@ -5341,6 +8131,13 @@
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
@@ -5353,6 +8150,9 @@
                 "has-ansi": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -5363,6 +8163,9 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
@@ -5379,10 +8182,21 @@
             "configstore": {
               "version": "3.1.0",
               "bundled": true,
+              "requires": {
+                "dot-prop": "4.1.1",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.0.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.1.0",
+                "xdg-basedir": "3.0.0"
+              },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.1.1",
                   "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
@@ -5393,6 +8207,9 @@
                 "make-dir": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "pify": "2.3.0"
+                  },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
@@ -5403,6 +8220,9 @@
                 "unique-string": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
@@ -5423,18 +8243,43 @@
             "latest-version": {
               "version": "3.1.0",
               "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.1",
+                    "registry-url": "3.1.0",
+                    "semver": "5.3.0"
+                  },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
@@ -5477,6 +8322,9 @@
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
@@ -5489,10 +8337,20 @@
                     "registry-auth-token": {
                       "version": "3.3.1",
                       "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1",
+                        "safe-buffer": "5.1.1"
+                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -5513,10 +8371,19 @@
                     "registry-url": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1"
+                      },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
@@ -5540,7 +8407,10 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "requires": {
+                "semver": "5.3.0"
+              }
             },
             "xdg-basedir": {
               "version": "3.0.0",
@@ -5555,10 +8425,17 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          },
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
@@ -5575,6 +8452,9 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
@@ -5585,6 +8465,9 @@
         "which": {
           "version": "1.2.14",
           "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
@@ -5595,10 +8478,17 @@
         "worker-farm": {
           "version": "1.4.1",
           "bundled": true,
+          "requires": {
+            "errno": "0.1.4",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
               "bundled": true,
+              "requires": {
+                "prr": "0.0.0"
+              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
@@ -5618,7 +8508,12 @@
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         }
       }
     },
@@ -5626,19 +8521,37 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
     },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
     },
     "nugget": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "minimist": "1.2.0",
+        "pretty-bytes": "1.0.4",
+        "progress-stream": "1.2.0",
+        "request": "2.81.0",
+        "single-line-log": "1.1.2",
+        "throttleit": "0.0.2"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -5691,12 +8604,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -5709,6 +8629,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -5722,7 +8646,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -5732,7 +8664,10 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -5743,23 +8678,41 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY="
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parse5": {
       "version": "1.5.1",
@@ -5771,7 +8724,10 @@
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-extra": {
       "version": "3.0.0",
@@ -5798,7 +8754,12 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -5824,7 +8785,10 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -5837,12 +8801,21 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.1.9",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3"
+      },
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -5850,79 +8823,132 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqid": "4.1.1"
+      }
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      },
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "caniuse-db": "1.0.30000700",
+            "electron-to-chromium": "1.3.15"
+          }
         }
       }
     },
@@ -5936,79 +8962,141 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3"
+      }
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -6020,7 +9108,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6044,7 +9137,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "private": {
       "version": "0.1.7",
@@ -6066,18 +9163,28 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "speedometer": "0.1.4",
+        "through2": "0.2.3"
+      }
     },
     "progressbar.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/progressbar.js/-/progressbar.js-1.0.1.tgz",
-      "integrity": "sha1-9/v8GVJA/guzL2972y5/9ADqcfk="
+      "integrity": "sha1-9/v8GVJA/guzL2972y5/9ADqcfk=",
+      "requires": {
+        "shifty": "1.5.4"
+      }
     },
     "promise": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
       "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
       "dev": true,
+      "requires": {
+        "asap": "1.0.0"
+      },
       "dependencies": {
         "asap": {
           "version": "1.0.0",
@@ -6091,6 +9198,10 @@
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6100,12 +9211,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6141,18 +9264,32 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "randomatic": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "kind-of": "3.2.2"
+      }
     },
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -6165,6 +9302,11 @@
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
       "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6174,12 +9316,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6187,6 +9341,11 @@
       "version": "15.5.4",
       "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.5.4.tgz",
       "integrity": "sha1-BIrLLzMqP0UL6uC+ZoJO2R5m4SI=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6196,12 +9355,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6210,6 +9381,10 @@
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
       "integrity": "sha1-k7yqcY/K5zYNQuj7HAl1bMNjAqI=",
       "dev": true,
+      "requires": {
+        "fbjs": "0.8.12",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6221,13 +9396,25 @@
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
           "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6235,6 +9422,10 @@
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.5.2.tgz",
       "integrity": "sha1-2mmJ2c/+J9/6yu3IYgAP+wmuIgY=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6244,24 +9435,53 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
     "react-bootstrap": {
       "version": "0.30.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.10.tgz",
-      "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag="
+      "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "invariant": "2.2.2",
+        "keycode": "2.1.9",
+        "prop-types": "15.5.10",
+        "react-overlays": "0.6.12",
+        "react-prop-types": "0.4.0",
+        "uncontrollable": "4.1.0",
+        "warning": "3.0.0"
+      }
     },
     "react-dom": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
       "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6271,12 +9491,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6284,6 +9516,12 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
       "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "fbjs": "0.8.12",
+        "prop-types": "15.5.10",
+        "warning": "3.0.0"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6293,49 +9531,94 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
     "react-overlays": {
       "version": "0.6.12",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
-      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM="
+      "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=",
+      "requires": {
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "react-prop-types": "0.4.0",
+        "warning": "3.0.0"
+      }
     },
     "react-progressbar.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-progressbar.js/-/react-progressbar.js-0.2.0.tgz",
-      "integrity": "sha1-/5bw+r2PD31EEbNjCx0gFsON9iU="
+      "integrity": "sha1-/5bw+r2PD31EEbNjCx0gFsON9iU=",
+      "requires": {
+        "lodash.isequal": "4.5.0",
+        "progressbar.js": "1.0.1",
+        "react": "15.4.2",
+        "react-dom": "15.4.2"
+      }
     },
     "react-prop-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A="
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
+        "warning": "3.0.0"
+      }
     },
     "react-redux": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
+      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
+      "requires": {
+        "create-react-class": "15.5.3",
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10"
+      }
     },
     "react-remarkable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz",
-      "integrity": "sha1-N5CKyViUV20NORh70om8LLtaxt4="
+      "integrity": "sha1-N5CKyViUV20NORh70om8LLtaxt4=",
+      "requires": {
+        "remarkable": "1.7.1"
+      }
     },
     "react-spotlight-clickable": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-spotlight-clickable/-/react-spotlight-clickable-1.0.5.tgz",
-      "integrity": "sha1-4Z7LClQXJlZiLjszM9R9JSIUx5U="
+      "integrity": "sha1-4Z7LClQXJlZiLjszM9R9JSIUx5U=",
+      "requires": {
+        "prop-types": "15.5.10"
+      }
     },
     "react-tap-event-plugin": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz",
       "integrity": "sha1-MWvrO8ZVbinshppyk+icgmqQdNI=",
+      "requires": {
+        "fbjs": "0.8.12"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6345,12 +9628,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6362,23 +9657,44 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.3.8",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "optional": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.2.11",
+        "set-immediate-shim": "1.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6390,13 +9706,25 @@
           "version": "2.2.11",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
           "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.0.1",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         }
       }
     },
@@ -6404,12 +9732,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "recompose": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.23.5.tgz",
       "integrity": "sha1-cqyCYSRr7DeCNdGHRn0CpyHosd4=",
+      "requires": {
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.12",
+        "hoist-non-react-statics": "1.2.0",
+        "symbol-observable": "1.0.4"
+      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -6419,12 +9758,24 @@
         "fbjs": {
           "version": "0.8.12",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+          "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.5"
+          }
         }
       }
     },
@@ -6432,24 +9783,42 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      }
     },
     "reduce-function-call": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2"
+      }
     },
     "redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
-      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
+      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0=",
+      "requires": {
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
+      }
     },
     "redux-mock-store": {
       "version": "1.2.3",
@@ -6460,7 +9829,10 @@
     "redux-subscriptions": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/redux-subscriptions/-/redux-subscriptions-0.2.0.tgz",
-      "integrity": "sha1-GrATXK428nzpoQvG0cDZo9MQMyM="
+      "integrity": "sha1-GrATXK428nzpoQvG0cDZo9MQMyM=",
+      "requires": {
+        "object-difference": "0.1.0"
+      }
     },
     "redux-test-utils": {
       "version": "0.1.2",
@@ -6486,18 +9858,32 @@
     "regenerator-transform": {
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM="
+      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.24.1",
+        "private": "0.1.7"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -6508,6 +9894,9 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "0.5.0"
+      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -6519,7 +9908,11 @@
     "remarkable": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
-      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y="
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "requires": {
+        "argparse": "0.1.16",
+        "autolinker": "0.15.3"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -6540,12 +9933,39 @@
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.0.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.0.1"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -6561,19 +9981,29 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "requirefresh": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.1.0.tgz",
       "integrity": "sha1-dC3Mwg86lpGNZsbxWX3I/+vE9vU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -6585,24 +10015,37 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -6613,7 +10056,10 @@
     "rxjs": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
-      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc="
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -6624,13 +10070,23 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
       "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3",
+        "graceful-fs": "4.1.11"
+      }
     },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
       "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
       "dev": true,
+      "requires": {
+        "es6-promise": "3.3.1",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      },
       "dependencies": {
         "es6-promise": {
           "version": "3.3.1",
@@ -6645,12 +10101,19 @@
       "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-1.0.2.tgz",
       "integrity": "sha1-wVxPcmHcKtsRs9WRLe1rCKFLIcg=",
       "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "is-relative-path": "1.0.1"
+      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         }
       }
     },
@@ -6722,7 +10185,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -6738,13 +10204,22 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "sorcery": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
       "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
       "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "minimist": "1.2.0",
+        "sander": "0.5.1",
+        "sourcemap-codec": "1.3.1"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -6758,7 +10233,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -6768,23 +10246,37 @@
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "sourcemap-codec": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz",
       "integrity": "sha1-mtb5vb1pGTEBbjCTnbyGhnMyMUY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.2"
+      }
     },
     "spawn-rx": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.11.tgz",
-      "integrity": "sha1-ZUUa1lZigB2up1VJgyp4LeAEjb8="
+      "integrity": "sha1-ZUUa1lZigB2up1VJgyp4LeAEjb8=",
+      "requires": {
+        "debug": "2.6.8",
+        "lodash.assign": "4.2.0",
+        "rxjs": "5.4.2"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -6812,6 +10304,16 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -6834,7 +10336,12 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6844,18 +10351,27 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -6867,6 +10383,14 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
+      "requires": {
+        "css-parse": "1.7.0",
+        "debug": "2.6.8",
+        "glob": "7.0.6",
+        "mkdirp": "0.5.1",
+        "sax": "0.5.8",
+        "source-map": "0.1.43"
+      },
       "dependencies": {
         "css-parse": {
           "version": "1.7.0",
@@ -6878,7 +10402,15 @@
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "sax": {
           "version": "0.5.8",
@@ -6890,7 +10422,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -6899,18 +10434,29 @@
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-1.0.1.tgz",
       "integrity": "sha1-qMvC4NLYcVdMN/Dim0axjcmfHWk=",
       "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "debug": "2.2.0",
+        "is-relative-path": "1.0.1"
+      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -6929,7 +10475,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
       "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "es6-promise": "4.1.1"
+      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -6941,12 +10491,24 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
+      "requires": {
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
+      },
       "dependencies": {
         "argparse": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
         },
         "esprima": {
           "version": "2.7.3",
@@ -6958,7 +10520,11 @@
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
         }
       }
     },
@@ -6985,6 +10551,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -6996,20 +10570,39 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
     },
     "tar-pack": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
       "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
       "optional": true,
+      "requires": {
+        "debug": "2.6.8",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.1",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7021,7 +10614,16 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -7032,14 +10634,23 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
     "tar-stream": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
-      "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0="
+      "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0=",
+      "requires": {
+        "bl": "0.9.5",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.1"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -7064,12 +10675,19 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
       "dependencies": {
         "xtend": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-keys": "0.4.0"
+          }
         }
       }
     },
@@ -7081,13 +10699,20 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "toutsuite": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/toutsuite/-/toutsuite-0.6.0.tgz",
       "integrity": "sha1-+tK0RTcsy7gxYJ1OeAP885K+1M4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "synchronous-promise": "1.0.12"
+      }
     },
     "tr46": {
       "version": "0.0.3",
@@ -7101,6 +10726,11 @@
       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
       "integrity": "sha1-XSPLNVYd2F3Gf7hIIwm0fVPM6ac=",
       "dev": true,
+      "requires": {
+        "css": "1.0.8",
+        "promise": "2.0.0",
+        "uglify-js": "2.2.5"
+      },
       "dependencies": {
         "is-promise": {
           "version": "1.0.1",
@@ -7112,25 +10742,38 @@
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
         },
         "promise": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
           "integrity": "sha1-RmSKqdYFr10ucMMCS/WUNtoCuA4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-promise": "1.0.1"
+          }
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         },
         "uglify-js": {
           "version": "2.2.5",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
           "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "optimist": "0.3.7",
+            "source-map": "0.1.43"
+          }
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -7160,7 +10803,10 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -7172,7 +10818,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -7184,7 +10833,10 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.4.1.tgz",
       "integrity": "sha1-+XuV9RsDhBchLWd9RaNz7nvO1+Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "editions": "1.3.3"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -7208,6 +10860,11 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -7219,7 +10876,12 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
         },
         "window-size": {
           "version": "0.1.0",
@@ -7237,7 +10899,13 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -7257,7 +10925,10 @@
     "uncontrollable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak="
+      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
+      "requires": {
+        "invariant": "2.2.2"
+      }
     },
     "underscore.string": {
       "version": "2.4.0",
@@ -7274,7 +10945,10 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
     },
     "uniqs": {
       "version": "2.0.0",
@@ -7310,12 +10984,19 @@
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ="
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "vendors": {
       "version": "1.0.1",
@@ -7326,7 +11007,10 @@
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "vlq": {
       "version": "0.2.2",
@@ -7350,7 +11034,11 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.4.1.tgz",
       "integrity": "sha512-DE7D9qpgT8ExbWwnzDeakZjmi2tEP1auxq4sD1R2L10A6PFTvo+R0r3bpxPAReGJBqxS4qrjw3kGFzT6Jvb3YQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "de-indent": "1.0.2",
+        "he": "1.1.1"
+      }
     },
     "vue-template-es2015-compiler": {
       "version": "1.5.3",
@@ -7361,7 +11049,10 @@
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w="
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "webidl-conversions": {
       "version": "2.0.1",
@@ -7380,7 +11071,10 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tr46": "0.0.3"
+      }
     },
     "whet.extend": {
       "version": "0.9.9",
@@ -7392,7 +11086,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -7403,7 +11100,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "window-size": {
       "version": "0.2.0",
@@ -7415,6 +11115,10 @@
       "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
       "integrity": "sha1-7v0VTp550sjTQXtkeo8U2f7M4U4=",
       "dev": true,
+      "requires": {
+        "acorn": "1.2.2",
+        "acorn-globals": "1.0.9"
+      },
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
@@ -7433,7 +11137,11 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -7444,7 +11152,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xml-name-validator": {
       "version": "2.0.1",
@@ -7476,12 +11187,32 @@
     "yargs": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA="
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "requires": {
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "lodash.assign": "4.2.0",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "2.4.1"
+      }
     },
     "yargs-parser": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "requires": {
+        "camelcase": "3.0.0",
+        "lodash.assign": "4.2.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -7494,17 +11225,28 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
+      }
     },
     "zip-folder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/zip-folder/-/zip-folder-1.0.0.tgz",
-      "integrity": "sha1-cKd0T9F4mi/rQa00GbMun9h5V7I="
+      "integrity": "sha1-cKd0T9F4mi/rQa00GbMun9h5V7I=",
+      "requires": {
+        "archiver": "0.11.0"
+      }
     },
     "zip-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
       "integrity": "sha1-TqeVqM4Z6fq0mjHR0IdyFBWfA6M=",
+      "requires": {
+        "compress-commons": "0.1.6",
+        "lodash": "2.4.2",
+        "readable-stream": "1.0.34"
+      },
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
@@ -7514,7 +11256,13 @@
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10967,9 +10967,9 @@
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
     },
     "usfm-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-0.0.2.tgz",
-      "integrity": "sha512-J5RuzU7OQwPqZPGHBf1iU6Uj5MQPCT5KMuvRX4iS526Ds2YE0wCJRDFa9YTREIhEZZx3+UB+ea5ZMCbDD8ofcQ=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-0.0.5.tgz",
+      "integrity": "sha512-qXG68XEn2DImJ481RbbW52H/7vHdiwtwmJq9DJiqBFoOXCOArxMgHhA2IrJVJdsLEJzuOJCiKOVm+eRJgPzfeg=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rimraf": "^2.6.1",
     "simple-git": "1.43.0",
     "sudo-prompt": "^6.2.1",
-    "usfm-js": "0.0.2",
+    "usfm-js": "0.0.5",
     "xregexp": "^3.1.1",
     "zip-folder": "^1.0.0"
   },

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -136,5 +136,5 @@ export function getUSFMIdTag(projectPath, manifest, bookName) {
   let lastEdited = fs.statSync(Path.join(projectPath), bookName).atime;
   let bookNameUppercase = bookName.toUpperCase();
   /**Note the indication here of tc on the end of the id. This will act as a flag to ensure the correct parsing*/
-  return `${bookNameUppercase}, ${targetLanguageCode}, ${resourceName}, ${lastEdited}, tc`;
+  return `${bookNameUppercase} ${resourceName} ${targetLanguageCode} ${lastEdited} tc`;
 }

--- a/src/js/helpers/ProjectSelectionHelpers.js
+++ b/src/js/helpers/ProjectSelectionHelpers.js
@@ -65,9 +65,10 @@ export function setUpUSFMFolderPath(usfmFilePath) {
   const {id, bookName, bookAbbr} = LoadHelpers.getIDsFromUSFM(parsedUSFM);
   /**If there is no bookAbbr then ultimately the usfm import should fail */
   if (!bookAbbr) console.warn('No book abbreviation detected in USFM');
-  let fileNameIdMarker = id ? `${id}_` : '';
-  let bookAbbrMarker = `${bookAbbr}_`;
-  let newUSFMProjectFolder = Path.join(DEFAULT_SAVE, `${fileNameIdMarker}${bookAbbrMarker}usfm`);
+  let oldFileName = Path.parse(usfmFilePath).name.toLowerCase();
+  let folderNamePrefix = id ? `${id}_${bookAbbr}_` : `${oldFileName}_`;
+  let textType = oldFileName.includes('_usfm') ? '' : '_usfm';
+  let newUSFMProjectFolder = Path.join(DEFAULT_SAVE, `${folderNamePrefix}${textType}`);
   const newUSFMFilePath = Path.join(newUSFMProjectFolder, bookAbbr) + '.usfm';
   fs.outputFileSync(newUSFMFilePath, usfmData);
   return newUSFMProjectFolder;


### PR DESCRIPTION
#### This pull request addresses:
This PR fixes issues with USFM exporting outlined in #1690.
This includes:
1. Using spaces for book abbreviation delimiting
2. Making id tag before h tag
other miscellaneous fixes for usfm so that exports are aligned with usfm standard format now.
also updates usfm-js version number

#### How to test this pull request:
Try exporting and importing usfm projects of any kind

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2301)
<!-- Reviewable:end -->
