### PR TITLE
updated strings in the door43 import modal and the Titus only alert dialog

### DIFF
--- a/src/js/actions/ProjectSelectionActions.js
+++ b/src/js/actions/ProjectSelectionActions.js
@@ -46,7 +46,7 @@ export function selectProject(projectPath, projectLink) {
       dispatch(loadProjectDetails(projectPath, manifest));
       dispatch(ProjectValidationActions.validateProject());
     } else {
-      dispatch(AlertModalActions.openAlertDialog('You can only load Titus projects for now.'));
+      dispatch(AlertModalActions.openAlertDialog('This version of translationCore only supports Titus projects.'));
       dispatch(RecentProjectsActions.getProjectsFromFolder());
       dispatch(clearLastProject());
     }

--- a/src/js/components/home/projectsManagement/onlineImport/OnlineImportModal.js
+++ b/src/js/components/home/projectsManagement/onlineImport/OnlineImportModal.js
@@ -53,7 +53,7 @@ export default class OnlineImportModal extends Component {
 
     const headerContent = (
       <div>
-        <span>{"Import From Door43"}</span>
+        <span>{"Import from Door43"}</span>
           <Glyphicon
             onClick={closeOnlineImportModal}
             glyph={"remove"}


### PR DESCRIPTION
#### This pull request addresses:
- Updated strings in the door43 import modal and the Titus only alert dialog
#2248 #2252

#### How to test this pull request:

- Open the door43 import modal and verify that the word "from" in the header isn't capitalized.
- Try to load a non-Titus project while in non-developer mode and the alert should say "This version of translationCore only supports Titus projects."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2540)
<!-- Reviewable:end -->
