### PR TITLE
Feature/klappy/default index/2760

### DIFF
--- a/__tests__/ResourcesHelpers.test.js
+++ b/__tests__/ResourcesHelpers.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+//helpers
+import * as ResourcesHelpers from '../src/js/helpers/ResourcesHelpers';
+
+describe('ResourcesHelpers.chapterGroupsIndex', () => {
+  it('should return groupsIndex array for chapters 1-150', function () {
+    const output = ResourcesHelpers.chapterGroupsIndex();
+    expect(output.constructor).toBe(Array);
+    expect(output.length).toEqual(150);
+    expect(output[0].id).toBe('chapter_1');
+    expect(output[0].name).toBe('Chapter 1');
+    expect(output[149].id).toBe('chapter_150');
+    expect(output[149].name).toBe('Chapter 150');
+  });
+});
+
+describe('ResourcesHelpers.chapterGroupsData', () => {
+  it('should return groupsData array for Titus', function () {
+    const output = ResourcesHelpers.chapterGroupsData('tit', 'toolTemplate');
+    expect(output.constructor).toBe(Array);
+    expect(output.length).toEqual(3);
+    expect(output[0].constructor).toBe(Array);
+    expect(output[0].length).toEqual(16);
+    expect(output[0][0].contextId.reference.bookId).toBe('tit');
+    expect(output[0][0].contextId.reference.chapter).toBe(1);
+    expect(output[0][0].contextId.reference.verse).toBe(1);
+    expect(output[0][0].contextId.tool).toBe('toolTemplate');
+    expect(output[0][0].contextId.groupId).toBe('chapter_1');
+    expect(output[2].constructor).toBe(Array);
+    expect(output[2].length).toEqual(15);
+    expect(output[2][14].contextId.reference.bookId).toBe('tit');
+    expect(output[2][14].contextId.reference.chapter).toBe(3);
+    expect(output[2][14].contextId.reference.verse).toBe(15);
+    expect(output[2][14].contextId.tool).toBe('toolTemplate');
+    expect(output[2][14].contextId.groupId).toBe('chapter_3');
+  });
+});

--- a/__tests__/groupsIndexHelper.test.js
+++ b/__tests__/groupsIndexHelper.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import isEqual from 'lodash/isEqual';
+//helpers
+import * as groupsIndexHelpers from '../src/js/helpers/groupsIndexHelpers';
+
+describe('groupsIndexHelpers.sortWordObjectsByString', () => {
+  it('should return groupsIndex sorted and in order', function () {
+    const groupsIndex = [
+      {"id":"chapter_1","name":"Chapter 1"},
+      {"id":"chapter_10","name":"Chapter 10"},
+      {"id":"chapter_100","name":"Chapter 100"},
+      {"id":"chapter_11","name":"Chapter 11"},
+      {"id":"chapter_19","name":"Chapter 19"},
+      {"id":"chapter_2","name":"Chapter 2"},
+      {"id":"chapter_20","name":"Chapter 20"},
+      {"id":"chapter_3","name":"Chapter 3"}
+    ];
+    const output = groupsIndexHelpers.sortGroupsIndex(groupsIndex);
+    const expected = [
+      {"id":"chapter_1","name":"Chapter 1"},
+      {"id":"chapter_2","name":"Chapter 2"},
+      {"id":"chapter_3","name":"Chapter 3"},
+      {"id":"chapter_10","name":"Chapter 10"},
+      {"id":"chapter_11","name":"Chapter 11"},
+      {"id":"chapter_19","name":"Chapter 19"},
+      {"id":"chapter_20","name":"Chapter 20"},
+      {"id":"chapter_100","name":"Chapter 100"}
+    ];
+    expect(isEqual(expected, output)).toBeTruthy;
+  });
+  it('should return groupsIndex sorted and in order', function () {
+    const groupsIndex = [
+      {"id":"s","name":"S"},
+      {"id":"g","name":"G"},
+      {"id":"a","name":"A"},
+      {"id":"f","name":"F"},
+      {"id":"k","name":"K"},
+      {"id":"h","name":"H"},
+      {"id":"d","name":"D"},
+      {"id":"j","name":"J"}
+    ];
+    const output = groupsIndexHelpers.sortGroupsIndex(groupsIndex);
+    const expected = [
+      {"id":"a","name":"A"},
+      {"id":"d","name":"D"},
+      {"id":"f","name":"F"},
+      {"id":"g","name":"G"},
+      {"id":"h","name":"H"},
+      {"id":"j","name":"J"},
+      {"id":"k","name":"K"},
+      {"id":"s","name":"S"}
+    ];
+    expect(isEqual(expected, output)).toBeTruthy;
+  });
+});

--- a/__tests__/wordAlignmentHelpers.test.js
+++ b/__tests__/wordAlignmentHelpers.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-env jest */
 import isEqual from 'lodash/isEqual';
 //helpers
 import * as wordAlignmentHelpers from '../src/js/helpers/wordAlignmentHelpers';

--- a/src/js/actions/GroupsIndexActions.js
+++ b/src/js/actions/GroupsIndexActions.js
@@ -1,30 +1,15 @@
 import consts from './ActionTypes';
-
+// helpers
+import * as groupsIndexHelpers from '../helpers/groupsIndexHelpers';
 /**
  * @description This action sends all of the group Ids and
  * group names to the groupsIndexReducer
  * @param {string} groupIndex - The object of group indecies
  * @return {object} action object.
  */
-export const loadGroupsIndex = (groupsIndex) => {
+export const loadGroupsIndex = (_groupsIndex) => {
   return ((dispatch) => {
-    // Alphabetize the groups order
-    groupsIndex = groupsIndex.sort((a, b) => {
-      // try to sort on the number
-      if (a.id.match(/\d+/) && b.id.match(/\d+/)) { // if both contain digits
-        if (a.id.replace(/\d+/,'') === b.id.replace(/\d+/,'')) { // if string is the same other than digits
-          return parseInt(a.id.replace(/[^\d]+/,'')) - parseInt(b.id.replace(/[^\d]+/,'')); // sort on the number
-        }
-      }
-      if (a.id.toUpperCase() < b.id.toUpperCase()) {
-        return -1;
-      }
-      if (a.id.toUpperCase() > b.id.toUpperCase()) {
-        return 1;
-      }
-      return 0;
-    });
-
+    const groupsIndex = groupsIndexHelpers.sortGroupsIndex(_groupsIndex);
     dispatch({
       type: consts.LOAD_GROUPS_INDEX,
       groupsIndex

--- a/src/js/actions/GroupsIndexActions.js
+++ b/src/js/actions/GroupsIndexActions.js
@@ -10,6 +10,12 @@ export const loadGroupsIndex = (groupsIndex) => {
   return ((dispatch) => {
     // Alphabetize the groups order
     groupsIndex = groupsIndex.sort((a, b) => {
+      // try to sort on the number
+      if (a.id.match(/\d+/) && b.id.match(/\d+/)) { // if both contain digits
+        if (a.id.replace(/\d+/,'') === b.id.replace(/\d+/,'')) { // if string is the same other than digits
+          return parseInt(a.id.replace(/[^\d]+/,'')) - parseInt(b.id.replace(/[^\d]+/,'')); // sort on the number
+        }
+      }
       if (a.id.toUpperCase() < b.id.toUpperCase()) {
         return -1;
       }

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -11,8 +11,8 @@ const STATIC_RESOURCES_PATH = path.join(__dirname, '../../../tC_resources/resour
 export function getBibleFromStaticPackage(force = false) {
   let languagesIds = ['en', 'grc', 'he']; // english, greek, hebrew.
   languagesIds.forEach((languagesId) => {
-    const STATIC_RESOURCES_BIBLES_PATH = path.join(__dirname, '../../../tC_resources/resources', languagesId, 'bibles');
-    const BIBLE_RESOURCES_PATH = path.join(path.homedir(), 'translationCore/resources', languagesId, 'bibles');
+    const STATIC_RESOURCES_BIBLES_PATH = path.join(STATIC_RESOURCES_PATH, languagesId, 'bibles');
+    const BIBLE_RESOURCES_PATH = path.join(USER_RESOURCES_PATH, languagesId, 'bibles');
     let bibleNames = fs.readdirSync(STATIC_RESOURCES_BIBLES_PATH);
     bibleNames.forEach((bibleName) => {
       let bibleSourcePath = path.join(STATIC_RESOURCES_BIBLES_PATH, bibleName);
@@ -60,7 +60,7 @@ export function getLexiconsFromStaticPackage(force = false) {
 
 export function copyGroupsIndexToProjectResources(currentToolName, projectGroupsIndexPath) {
   const languageId = 'en';
-  const version = currentToolName === 'translationWords' ? 'v6' : 'V0';
+  const version = currentToolName === 'translationWords' ? 'v6' : 'v0';
   const groupsIndexPath = currentToolName === 'translationWords' ? path.join('kt', 'index.json') : 'index.json';
   const groupsIndexSourcePath = path.join(USER_RESOURCES_PATH, languageId, 'translationHelps', currentToolName, version, groupsIndexPath);
   const groupsIndexDestinationPath = path.join(projectGroupsIndexPath,'index.json');
@@ -68,9 +68,24 @@ export function copyGroupsIndexToProjectResources(currentToolName, projectGroups
   if(fs.existsSync(groupsIndexSourcePath)) {
     fs.copySync(groupsIndexSourcePath, groupsIndexDestinationPath);
   } else {
-    console.log("translationHelps resources path was not found, " + groupsIndexSourcePath);
+    copyChapterGroupsIndexToProjectResources(groupsIndexDestinationPath);
+    console.log("Chapter Groups Index generated. translationHelps resources path was not found, " + groupsIndexSourcePath);
   }
 }
+/**
+ * @description - Auto generate the chapter index since more projects will use it
+ * @param {String} groupsIndexDestinationPath - path to store the index
+ */
+export const copyChapterGroupsIndexToProjectResources = (groupsIndexDestinationPath) => {
+  const groupsIndex = Array(150).fill().map((_, i) => {
+    let chapter = i + 1;
+    return {
+      id: 'chapter_' + chapter,
+      name: 'Chapter ' + chapter
+    };
+  });
+  fs.outputJsonSync(groupsIndexDestinationPath, groupsIndex);
+};
 
 export function copyGroupsDataToProjectResources(currentToolName, groupsDataDirectory, bookAbbreviation) {
   const languageId = 'en';
@@ -81,9 +96,43 @@ export function copyGroupsDataToProjectResources(currentToolName, groupsDataDire
   if(fs.existsSync(groupsDataSourcePath)) {
     fs.copySync(groupsDataSourcePath, groupsDataDirectory);
   } else {
-    console.log("translationHelps resources path was not found, " + groupsDataSourcePath);
+    copyChapterGroupsDataToProjectResources(bookAbbreviation, currentToolName, groupsDataDirectory);
+    console.log("Chapter Groups Data generated. translationHelps resources path was not found, " + groupsDataSourcePath);
   }
 }
+/**
+ * @description - Auto generate the chapter index since more projects will use it
+ * @param {String} bookId - id of the current book
+ * @param {String} toolId - id of the current tool
+ * @param {String} groupsDataDirectory - path to store the index
+ */
+export const copyChapterGroupsDataToProjectResources = (bookId, currentToolName, groupsDataDirectory) => {
+  const ulbIndexPath = path.join(STATIC_RESOURCES_PATH, 'en', 'bibles', 'ulb', 'v10', 'index.json');
+  if (fs.existsSync(ulbIndexPath)) { // make sure it doens't crash if the path doesn't exist
+    const ulbIndex = fs.readJsonSync(ulbIndexPath); // the index of book/chapter/verses
+    const bookData = ulbIndex[bookId]; // get the data in the index for the current book
+    Array(bookData.chapters).fill().map((_, i) => { // create array from number of chapters
+      const chapter = i + 1; // index is 0 based, so add one for chapter number
+      const verses = bookData[chapter]; // get the number of verses in the chapter
+      const groupData = Array(verses).fill().map((_, i) => { // turn number of verses into array
+        const verse = i + 1; // index is 0 based, so add one for verse number
+        return {
+          "contextId": {
+            "reference": {
+              "bookId": bookId,
+              "chapter": chapter,
+              "verse": verse
+            },
+            "tool": currentToolName,
+            "groupId": "chapter_" + chapter
+          }
+        };
+      });
+      const chapterIndexPath = path.join(groupsDataDirectory, 'chapter_' + chapter + '.json');
+      fs.outputFileSync(chapterIndexPath, JSON.stringify(groupData, null, 2));
+    });
+  }
+};
 
 /**
  * @description Helper function to get a bibles manifest file from the bible resources folder.

--- a/src/js/helpers/groupsIndexHelpers.js
+++ b/src/js/helpers/groupsIndexHelpers.js
@@ -1,0 +1,24 @@
+/**
+ * @description This action sorts groupsIndex
+ * @param {string} groupsIndex - The object of group indecies
+ * @return {array} - groupsIndex
+ */
+export const sortGroupsIndex = (groupsIndex) => {
+  // Alphabetize the groups order
+  const _groupsIndex = groupsIndex.sort((a, b) => {
+    // try to sort on the number
+    if (a.id.match(/\d+/) && b.id.match(/\d+/)) { // if both contain digits
+      if (a.id.replace(/\d+/,'') === b.id.replace(/\d+/,'')) { // if string is the same other than digits
+        return parseInt(a.id.replace(/[^\d]+/,'')) - parseInt(b.id.replace(/[^\d]+/,'')); // sort on the number
+      }
+    }
+    if (a.id.toUpperCase() < b.id.toUpperCase()) {
+      return -1;
+    }
+    if (a.id.toUpperCase() > b.id.toUpperCase()) {
+      return 1;
+    }
+    return 0;
+  });
+  return _groupsIndex;
+};


### PR DESCRIPTION
#### This pull request addresses:

Dynamically generates a book chapter verse index for tools that don't have a prebuilt index.


#### How to test this pull request:

Open up a project and load the word alignment tool.
It shouldn't crash due to missing index anymore.
Ensure menu is in proper sort order when opening large books with more than 10 chapters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2813)
<!-- Reviewable:end -->
