### PR TITLE
Prevent import and selection of non-titus books

### DIFF
--- a/src/js/actions/ProjectSelectionActions.js
+++ b/src/js/actions/ProjectSelectionActions.js
@@ -41,9 +41,16 @@ export function selectProject(projectPath, projectLink) {
       manifest = ProjectSelectionHelpers.getProjectManifest(projectPath, projectLink, username);
       if (!manifest) dispatch(AlertModalActions.openAlertDialog("No valid manifest found in project"));
     }
-    dispatch(clearLastProject());
-    dispatch(loadProjectDetails(projectPath, manifest));
-    dispatch(ProjectValidationActions.validateProject());
+    const { currentSettings } = getState().settingsReducer;
+    if (manifestHelpers.checkIfValidBetaProject(manifest) || currentSettings.developerMode) {
+      dispatch(clearLastProject());
+      dispatch(loadProjectDetails(projectPath, manifest));
+      dispatch(ProjectValidationActions.validateProject());
+    } else {
+      dispatch(AlertModalActions.openAlertDialog('You can only load Titus projects for now.'));
+      dispatch(RecentProjectsActions.getProjectsFromFolder());
+      dispatch(clearLastProject());
+    }
   })
 }
 


### PR DESCRIPTION
#### This pull request addresses:

Prevents import and selection of non-titus books when not in developer mode.


#### How to test this pull request:

- Turn off Dev mode. 
- Try to select a non-titus project. 
  - Ensure that you are immediately greeted with the alert.
- Try to import a non-titus project. 
  - Ensure that you are immediately greeted with the alert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2487)
<!-- Reviewable:end -->
