### PR TITLE
Fix solo TopWord from disappearing when dropped on empty alignment

### DIFF
--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -151,11 +151,11 @@ export const moveTopWordItemToAlignment = (topWordItem, fromAlignmentIndex, toAl
     // if only one topWord in the fromAlignments, merge them
     let verseAlignmentData = { alignments, wordBank }; // if it's the same alignmentIndex then it needs unmerged
     const sameAlignmentIndex = fromAlignmentIndex === toAlignmentIndex;
-    if (!sameAlignmentIndex || fromAlignments.topWords.length === 1 && toAlignments.topWords.length > 0) {
+    if (sameAlignmentIndex && fromAlignments.topWords.length > 1) { // if more than one topWord in fromAlignments or moving to an empty alignment, move topWord, and move bottomWords of fromAlignments to wordBank
+      verseAlignmentData = unmergeAlignments(topWordItem, alignments, wordBank, fromAlignmentIndex, topWordVerseData, bottomWordVerseText);
+    } else if (fromAlignments.topWords.length === 1 && toAlignments.topWords.length > 0) {
       alignments = mergeAlignments(alignments, fromAlignmentIndex, toAlignmentIndex, topWordVerseData, bottomWordVerseText);
       verseAlignmentData = { alignments, wordBank };
-    } else { // if more than one topWord in fromAlignments or moving to an empty alignment, move topWord, and move bottomWords of fromAlignments to wordBank
-      verseAlignmentData = unmergeAlignments(topWordItem, alignments, wordBank, fromAlignmentIndex, topWordVerseData, bottomWordVerseText);
     }
     // update the alignmentData
     _alignmentData[chapter][verse] = verseAlignmentData;
@@ -209,7 +209,6 @@ export const unmergeAlignments = (topWordItem, alignments, wordBank, fromAlignme
   // overwrite the alignments
   alignments[toAlignmentIndex] = toAlignments;
   alignments[fromAlignmentIndex] = fromAlignments;
-
   // sort verseAlignmentData
   alignments = sortAlignmentsByTopWordVerseData(alignments, topWordVerseData);
   return { alignments, wordBank };

--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -151,9 +151,11 @@ export const moveTopWordItemToAlignment = (topWordItem, fromAlignmentIndex, toAl
     // if only one topWord in the fromAlignments, merge them
     let verseAlignmentData = { alignments, wordBank }; // if it's the same alignmentIndex then it needs unmerged
     const sameAlignmentIndex = fromAlignmentIndex === toAlignmentIndex;
-    if (sameAlignmentIndex && fromAlignments.topWords.length > 1) { // if more than one topWord in fromAlignments or moving to an empty alignment, move topWord, and move bottomWords of fromAlignments to wordBank
+    const performUnmerge = sameAlignmentIndex && fromAlignments.topWords.length > 1;
+    const performMerge = !sameAlignmentIndex && fromAlignments.topWords.length === 1 && toAlignments.topWords.length > 0;
+    if (performUnmerge) { // if more than one topWord in fromAlignments or moving to an empty alignment, move topWord, and move bottomWords of fromAlignments to wordBank
       verseAlignmentData = unmergeAlignments(topWordItem, alignments, wordBank, fromAlignmentIndex, topWordVerseData, bottomWordVerseText);
-    } else if (fromAlignments.topWords.length === 1 && toAlignments.topWords.length > 0) {
+    } else if (performMerge) {
       alignments = mergeAlignments(alignments, fromAlignmentIndex, toAlignmentIndex, topWordVerseData, bottomWordVerseText);
       verseAlignmentData = { alignments, wordBank };
     }


### PR DESCRIPTION
#### This pull request addresses:

Fixes the use case when a TopWord was by itself and dropped on the empty alignment box causing it to disappear.

#### How to test this pull request:

Must test independently of the other matching PR.
This was addressed fundamentally in the core actions and also in the tool UI.
Tool fix addresses root behavior, tool fix prevents it from happening

- Drag a TopWord that is solo onto the empty alignment box and it shouldn't disappear anymore.
- Test existing functionality to ensure other use cases weren't broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2885)
<!-- Reviewable:end -->
