### PR TITLE
Stepper Steps Clickable / Remove Statusbar in Stepper

### DIFF
--- a/src/js/components/home/stepper/Stepper.js
+++ b/src/js/components/home/stepper/Stepper.js
@@ -28,23 +28,23 @@ class StepperComponent extends Component {
         <Card>
           <div style={{width: '100%', maxWidth: '100%', margin: 'auto'}}>
             <Stepper activeStep={stepIndex} style={{padding: '0 50px'}}>
-              <Step>
-                <StepLabel icon={homeIcon}>
+              <Step disabled={false} style={{cursor:'pointer'}}>
+                <StepLabel onClick={()=>this.props.actions.goToStep(0)} icon={homeIcon}>
                   <span style={{color: homeColor}}>{" Home "}</span>
                 </StepLabel>
               </Step>
-              <Step>
-                <StepLabel icon={userIcon}>
+              <Step disabled={false} style={{cursor:'pointer'}}>
+                <StepLabel onClick={()=>this.props.actions.goToStep(1)} icon={userIcon}>
                   <span style={{color: userColor}}>{" User "}</span>
                 </StepLabel>
               </Step>
-              <Step>
-                <StepLabel icon={projectIcon}>
+              <Step disabled={false} style={{cursor:'pointer'}}>
+                <StepLabel onClick={()=>this.props.actions.goToStep(2)} icon={projectIcon}>
                   <span style={{color: projectColor}}>{" Project "}</span>
                 </StepLabel>
               </Step>
-              <Step>
-                <StepLabel icon={toolIcon}>
+              <Step disabled={false} style={{cursor:'pointer'}}>
+                <StepLabel onClick={()=>this.props.actions.goToStep(3)} icon={toolIcon}>
                   <span style={{color: toolColor}}>{" Tool "}</span>
                 </StepLabel>
               </Step>

--- a/src/js/containers/StatusBarContainer.js
+++ b/src/js/containers/StatusBarContainer.js
@@ -16,6 +16,7 @@ class StatusBarContainer extends React.Component {
   }
 
   render() {
+    const { displayHomeView } = this.props.homeScreenReducer;
     let projectName = this.props.projectDetailsReducer.projectSaveLocation.split("/").pop();
     //Expecting a folder path as such: "~/project_name"
     let { currentToolTitle } = this.props.toolsReducer;
@@ -24,6 +25,7 @@ class StatusBarContainer extends React.Component {
 
     return (
       <div>
+      {displayHomeView ? null :
         <StatusBar
           {...this.props}
           toggleHomeScreen={this.props.actions.toggleHomeScreen}
@@ -35,6 +37,7 @@ class StatusBarContainer extends React.Component {
           currentUser={username}
           loggedInUser={loggedInUser}
         />
+      }
       </div>
     );
   }

--- a/src/js/containers/home/BodyContainer.js
+++ b/src/js/containers/home/BodyContainer.js
@@ -10,11 +10,11 @@ class BodyContainer extends Component {
   render() {
     let { displayHomeView } = this.props.reducers.homeScreenReducer;
     return (
-        <div style={{display: 'flex', height: 'calc(100vh - 30px)', width: '100%'}}>
+        <div style={{display: 'flex', height: '100vh', width: '100%'}}>
           {displayHomeView ? (
                 <HomeContainer />
             ) : (
-              <div style={{display: 'flex', flex: 'auto'}}>
+              <div style={{display: 'flex', flex: 'auto', height: 'calc(100vh - 30px)'}}>
                 <div style={{ flex: "0 0 250px" }}>
                   <GroupMenuContainer />
                 </div>

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -60,7 +60,7 @@ class HomeContainer extends Component {
           (
             <MuiThemeProvider style={{ fontSize: '1.1em' }}>
               <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%', background: 'var(--background-color-light)' }}>
-                <Stepper homeScreenReducer={this.props.reducers.homeScreenReducer} />
+                <Stepper {...this.props} homeScreenReducer={this.props.reducers.homeScreenReducer} />
                 <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', height: '70%' }}>
                   <div style={{ width: '400px', padding: '0 20px' }}>
                     <Instructions {...this.props} />


### PR DESCRIPTION
#### This pull request addresses:
This PR removes the status bar when on the home stepper and makes each step clickable, but only allows navigation when prerequisites are met.


#### How to test this pull request:
Open the home stepper and ensure the status bar is not showing. and try to click on different steps with different conditions. Ensure the status bar shows up after selecting a tool and checking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2501)
<!-- Reviewable:end -->
