### PR TITLE
Don't skip invalid checks

### DIFF
--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -33,12 +33,7 @@ export const changeCurrentContextId = contextId => {
       loadCheckData(dispatch);
       dispatch(ResourcesActions.loadBiblesChapter(contextId));
       let state = getState();
-      const isValidContextId = contextIdHelpers.validateContextIdQuote(state, contextId, 'ulb');
-      if (isValidContextId) {
-        saveContextId(state, contextId);
-      } else {
-        dispatch(changeToNextContextId());
-      }
+      saveContextId(state, contextId);
     }
   });
 }


### PR DESCRIPTION
#### This pull request addresses:

This PR no longer skips invalid check items in the menu.
This will cause some checks to break in the Scripture Pane so that the scripture pane can be fixed.

The Scripture Pane errors will be fixed in another PR in that repo.

#### How to test this pull request:

Open a tW tool on any project.
Click around on the menu opening checks that have multiple words and it will no longer skip and cause errors in the Scripture Pane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2706)
<!-- Reviewable:end -->
