### PR TITLE
Added Use Case For Dealing With Non-Books Of Bible Projects

### DIFF
--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -138,7 +138,7 @@ function detectInvalidProjectStructure(sourcePath) {
       if (validManifestPath) {
         const projectManifest = fs.readJsonSync(validManifestPath);
         if (projectManifest.project) {
-          //Project manifest is valid
+          //Project manifest is valid, not checking for book id because it can be fixed later
           return resolve();
         } else {
           return reject('Project manifest invalid.')

--- a/src/js/actions/ImportOnlineActions.js
+++ b/src/js/actions/ImportOnlineActions.js
@@ -11,7 +11,6 @@ import * as MyProjectsActions from './MyProjectsActions';
 import * as ImportLocalActions from './ImportLocalActions'
 // helpers
 import * as loadOnline from '../helpers/LoadOnlineHelpers';
-import * as ProjectSelectionHelpers from '../helpers/ProjectSelectionHelpers';
 
 export function updateRepos() {
     return ((dispatch, getState) => {
@@ -74,18 +73,6 @@ export function importOnlineProject() {
           dispatch({ type: consts.RESET_IMPORT_ONLINE_REDUCER })
           dispatch(clearLink());
           dispatch(AlertModalActions.closeAlertDialog());
-          let invalidProjectTypeError = ProjectSelectionHelpers.verifyProjectType(savePath);
-          if (invalidProjectTypeError) {
-            dispatch(AlertModalActions.openAlertDialog(
-              <div>
-                Project selection failed<br />
-                {invalidProjectTypeError}<br />
-              </div>
-            ));
-            dispatch(ProjectSelectionActions.clearLastProject());
-            /** Need to re-run projects retreival because a project may have been deleted */
-            return dispatch(MyProjectsActions.getMyProjects());
-          }
           dispatch(ImportLocalActions.verifyAndSelectProject(savePath, url));
         }
       });

--- a/src/js/helpers/ProjectSelectionHelpers.js
+++ b/src/js/helpers/ProjectSelectionHelpers.js
@@ -92,7 +92,7 @@ export function testResourceByType(projectPath, type) {
   try {
     let projectManifest = fs.readJSONSync(path.join(projectPath, 'manifest.json'));
     if (projectManifest) {
-      if (projectManifest.project && projectManifest.project.id === `${type}`)
+      if (projectManifest.project && projectManifest.project.id === `${type}` || projectManifest.type.id === `${type}`)
         return true;
     }
   } catch (e) { }


### PR DESCRIPTION
#### This pull request addresses:
This PR address a use case where the manifest is expected in a different format than being checked for.


#### How to test this pull request:
According to the story try importing 
https://git.door43.org/danieldane003/ceb_2sa_tq_L3
https://git.door43.org/danieldane003/ceb_2sa_tn_L3
And ensuring the  projects do not load
Try importing other non-standard books of bible you can find on door 43. Should handle most use cases without breaking

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2749)
<!-- Reviewable:end -->
