### PR TITLE
Updated UGNT reference to BHP

### DIFF
--- a/scripts/resources/helpers/stringsHelpers.js
+++ b/scripts/resources/helpers/stringsHelpers.js
@@ -2,7 +2,7 @@ export function getResourceType(resourceId) {
   switch (resourceId) {
     case 'ulb':
     case 'udb':
-    case 'ugnt':
+    case 'bhp':
       return 'bibles';
     case 'tn':
     case 'ta':
@@ -17,7 +17,7 @@ export function getResourceId(resourceId) {
   switch (resourceId) {
     case 'ulb':
     case 'udb':
-    case 'ugnt':
+    case 'bhp':
       return resourceId;
     case 'tn':
       return 'translationNotes';

--- a/scripts/resources/index.js
+++ b/scripts/resources/index.js
@@ -23,9 +23,9 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 // node process variables
 const LANGUAGE_ID = process.argv[2].toLowerCase(); // ex. en, hi, es
-const RESOURCE_ID = process.argv[3].toLowerCase(); // ex. ulb, udb, ugnt, tW, tN, tA
+const RESOURCE_ID = process.argv[3].toLowerCase(); // ex. ulb, udb, bhp, tW, tN, tA
 // constants
-const RESOURCE_Key = stringsHelper.getResourceId(process.argv[3].toLowerCase()); // ex. ulb, udb, ugnt, translatioWords, translationNotes, translationAcademy
+const RESOURCE_Key = stringsHelper.getResourceId(process.argv[3].toLowerCase()); // ex. ulb, udb, bhp, translatioWords, translationNotes, translationAcademy
 const RESOURCE_TYPE = stringsHelper.getResourceType(RESOURCE_ID);
 const TEMP_PATH = path.join(__dirname, 'temp');
 const RESOURCE_INPUT_PATH = path.join(TEMP_PATH, 'input');
@@ -98,8 +98,8 @@ door43ApiHelper
     .then(() => {
       // remove temp folder
       setTimeout(() => {
-        fs.removeSync(TEMP_PATH)
-      }, 1000)
+        fs.removeSync(TEMP_PATH);
+      }, 1000);
     });
   })
   .catch(err => {

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -144,7 +144,7 @@ export const chapterGroupsData = (bookId, currentToolName) => {
 /**
  * @description Helper function to get a bibles manifest file from the bible resources folder.
  * @param {string} bibleVersionPath - path to a bibles version folder.
- * @param {string} bibleID - bible name. ex. ugnt, uhb, udb, ulb.
+ * @param {string} bibleID - bible name. ex. bhp, uhb, udb, ulb.
  */
 export function getBibleManifest(bibleVersionPath, bibleID) {
   let fileName = 'manifest.json';
@@ -161,7 +161,7 @@ export function getBibleManifest(bibleVersionPath, bibleID) {
 
 /**
  * @description Helper function to get a bibles index from the bible resources folder.
- * @param {string} bibleId - bible name. ex. ugnt, uhb, udb, ulb.
+ * @param {string} bibleId - bible name. ex. bhp, uhb, udb, ulb.
  * @param {string} bibleVersion - release version.
  */
 export function getBibleIndex(languageId, bibleId, bibleVersion) {


### PR DESCRIPTION
#### This pull request addresses:
- Updated `UGNT` reference to `BHP`
 
#### How to test this pull request:
- Delete the resources folder from the `translationCore` folder in the user directory.
- Then open a tool and you should not be able to load UGNT in the scripture pane
- This PR should be tested together with:
https://github.com/unfoldingWord-dev/translationCore/pull/2856
https://github.com/translationCoreApps/tC_Resources/pull/7
https://github.com/translationCoreApps/word-alignment-tool/pull/7
https://github.com/translationCoreApps/ScripturePane/pull/66

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2856)
<!-- Reviewable:end -->
