### PR TITLE
CSV: create empty files for checkdata

### DIFF
--- a/src/js/utils/csvMethods.js
+++ b/src/js/utils/csvMethods.js
@@ -24,8 +24,9 @@ export const generateCSVString = (objectArray, callback) => {
     csv.stringify(data, function(err, data){
       callback(err, data);
     });
-  } else {
-    callback(null, undefined);
+  } else { // there is no data, give back enough data to create an empty file.
+    const data = [['No data']];
+    callback(null, data);
   }
 }
 /**


### PR DESCRIPTION
#### This pull request addresses:

Exporting a project to CSV with only opening a single tool and not performing checks caused the resulting zip file not to open with a subfolder and put a single file in the target directory.

Creating empty data csv files for the checkData kept consistency.


#### How to test this pull request:

Import a new project that no checks have been performed or tools opened before.
Open a single tool but do not perform a check.
Export CSV for that project.
Open the zip file and ensure that empty csv files were created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2705)
<!-- Reviewable:end -->
