### PR TITLE
Changed project details edit mode verbiage per QA request

### DIFF
--- a/src/js/components/projectValidation/ProjectValidationNavigation.js
+++ b/src/js/components/projectValidation/ProjectValidationNavigation.js
@@ -36,12 +36,18 @@ const ProjectValidationNavigation = (props) => {
         {previousStepName}
       </button>
       <button className='btn-prime' onClick={finalize} disabled={nextDisabled}>
-        Continue
-        <Glyphicon glyph='share-alt' style={{ marginLeft: '10px' }} />
+        {
+          onlyShowProjectInformationScreen ? 'Save Changes'
+          :
+          <div>
+            <span>Continue</span>
+            <Glyphicon glyph='share-alt' style={{ marginLeft: '10px' }} />
+          </div>
+        }
       </button>
     </div>
-  )
-}
+  );
+};
 
 
 ProjectValidationNavigation.propTypes = {
@@ -56,6 +62,6 @@ ProjectValidationNavigation.propTypes = {
     })
   }),
   actions: PropTypes.object.isRequired
-}
+};
 
 export default ProjectValidationNavigation;


### PR DESCRIPTION
#### This pull request addresses:

Change the verbiage on the button from "Continue" to "Save Changes" as defined in the requirement.


#### How to test this pull request:

- In the project card 3 dot menu select `Edit project details` and verify that the bottom right button text says "Save Changes" instead of "continue"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2739)
<!-- Reviewable:end -->
