### PR TITLE
Truncate Stepper Labels

### DIFF
--- a/src/js/actions/ProjectValidationActions.js
+++ b/src/js/actions/ProjectValidationActions.js
@@ -7,6 +7,7 @@ import * as ProjectInformationCheckActions from './ProjectInformationCheckAction
 import * as MergeConflictActions from './MergeConflictActions';
 import * as MissingVersesActions from './MissingVersesActions';
 import * as MyProjectsActions from './MyProjectsActions';
+import * as BodyUIActions from './BodyUIActions';
 //Namespaces for each step to be referenced by
 const MERGE_CONFLICT_NAMESPACE = 'mergeConflictCheck';
 const COPYRIGHT_NAMESPACE = 'copyrightCheck';
@@ -155,6 +156,7 @@ export function cancelProjectValidationStepper() {
   return ((dispatch) => {
     dispatch(toggleProjectValidationStepper(false));
     dispatch(ProjectSelectionActions.clearLastProject());
+    dispatch(BodyUIActions.resetStepLabels(1));
     dispatch({ type: consts.CLEAR_COPYRIGHT_CHECK_REDUCER });
     dispatch({ type: consts.CLEAR_PROJECT_INFORMATION_REDUCER });
     // updating project list

--- a/src/js/components/home/stepper/Stepper.js
+++ b/src/js/components/home/stepper/Stepper.js
@@ -29,22 +29,22 @@ class StepperComponent extends Component {
             <Stepper activeStep={stepIndex} style={{padding: '0 50px'}}>
               <Step disabled={!stepIndexAvailable[0]} style={{cursor:'pointer'}}>
                 <StepLabel onClick={()=>this.props.actions.goToStep(0)} icon={homeIcon}>
-                  <span style={{color: homeColor}}>{` ${stepperLabels[0]} `}</span>
+                  <span style={{color: homeColor, maxWidth:150, whiteSpace:'nowrap', textOverflow:'ellipsis', overflow:'hidden'}}>{` ${stepperLabels[0]} `}</span>
                 </StepLabel>
               </Step>
               <Step disabled={!stepIndexAvailable[1]} style={{cursor:'pointer'}}>
                 <StepLabel onClick={()=>this.props.actions.goToStep(1)} icon={userIcon}>
-                  <span style={{color: userColor}}>{` ${stepperLabels[1]} `}</span>
+                  <span style={{color: userColor, maxWidth:150, whiteSpace:'nowrap', textOverflow:'ellipsis', overflow:'hidden'}}>{` ${stepperLabels[1]} `}</span>
                 </StepLabel>
               </Step>
               <Step disabled={!stepIndexAvailable[2]} style={{cursor:'pointer'}}>
                 <StepLabel onClick={()=>this.props.actions.goToStep(2)} icon={projectIcon}>
-                  <span style={{color: projectColor}}>{` ${stepperLabels[2]} `}</span>
+                  <span style={{color: projectColor, maxWidth:150, whiteSpace:'nowrap', textOverflow:'ellipsis', overflow:'hidden'}}>{` ${stepperLabels[2]} `}</span>
                 </StepLabel>
               </Step>
               <Step disabled={!stepIndexAvailable[3]} style={{cursor:'pointer'}}>
                 <StepLabel onClick={()=>this.props.actions.goToStep(3)} icon={toolIcon}>
-                  <span style={{color: toolColor}}>{` ${stepperLabels[3]} `}</span>
+                  <span style={{color: toolColor, maxWidth:150, whiteSpace:'nowrap', textOverflow:'ellipsis', overflow:'hidden'}}>{` ${stepperLabels[3]} `}</span>
                 </StepLabel>
               </Step>
             </Stepper>


### PR DESCRIPTION
#### This pull request addresses:
This PR simply truncates the stepper labels if they are too long as described in #2309


#### How to test this pull request:
Try using a very long user name, and project path and ensure the text does not overflow the allowed width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2616)
<!-- Reviewable:end -->
