### PR TITLE
Unmerging TopWords in Alignment

### DIFF
--- a/__tests__/WordAlignmentHelpers.test.js
+++ b/__tests__/WordAlignmentHelpers.test.js
@@ -3,8 +3,8 @@
 import * as WordAlignmentHelpers from '../src/js/helpers/WordAlignmentHelpers';
 
 describe('WordAlignmentHelpers.sortWordObjectsByString', () => {
-  const string = 'qwerty asdf zxcv uiop jkl; bnm, qwerty asdf zxcv jkl; bnm,';
-  it('should return wordObjectsArray sorted and in order', function () {
+  it('should return wordObjectsArray sorted and in order from string', function () {
+    const string = 'qwerty asdf zxcv uiop jkl; bnm, qwerty asdf zxcv jkl; bnm,';
     const wordObjectArray = [
       { word: 'zxcv', occurrence: 2, occurrences: 2 },
       { word: 'qwerty', occurrence: 2, occurrences: 2 },
@@ -17,6 +17,24 @@ describe('WordAlignmentHelpers.sortWordObjectsByString', () => {
       { word: 'zxcv', occurrence: 1, occurrences: 2 },
       { word: 'qwerty', occurrence: 2, occurrences: 2 },
       { word: 'zxcv', occurrence: 2, occurrences: 2 }
+    ];
+    expect(output).toEqual(expected);
+  });
+  it('should return wordObjectsArray sorted and in order from stringWordObjects', function () {
+    const stringData = [
+      { word: 'qwerty', occurrence: 1, occurrences: 2, stringData: 0 },
+      { word: 'zxcv', occurrence: 1, occurrences: 2, stringData: 0 },
+      { word: 'qwerty', occurrence: 2, occurrences: 2, stringData: 0 },
+      { word: 'zxcv', occurrence: 2, occurrences: 2, stringData: 0 }
+    ];
+    const wordObjectArray = [
+      { word: 'zxcv', occurrence: 2, occurrences: 2, wordObjectData: 1 },
+      { word: 'qwerty', occurrence: 1, occurrences: 2, wordObjectData: 1 }
+    ];
+    const output = WordAlignmentHelpers.sortWordObjectsByString(wordObjectArray, stringData);
+    const expected = [
+      { word: 'qwerty', occurrence: 1, occurrences: 2, wordObjectData: 1 },
+      { word: 'zxcv', occurrence: 2, occurrences: 2, wordObjectData: 1 }
     ];
     expect(output).toEqual(expected);
   });

--- a/src/js/containers/ToolsContainer.js
+++ b/src/js/containers/ToolsContainer.js
@@ -133,8 +133,8 @@ const mapDispatchToProps = (dispatch) => {
       moveWordBankItemToAlignment: (DropBoxItemIndex, WordBankItem) => {
         dispatch(WordAlignmentActions.moveWordBankItemToAlignment(DropBoxItemIndex, WordBankItem));
       },
-      mergeAlignments: (fromAlignmentIndex, toAlignmentIndex) => {
-        dispatch(WordAlignmentActions.mergeAlignments(fromAlignmentIndex, toAlignmentIndex));
+      moveTopWordItemToAlignment: (topWordItem, fromAlignmentIndex, toAlignmentIndex) => {
+        dispatch(WordAlignmentActions.moveTopWordItemToAlignment(topWordItem, fromAlignmentIndex, toAlignmentIndex));
       },
       moveBackToWordBank: (wordBankItem) => {
         dispatch(WordAlignmentActions.moveBackToWordBank(wordBankItem));

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -4,15 +4,18 @@ import * as stringHelpers from './stringHelpers';
  * Concatenates an array of string into a verse.
  * @param {array} verseArray - array of strings in a verse.
  */
-export function combineGreekVerse(verseArray) {
-  let combinedVerse = '';
+ export const combineGreekVerse = (verseArray) => {
+  return verseArray.map(o => o.word).join(' ');
+};
 
-  verseArray.forEach(wordData => {
-    combinedVerse += ' ' + wordData.word;
-  }, this);
-
-  return combinedVerse;
-}
+export const populateOccurrencesInWordObjects = (wordObjects) => {
+  const string = combineGreekVerse(wordObjects);
+  return wordObjects.map((wordObject, index) => {
+    wordObject.occurrence = getOccurrenceInString(string, index, wordObject.word);
+    wordObject.occurrences = occurrencesInString(string, wordObject.word);
+    return wordObject;
+  });
+};
 
 /**
  * gets the occurrence of a subString in a string by using the subString index in the string.
@@ -76,8 +79,12 @@ export const wordObjectArrayFromString = (string) => {
  * @param {String} string - The string to search in
  * @returns {Array} - sorted array of wordObjects
  */
-export const sortWordObjectsByString = (wordObjectArray, string) => {
-  const stringWordObjectArray = wordObjectArrayFromString(string);
+export const sortWordObjectsByString = (wordObjectArray, stringData) => {
+  if (stringData.constructor !== Array) {
+    stringData = wordObjectArrayFromString(stringData);
+  } else {
+    stringData = populateOccurrencesInWordObjects(stringData);
+  }
   let _wordObjectArray = wordObjectArray.map((wordObject) => {
     const {word, occurrence, occurrences} = wordObject;
     const _wordObject = {
@@ -85,8 +92,13 @@ export const sortWordObjectsByString = (wordObjectArray, string) => {
       occurrence,
       occurrences
     };
-    const indexInString = stringWordObjectArray.findIndex(object => {
-      return isEqual(object, _wordObject);
+    const indexInString = stringData.findIndex(object => {
+      const equal = (
+        object.word === _wordObject.word &&
+        object.occurrence === _wordObject.occurrence &&
+        object.occurrences === _wordObject.occurrences
+      );
+      return equal;
     });
     wordObject.index = indexInString;
     return wordObject;


### PR DESCRIPTION
#### This pull request addresses:

Unmerging TopWords in Alignment

#### How to test this pull request:

- Drag and drop TopWords in alignment and see if they behave as expected, including sorting.
- Drag and drop BottomWords and ensure they work as before/expected.
  - Should Sort properly now.
- Drag TopWords together after BottomWords are aligned.
  - Should merge BottomWords from both if the Dragged TopWord was solo.
  - Should reset BottomWords from both if Dragged TopWord was not solo.
- Drag a Merged TopWord to the blank Alignment at the bottom.
  - Should unmerge it and reset BottomWords from where it came.
  - Should properly sort the TopWords.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2857)
<!-- Reviewable:end -->
