### PR TITLE
Prohibit Previously Imported USFM Projects

### DIFF
--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -39,7 +39,10 @@ export function selectLocalProjectToLoad() {
         dispatch(AlertModalActions.openAlertDialog(ALERT_MESSAGE));
       } else if (usfmFilePath) {
         newProjectPath = ProjectSelectionHelpers.setUpUSFMFolderPath(usfmFilePath);
-        dispatch(selectAndLoadProject(newProjectPath));
+        if(newProjectPath) dispatch(selectAndLoadProject(newProjectPath));
+        else {
+          dispatch(AlertModalActions.openAlertDialog('You cannot import a usfm project thats already been imported.'))
+        }
       }
       else if (path.extname(sourcePath) === '.tstudio') {
         // unzip project to ~./translationCore folder.

--- a/src/js/helpers/ProjectSelectionHelpers.js
+++ b/src/js/helpers/ProjectSelectionHelpers.js
@@ -70,6 +70,7 @@ export function setUpUSFMFolderPath(usfmFilePath) {
   let textType = oldFileName.includes('_usfm') ? '' : '_usfm';
   let newUSFMProjectFolder = Path.join(DEFAULT_SAVE, `${folderNamePrefix}${textType}`);
   const newUSFMFilePath = Path.join(newUSFMProjectFolder, bookAbbr) + '.usfm';
+  if (fs.existsSync(newUSFMProjectFolder)) return;
   fs.outputFileSync(newUSFMFilePath, usfmData);
   return newUSFMProjectFolder;
 }


### PR DESCRIPTION
#### This pull request addresses:
Previously imported USFM projects with the same language id and book name are stopped from being imported


#### How to test this pull request:
Try importing a usfm project and re-importing it to ensure the action is blocked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2384)
<!-- Reviewable:end -->
