### PR TITLE
Project information Check QA issues

### DIFF
--- a/src/js/actions/CopyrightCheckActions.js
+++ b/src/js/actions/CopyrightCheckActions.js
@@ -61,7 +61,7 @@ export function finalize() {
  * @param {String} selectedLicenseId 
  */
 export function selectProjectLicense(selectedLicenseId) {
-  return ((dispatch, getState) => {
+  return ((dispatch) => {
     dispatch({
       type: consts.SELECT_PROJECT_LICENSE_ID,
       selectedLicenseId

--- a/src/js/components/projectValidation/ProjectInformationCheck/BookDropdownMenu.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/BookDropdownMenu.js
@@ -13,7 +13,9 @@ const BookDropdownMenu = ({
     <div>
       <SelectField
         value={bookId}
-        style={{ width: '200px' }}
+        style={{ width: '200px', marginTop: bookId === "" ? '30px' : '' }}
+        errorText={bookId === "" ? "This field is required." : null}
+        errorStyle={{ color: '#cd0033' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
         floatingLabelFixed={true}
         floatingLabelStyle={{ color: '#000', fontSize: '22px', fontWeight: 'bold' }}
@@ -21,7 +23,7 @@ const BookDropdownMenu = ({
           <div>
             <Glyphicon glyph={"book"} style={{ color: "#000000", fontSize: '22px' }} />&nbsp;
             <span>Book</span>&nbsp;
-            <span style={{ color: '#800020'}}>*</span>
+            <span style={{ color: '#cd0033'}}>*</span>
           </div>
         }
         onChange={(event, index, value) => {

--- a/src/js/components/projectValidation/ProjectInformationCheck/BookDropdownMenu.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/BookDropdownMenu.js
@@ -13,12 +13,13 @@ const BookDropdownMenu = ({
     <div>
       <SelectField
         value={bookId}
-        style={{ width: '150px' }}
+        style={{ width: '200px' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
-        floatingLabelStyle={{ color: '#000' }}
+        floatingLabelFixed={true}
+        floatingLabelStyle={{ color: '#000', fontSize: '22px', fontWeight: 'bold' }}
         floatingLabelText={
           <div>
-            <Glyphicon glyph={"book"} style={{ color: "#000000" }} />&nbsp;
+            <Glyphicon glyph={"book"} style={{ color: "#000000", fontSize: '22px' }} />&nbsp;
             <span>Book</span>&nbsp;
             <span style={{ color: '#800020'}}>*</span>
           </div>
@@ -30,7 +31,7 @@ const BookDropdownMenu = ({
       <MenuItem value={""} primaryText={""} />
       {
         Object.keys(BooksOfTheBible.newTestament).map((key, index) => {
-          const BookName = BooksOfTheBible.newTestament[key];
+          const BookName = BooksOfTheBible.newTestament[key] + ` (${key})`;
           return (
             <MenuItem key={index} value={key} primaryText={BookName} />
           );

--- a/src/js/components/projectValidation/ProjectInformationCheck/CheckersArea.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/CheckersArea.js
@@ -16,7 +16,7 @@ const CheckersArea = ({
     <div style={{ display: 'flex', flex: '1', flexDirection: 'column', alignItems: 'center', overflowY: 'auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', margin: '10px'}}>
         <GroupAddIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
-        <span style={{ fontWeight: 'bold' }}>Checkers</span>&nbsp;
+        <span style={{ fontWeight: 'bold' }}>Checkers</span>
       </div>
       <div
         onClick={() => addChecker()}

--- a/src/js/components/projectValidation/ProjectInformationCheck/CheckersArea.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/CheckersArea.js
@@ -15,9 +15,8 @@ const CheckersArea = ({
   return (
     <div style={{ display: 'flex', flex: '1', flexDirection: 'column', alignItems: 'center', overflowY: 'auto' }}>
       <div style={{ display: 'flex', alignItems: 'center', margin: '10px'}}>
-        <GroupAddIcon style={{ height: "30px", width: "30px", color: "#000000" }} />&nbsp;
-        <span>Checkers</span>&nbsp;
-        <span style={{ color: '#800020'}}>*</span>
+        <GroupAddIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
+        <span style={{ fontWeight: 'bold' }}>Checkers</span>&nbsp;
       </div>
       <div
         onClick={() => addChecker()}

--- a/src/js/components/projectValidation/ProjectInformationCheck/ContributorsArea.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/ContributorsArea.js
@@ -15,8 +15,8 @@ const ContributorsArea = ({
   return (
     <div style={{ display: 'flex', flex: '1', flexDirection: 'column', alignItems: 'center' }}>
       <div style={{ display: 'flex', alignItems: 'center', margin: '10px'}}>
-        <GroupIcon style={{ height: "30px", width: "30px", color: "#000000" }} />&nbsp;
-      <span>Contributors</span>
+        <GroupIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
+        <span style={{ fontWeight: 'bold' }}>Contributors</span>
       </div>
       <div
         onClick={() => addContributor()}

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageDirectionDropdownMenu.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageDirectionDropdownMenu.js
@@ -12,7 +12,9 @@ const LanguageDirectionDropdownMenu = ({
     <div>
       <SelectField
         value={languageDirection}
-        style={{ width: '200px' }}
+        style={{ width: '200px', marginTop: languageDirection === "" ? '30px' : '' }}
+        errorText={languageDirection === "" ? "This field is required." : null}
+        errorStyle={{ color: '#cd0033' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
         floatingLabelFixed={true}
         floatingLabelStyle={{ color: 'var(--text-color-dark)', fontSize: '22px', fontWeight: 'bold', top: '32px' }}
@@ -20,7 +22,7 @@ const LanguageDirectionDropdownMenu = ({
           <div style={{ width: '270px' }}>
             <Glyphicon glyph={"eye-open"} style={{ color: "#000000", fontSize: '28px' }} />&nbsp;
             <span>Language Direction</span>&nbsp;
-            <span style={{ color: '#800020'}}>*</span>
+            <span style={{ color: '#cd0033'}}>*</span>
           </div>
         }
         onChange={(event, index, value) => {

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageDirectionDropdownMenu.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageDirectionDropdownMenu.js
@@ -8,26 +8,17 @@ const LanguageDirectionDropdownMenu = ({
   languageDirection,
   updateLanguageDirection
 }) => {
-  const ltrText = 'Left to Right';
-  const rtlText = 'Right to Left';
-  let textDirection;
-
-  if (languageDirection) {
-    textDirection = languageDirection === 'ltr' ? ltrText : rtlText;
-  } else {
-    textDirection = '';
-  }
-
   return (
     <div>
       <SelectField
         value={languageDirection}
-        style={{ width: '220px' }}
+        style={{ width: '200px' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
-        floatingLabelStyle={{ color: '#000' }}
+        floatingLabelFixed={true}
+        floatingLabelStyle={{ color: 'var(--text-color-dark)', fontSize: '22px', fontWeight: 'bold', top: '32px' }}
         floatingLabelText={
-          <div>
-            <Glyphicon glyph={"eye-open"} style={{ color: "#000000" }} />&nbsp;
+          <div style={{ width: '270px' }}>
+            <Glyphicon glyph={"eye-open"} style={{ color: "#000000", fontSize: '28px' }} />&nbsp;
             <span>Language Direction</span>&nbsp;
             <span style={{ color: '#800020'}}>*</span>
           </div>
@@ -36,9 +27,9 @@ const LanguageDirectionDropdownMenu = ({
           updateLanguageDirection(value);
         }}
       >
-        <MenuItem value={languageDirection} primaryText={textDirection} />
-        <MenuItem value={'ltr'} primaryText={ltrText} />
-        <MenuItem value={'rtl'} primaryText={rtlText} />
+        <MenuItem value={""} primaryText={""} />
+        <MenuItem value={'ltr'} primaryText={'Left to Right'} />
+        <MenuItem value={'rtl'} primaryText={'Right to Left'} />
       </SelectField>
     </div>
   );

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
@@ -13,13 +13,14 @@ const LanguageIdTextBox = ({
     <div>
       <TextField
         value={languageId}
-        style={{ width: '150px' }}
+        style={{ width: '200px', height: '80px' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
-        floatingLabelStyle={{ color: "var(--text-color-dark)", opacity: "1", fontWeight: "bold" }}
+        floatingLabelFixed={true}
+        floatingLabelStyle={{ color: "var(--text-color-dark)", fontSize: '22px', fontWeight: 'bold' }}
         floatingLabelText={
-          <div style={{ width: '150px' }}>
-            <TranslateIcon style={{ height: "20px", width: "20px", color: "#000000" }} />&nbsp;
-            <span>Language Id</span>&nbsp;
+          <div style={{ width: '260px' }}>
+            <TranslateIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
+            <span>Language Code</span>&nbsp;
             <span style={{ color: '#800020'}}>*</span>
           </div>
         }

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
@@ -13,7 +13,9 @@ const LanguageIdTextBox = ({
     <div>
       <TextField
         value={languageId}
-        style={{ width: '200px', height: '80px' }}
+        style={{ width: '200px', height: '80px', marginTop: languageId === "" ? '30px' : '' }}
+        errorText={languageId === "" ? "This field is required." : null}
+        errorStyle={{ color: '#cd0033' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
         floatingLabelFixed={true}
         floatingLabelStyle={{ color: "var(--text-color-dark)", fontSize: '22px', fontWeight: 'bold' }}
@@ -21,7 +23,7 @@ const LanguageIdTextBox = ({
           <div style={{ width: '260px' }}>
             <TranslateIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
             <span>Language Code</span>&nbsp;
-            <span style={{ color: '#800020'}}>*</span>
+            <span style={{ color: '#cd0033'}}>*</span>
           </div>
         }
         onChange={e => updateLanguageId(e.target.value)}

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
@@ -13,7 +13,9 @@ const LanguageNameTextBox = ({
     <div>
       <TextField
         value={languageName}
-        style={{ width: '200px', height: '80px' }}
+        style={{ width: '200px', height: '80px', marginTop: languageName === "" ? '30px' : '' }}
+        errorText={languageName === "" ? "This field is required." : null}
+        errorStyle={{ color: '#cd0033' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
         floatingLabelFixed={true}
         floatingLabelStyle={{ color: "var(--text-color-dark)", fontSize: '22px', fontWeight: 'bold' }}
@@ -21,7 +23,7 @@ const LanguageNameTextBox = ({
           <div style={{ width: '260px' }}>
             <TranslateIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
             <span>Language Name</span>&nbsp;
-            <span style={{ color: '#800020'}}>*</span>
+            <span style={{ color: '#cd0033'}}>*</span>
           </div>
         }
         onChange={e => updateLanguageName(e.target.value)}

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
@@ -13,12 +13,13 @@ const LanguageNameTextBox = ({
     <div>
       <TextField
         value={languageName}
-        style={{ width: '150px' }}
+        style={{ width: '200px', height: '80px' }}
         underlineFocusStyle={{ borderColor: "var(--accent-color-dark)" }}
-        floatingLabelStyle={{ color: "var(--text-color-dark)", opacity: "1", fontWeight: "bold" }}
+        floatingLabelFixed={true}
+        floatingLabelStyle={{ color: "var(--text-color-dark)", fontSize: '22px', fontWeight: 'bold' }}
         floatingLabelText={
-          <div style={{ width: '200px' }}>
-            <TranslateIcon style={{ height: "20px", width: "20px", color: "#000000" }} />&nbsp;
+          <div style={{ width: '260px' }}>
+            <TranslateIcon style={{ height: "28px", width: "28px", color: "#000000" }} />&nbsp;
             <span>Language Name</span>&nbsp;
             <span style={{ color: '#800020'}}>*</span>
           </div>

--- a/src/js/components/projectValidation/ProjectInformationCheck/index.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/index.js
@@ -88,21 +88,21 @@ class ProjectInformationCheck extends Component {
         Project Information
         <Card
           style={{ width: '100%', height: '100%' }}
-          containerStyle={{ overflowY: 'auto', overflowX: 'hidden', height: '100%', paddingRight: '40px' }}
+          containerStyle={{ overflowY: 'auto', overflowX: 'hidden', height: '100%' }}
         >
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
             <span style={{ color: '#800020', margin: '10px' }}>* Required</span><br />
           </div>
-          <table style={{ display: 'flex', justifyContent: 'center' }}>
+          <table style={{ display: 'flex', justifyContent: 'center', marginLeft: '-15px' }}>
             <tbody>
               <tr>
-                <td style={{ padding: '10px 80px' }}>
+                <td>
                   <BookDropdownMenu
                     bookId={bookId}
                     updateBookId={(bookId) => this.props.actions.setBookIDInProjectInformationReducer(bookId)}
                   />
                 </td>
-                <td style={{ padding: '10px 0px 0px 80px' }}>
+                <td style={{ padding: '0px 0px 0px 120px' }}>
                   <LanguageDirectionDropdownMenu
                     languageDirection={languageDirection}
                     updateLanguageDirection={(languageDirection) => this.props.actions.setLanguageDirectionInProjectInformationReducer(languageDirection)}
@@ -110,13 +110,13 @@ class ProjectInformationCheck extends Component {
                 </td>
               </tr>
               <tr>
-                <td style={{ padding: '10px 80px' }}>
+                <td>
                   <LanguageIdTextBox
                     languageId={languageId}
                     updateLanguageId={(languageId) => this.props.actions.setLanguageIdInProjectInformationReducer(languageId)}
                   />
                 </td>
-                <td style={{ padding: '10px 0px 0px 80px' }}>
+                <td style={{ padding: '0px 0px 0px 120px' }}>
                   <LanguageNameTextBox
                     languageName={languageName}
                     updateLanguageName={(languageName) => this.props.actions.setLanguageNameInProjectInformationReducer(languageName)}
@@ -125,7 +125,7 @@ class ProjectInformationCheck extends Component {
               </tr>
             </tbody>
           </table><br />
-          <div style={{ display: 'flex' }}>
+          <div style={{ display: 'flex', marginLeft: '-40px' }}>
             <ContributorsArea 
               contributors={contributors}
               addContributor={this.addContributor.bind(this)}

--- a/src/js/components/projectValidation/ProjectInformationCheck/index.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/index.js
@@ -91,7 +91,7 @@ class ProjectInformationCheck extends Component {
           containerStyle={{ overflowY: 'auto', overflowX: 'hidden', height: '100%' }}
         >
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <span style={{ color: '#800020', margin: '10px' }}>* Required</span><br />
+            <span style={{ color: '#cd0033', margin: '10px 10px 0px' }}>* Required</span>
           </div>
           <table style={{ display: 'flex', justifyContent: 'center', marginLeft: '-15px' }}>
             <tbody>
@@ -111,20 +111,20 @@ class ProjectInformationCheck extends Component {
               </tr>
               <tr>
                 <td>
-                  <LanguageIdTextBox
-                    languageId={languageId}
-                    updateLanguageId={(languageId) => this.props.actions.setLanguageIdInProjectInformationReducer(languageId)}
-                  />
-                </td>
-                <td style={{ padding: '0px 0px 0px 120px' }}>
                   <LanguageNameTextBox
                     languageName={languageName}
                     updateLanguageName={(languageName) => this.props.actions.setLanguageNameInProjectInformationReducer(languageName)}
                   />
                 </td>
+                <td style={{ padding: '0px 0px 0px 120px' }}>
+                  <LanguageIdTextBox
+                    languageId={languageId}
+                    updateLanguageId={(languageId) => this.props.actions.setLanguageIdInProjectInformationReducer(languageId)}
+                  />
+                </td>
               </tr>
             </tbody>
-          </table><br />
+          </table>
           <div style={{ display: 'flex', marginLeft: '-40px' }}>
             <ContributorsArea 
               contributors={contributors}

--- a/src/js/helpers/ProjectInformationCheckHelpers.js
+++ b/src/js/helpers/ProjectInformationCheckHelpers.js
@@ -60,7 +60,7 @@ export function verifyAllRequiredFieldsAreCompleted(state) {
     checkers
   } = state.projectInformationCheckReducer;
 
-  if (bookId && languageId && languageName && languageDirection && checkers.length > 0 && !contributors.includes("") && !checkers.includes("")) {
+  if (bookId && languageId && languageName && languageDirection && !contributors.includes("") && !checkers.includes("")) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
# This pull request addresses:
- Project information Check QA issues

# How to test this pull request:
 - Open a project that fails the project information check. (e.g. Project with a manifest.json that is missing the `target_language: { direction:  "" }` field)

### Verify the following: 
1. All text should be the same font and size as the current word “Contributors”
2. The labels should be bolded and in a fixed size and position above the entry field
3. Change the text from “Language ID” to “Language Code”
4. The focus should be set to the first empty field if there is one. 
5. Checkers should not be a required field
6. Left to right should not be in the language direction list twice
![image](https://user-images.githubusercontent.com/8171759/29584334-038370d6-8749-11e7-9bc7-8cbceca86428.png)
7. The list of books is to contain both the book name and book abbreviation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2547)
<!-- Reviewable:end -->
