### PR TITLE
Drag words back to the word bank area

### DIFF
--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -36,6 +36,39 @@ export function moveWordBankItemToAlignment(newAlignmentIndex, wordBankItem) {
     dispatch(WordAlignmentLoadActions.updateAlignmentData(_alignmentData));
   });
 }
+/**
+ * @description Moves an item from the drop zone area to the word bank area.
+ * @param {Object} wordBankItem 
+ */
+export function moveBackToWordBank(wordBankItem) {
+  return ((dispatch, getState) => {
+    console.log(wordBankItem);
+    const {
+      wordAlignmentReducer: {
+        alignmentData
+      },
+      contextIdReducer: {
+        contextId
+      },
+      resourcesReducer: {
+        bibles: {
+          targetLanguage
+        }
+      }
+    } = getState();
+    const { chapter, verse } = contextId.reference;
+    let _alignmentData = JSON.parse(JSON.stringify(alignmentData));
+    let {alignments, wordBank} = _alignmentData[chapter][verse];
+    let currentVerse = targetLanguage[chapter][verse];
+
+    alignments = removeWordBankItemFromAlignments(wordBankItem, alignments);
+    wordBank = addWordBankItemToWordBank(wordBank, wordBankItem, currentVerse);
+
+    _alignmentData[chapter][verse] = {alignments, wordBank};
+
+    dispatch(WordAlignmentLoadActions.updateAlignmentData(_alignmentData));
+  });
+}
 
 export function addWordBankItemToAlignments(wordBankItem, alignments, alignmentIndex) {
   let alignment = alignments[alignmentIndex];
@@ -66,6 +99,17 @@ export function removeWordBankItemFromWordBank(wordBank, wordBankItem) {
     return !isEqual(metadata, wordBankItem);
   });
   return wordBank;
+}
+/**
+ * @description Adda a wordBankItem to the wordBank array and then sorts 
+ *  the array based on the currentVerseString
+ * @param {Array} wordBank 
+ * @param {Object} wordBankItem 
+ * @param {String} currentVerseString 
+ */
+export function addWordBankItemToWordBank(wordBank, wordBankItem, currentVerseString) {
+  wordBank.push(wordBankItem);
+  return WordAlignmentHelpers.sortWordObjectsByString(wordBank, currentVerseString.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g,""));
 }
 /**
  * @description - updates the targetLanguageVerse from wordAlignmentReducer

--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -42,7 +42,6 @@ export function moveWordBankItemToAlignment(newAlignmentIndex, wordBankItem) {
  */
 export function moveBackToWordBank(wordBankItem) {
   return ((dispatch, getState) => {
-    console.log(wordBankItem);
     const {
       wordAlignmentReducer: {
         alignmentData
@@ -109,7 +108,7 @@ export function removeWordBankItemFromWordBank(wordBank, wordBankItem) {
  */
 export function addWordBankItemToWordBank(wordBank, wordBankItem, currentVerseString) {
   wordBank.push(wordBankItem);
-  return WordAlignmentHelpers.sortWordObjectsByString(wordBank, currentVerseString.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g,""));
+  return WordAlignmentHelpers.sortWordObjectsByString(wordBank, currentVerseString);
 }
 /**
  * @description - updates the targetLanguageVerse from wordAlignmentReducer

--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -132,8 +132,11 @@ const mapDispatchToProps = (dispatch) => {
       },
       moveWordBankItemToAlignment: (DropBoxItemIndex, WordBankItemItem) => {
         dispatch(WordAlignmentActions.moveWordBankItemToAlignment(DropBoxItemIndex, WordBankItemItem));
+      },
+      moveBackToWordBank: (wordBankItemItem) => {
+        dispatch(WordAlignmentActions.moveBackToWordBank(wordBankItemItem));
       }
-    }
+     }
   };
 };
 

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual';
+import * as stringHelpers from './stringHelpers';
 /**
  * Concatenates an array of string into a verse.
  * @param {array} verseArray - array of strings in a verse.
@@ -58,7 +59,7 @@ export const occurrencesInString = (string, subString) => {
  * @returns {Array} - array of wordObjects
  */
 export const wordObjectArrayFromString = (string) => {
-  const wordObjectArray = string.split(/\s/).map( (word, index) => {
+  const wordObjectArray = stringHelpers.tokenize(string).map( (word, index) => {
     const occurrence = getOccurrenceInString(string, index, word);
     const occurrences = occurrencesInString(string, word);
     return {


### PR DESCRIPTION
#### This pull request addresses:
- Made the word bank area a drop zone to allow wordBankItems to be moved back to it.
- Added actions that perform the word bank item moving

#### How to test this pull request:
- Test with https://github.com/translationCoreApps/word-alignment-tool/pull/5
- Try dragging words from the greek area back to the word bank area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2844)
<!-- Reviewable:end -->
