### PR TITLE
Closing Tab When Import Local Finder Shows

### DIFF
--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -30,7 +30,7 @@ export function selectLocalProjectToLoad() {
     dialog.showOpenDialog({ properties: ['openFile', 'openDirectory'] }, (filePaths) => {
       dispatch(AlertModalActions.openAlertDialog(`Importing local project`, true));
       //no file path given
-      if (!filePaths) dispatch(AlertModalActions.openAlertDialog('Project import cancelled', false));
+      if (!filePaths) return dispatch(AlertModalActions.openAlertDialog('Project import cancelled', false));
       const sourcePath = filePaths[0];
       const fileName = path.parse(sourcePath).base.split('.')[0];
       // project path in ~./translationCore.

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -5,7 +5,6 @@ import AdmZip from 'adm-zip';
 import { remote } from 'electron';
 // actions
 import * as AlertModalActions from './AlertModalActions';
-import * as BodyUIActions from './BodyUIActions';
 import * as ProjectSelectionActions from './ProjectSelectionActions';
 import * as ProjectDetailsActions from './projectDetailsActions';
 //helpers
@@ -37,7 +36,6 @@ export function selectLocalProjectToLoad() {
       // project path in ~./translationCore.
       let newProjectPath = path.join(DEFAULT_SAVE, fileName);
       let usfmFilePath = usfmHelpers.isUSFMProject(sourcePath)
-      dispatch(BodyUIActions.toggleProjectsFAB());
       if (filePaths === undefined) {
         //need to break out of function here so that successfull import
         //dialog does not dispatch

--- a/src/js/containers/home/ProjectsManagementContainer.js
+++ b/src/js/containers/home/ProjectsManagementContainer.js
@@ -86,6 +86,7 @@ const mapDispatchToProps = (dispatch) => {
         dispatch(ProjectSelectionActions.selectProject(projectPath));
       },
       selectLocalProjectToLoad: () => {
+        dispatch(BodyUIActions.toggleProjectsFAB());
         dispatch(ImportLocalActions.selectLocalProjectToLoad());
       },
       exportToCSV: (projectPath) => {


### PR DESCRIPTION
#### This pull request addresses:
This PR addresses the issue where the FAB still shows in the local import options after the finder opens


#### How to test this pull request:
Try and use the FAB local import option and ensure that the FAB disappears upon clicking the options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2710)
<!-- Reviewable:end -->
