### PR TITLE
fixed checks that don't load

### DIFF
--- a/src/js/helpers/contextIdHelpers.js
+++ b/src/js/helpers/contextIdHelpers.js
@@ -14,7 +14,7 @@ export const validateContextIdQuote = (state, contextId, bibleId) => {
     const { chapter, verse } = contextId.reference;
     const { quote, occurrence } = contextId;
     const verseText = state.resourcesReducer.bibles[bibleId][chapter][verse];
-    const occurrences = selectionHelpers.getQuoteOccurrencesInVerse(verseText, quote);
+    const occurrences = selectionHelpers.occurrences(verseText, quote);
     valid = occurrence <= occurrences;
   }
   return valid;


### PR DESCRIPTION
#### This pull request addresses:

Fixes Certain checks that would not load, tW Ephesians.
First of: `In Christ, In Jesus, In the Lord, in him`
- Ephesians 1:13
- Ephesians 2:21

#### How to test this pull request:

1. Load any Ephesians project, tW.
2. Click `In Christ, In Jesus, In the Lord, in him`
3. Click both checks for `Ephesians 1:13` and `Ephesians 2:21`
4. Click prev/next for those checks back and forth and ensure all checks render without skipping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2463)
<!-- Reviewable:end -->
