### PR TITLE
Created action for merging TopWords and aligned bottom words

### DIFF
--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -103,7 +103,7 @@ export const removeWordBankItemFromWordBank = (wordBank, wordBankItem) => {
   return wordBank;
 };
 /**
- * @description Adda a wordBankItem to the wordBank array and then sorts 
+ * @description Adda a wordBankItem to the wordBank array and then sorts
  *  the array based on the currentVerseString
  * @param {Array} wordBank
  * @param {Object} wordBankItem

--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import isEqual from 'lodash/isEqual';
 // actions
-import * as VerseEditActions from './VerseEditActions';
 import * as WordAlignmentLoadActions from './WordAlignmentLoadActions';
 // helpers
 import * as WordAlignmentHelpers from '../helpers/WordAlignmentHelpers';
@@ -55,31 +54,62 @@ export function removeWordBankItemFromAlignments(wordBankItem, alignments) {
   alignments[alignmentIndex] = alignment;
   return alignments;
 }
-
 /**
  * @description - removes a source word from the word bank.
  * @param {Object} wordBank
  * @param {Object} wordBankItem
  */
-export function removeWordBankItemFromWordBank(wordBank, wordBankItem) {
+export const removeWordBankItemFromWordBank = (wordBank, wordBankItem) => {
   wordBank = wordBank.filter((metadata) => {
-    return !isEqual(metadata, wordBankItem);
+    const equal = (
+      metadata.word === wordBankItem.word &&
+      metadata.occurrence === wordBankItem.occurrence &&
+      metadata.occurrences === wordBankItem.occurrences
+    );
+    return !equal;
   });
   return wordBank;
-}
+};
 /**
- * @description - updates the targetLanguageVerse from wordAlignmentReducer
+ * @description - merges two alignments together
+ * @param {Number} fromAlignmentIndex
+ * @param {Number} toAlignmentIndex
  */
-export const updateTargetLanguageVerseFromAlignmentData = () => {
-  return((dispatch, getState) => {
-    const {contextIdReducer, resourcesReducer, wordAlignmentReducer} = getState();
-    const {chapter, verse} = contextIdReducer.contextId.reference;
-    const verseText = resourcesReducer.bibles.targetLanguage[chapter][verse];
-    const {alignments, wordBank} = wordAlignmentReducer.alignmentData[chapter][verse];
+export const mergeAlignments = (fromAlignmentIndex, toAlignmentIndex) => {
+  return ((dispatch, getState) => {
+    const {
+      wordAlignmentReducer: {
+        alignmentData
+      },
+      contextIdReducer: {
+        contextId
+      },
+      resourcesReducer: {
+        bibles: { bhp, targetLanguage }
+      }
+    } = getState();
+    const { chapter, verse } = contextId.reference;
+    let _alignmentData = JSON.parse(JSON.stringify(alignmentData));
+    let {alignments, wordBank} = _alignmentData[chapter][verse];
 
-    let verseWordObjects = WordAlignmentHelpers.targetLanguageVerseFromAlignments(alignments, wordBank, verseText);
-    dispatch(
-      VerseEditActions.editTargetVerseInBiblesReducer(verseWordObjects)
-    );
+    // get the alignments to move
+    const fromAlignments = alignments[fromAlignmentIndex];
+    // get the alignments to move to
+    let toAlignments = alignments[toAlignmentIndex];
+    // merge the alignments together
+    const topWords = toAlignments.topWords.concat(fromAlignments.topWords);
+    const bottomWords = toAlignments.bottomWords.concat(fromAlignments.bottomWords);
+    // sort the topWords and bottomWords
+    const topWordVerseText = bhp[chapter][verse].map(o => o.word).join(' ');
+    toAlignments.topWords = WordAlignmentHelpers.sortWordObjectsByString(topWords, topWordVerseText);
+    const bottomWordVerseText = targetLanguage[chapter][verse];
+    toAlignments.bottomWords = WordAlignmentHelpers.sortWordObjectsByString(bottomWords, bottomWordVerseText);
+    // overwrite the alignment in the toAlignmentIndex
+    alignments[toAlignmentIndex] = toAlignments;
+    // remove the alignments that got moved
+    alignments = alignments.filter((_, i) => i !== fromAlignmentIndex);
+    // update the alignmentData
+    _alignmentData[chapter][verse] = {alignments, wordBank};
+    dispatch(WordAlignmentLoadActions.updateAlignmentData(_alignmentData));
   });
 };

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -105,7 +105,6 @@ export const generateBlankAlignments = (verseData) => {
           strongs: wordData.strongs,
           lemma: wordData.lemma,
           morph: wordData.morph,
-          alignmentIndex: index,
           occurrence,
           occurrences
         }

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -102,7 +102,10 @@ export const generateBlankAlignments = (verseData) => {
       topWords: [
         {
           word: wordData.word,
-          strongs: wordData.strong,
+          strongs: wordData.strongs,
+          lemma: wordData.lemma,
+          morph: wordData.morph,
+          alignmentIndex: index,
           occurrence,
           occurrences
         }

--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -130,8 +130,11 @@ const mapDispatchToProps = (dispatch) => {
       closeAlertDialog: () => {
         dispatch(closeAlertDialog());
       },
-      moveWordBankItemToAlignment: (DropBoxItemIndex, WordBankItemItem) => {
-        dispatch(WordAlignmentActions.moveWordBankItemToAlignment(DropBoxItemIndex, WordBankItemItem));
+      moveWordBankItemToAlignment: (DropBoxItemIndex, WordBankItem) => {
+        dispatch(WordAlignmentActions.moveWordBankItemToAlignment(DropBoxItemIndex, WordBankItem));
+      },
+      mergeAlignments: (fromAlignmentIndex, toAlignmentIndex) => {
+        dispatch(WordAlignmentActions.mergeAlignments(fromAlignmentIndex, toAlignmentIndex));
       }
     }
   };


### PR DESCRIPTION
#### This pull request addresses:

Created action for merging TopWords and aligned bottom words

#### How to test this pull request:

- Checkout the same branch in the wordAlignment tool.
- Test the dragging and dropping of Top words.
  - Should be droppable one to the left and to the right of it.
  - Should not be droppable on any others.
- Test pre-existing drag and drop functionality of word bank and bottom words.
- Test the dragging and dropping of Top Words that include bottom words.
  - Should merge all bottom words.

#### Known limitations:
- Dragging TopWords that are already merged will merge all pre-merged alignments.
  - This will be addressed after unmerging Top Words as that is a prerequisite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2846)
<!-- Reviewable:end -->
