### PR TITLE
Tools Management Container Header Rename

### DIFF
--- a/src/js/containers/home/ToolsManagementContainer.js
+++ b/src/js/containers/home/ToolsManagementContainer.js
@@ -41,7 +41,7 @@ class ToolsManagementContainer extends Component {
 
     return (
       <div style={{ height: '100%' }}>
-        ToolsManagementContainer
+        Tools
         <ToolsCards
           bookName={name}
           loggedInUser={loggedInUser}


### PR DESCRIPTION
#### This pull request addresses:
Simply renames "ToolsManagementContainer" to "Tools" on the Tools page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2632)
<!-- Reviewable:end -->
