### PR TITLE
contextId Validatation

### DIFF
--- a/src/js/helpers/contextIdHelpers.js
+++ b/src/js/helpers/contextIdHelpers.js
@@ -1,0 +1,21 @@
+// helpers
+import * as selectionHelpers from './selectionHelpers';
+
+/**
+ * @description this action validates if the contextId is valid by checking to see if the quote occurrence exists
+ * @param {object} state - current state to get the verse out of
+ * @param {object} contextId - the contextId object.
+ * @param {string} bibleId - the id/name of the bible to get the chapter/verse text to check for the string occurrences
+ * @return {object} New state for contextId reducer.
+ */
+export const validateContextIdQuote = (state, contextId, bibleId) => {
+  let valid = false
+  if (contextId && bibleId) {
+    const { chapter, verse } = contextId.reference;
+    const { quote, occurrence } = contextId;
+    const verseText = state.resourcesReducer.bibles[bibleId][chapter][verse];
+    const occurrences = selectionHelpers.occurrences(verseText, quote);
+    valid = occurrence <= occurrences;
+  }
+  return valid;
+}

--- a/src/js/helpers/contextIdHelpers.js
+++ b/src/js/helpers/contextIdHelpers.js
@@ -6,7 +6,7 @@ import * as selectionHelpers from './selectionHelpers';
  * @param {object} state - current state to get the verse out of
  * @param {object} contextId - the contextId object.
  * @param {string} bibleId - the id/name of the bible to get the chapter/verse text to check for the string occurrences
- * @return {object} New state for contextId reducer.
+ * @return {bool} returns if the contextId is valid.
  */
 export const validateContextIdQuote = (state, contextId, bibleId) => {
   let valid = false

--- a/src/js/helpers/selectionHelpers.js
+++ b/src/js/helpers/selectionHelpers.js
@@ -7,7 +7,7 @@
   * @see http://stackoverflow.com/questions/4009756/how-to-count-string-occurrence-in-string/7924240#7924240
   * modified to fit our use cases, return zero for '' substring, and no use case for overlapping.
   */
-const occurrences = (string, subString) => {
+export const occurrences = (string, subString) => {
   if (subString.length <= 0) return 0
   var n = 0, pos = 0, step = subString.length
   while (true) {


### PR DESCRIPTION
#### This pull request addresses:

Many times tW had quotes that did not exist in the text and was causing multiple issues in the app. Fixing one led to another and after a few times, decided to backup and detect invalid context and move to the next one if it was bad.

#### How to test this pull request:

- Open up an Eph project in any language.
- Open tW tool.
- Click on God in the menu.
- Click the first Eph 2:6 in the submenu.
  - Should render fine because it exists.
- Click the second Eph 2:6 in the submenu.
  - Should skip to the next because it isn't valid.
- Click previous and next around the second Eph 2:6 to make sure it doesn't crash the app like before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2385)
<!-- Reviewable:end -->
