### PR TITLE
Addressed duplicates in word bank with temp fix.

### DIFF
--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -4,6 +4,7 @@ import isEqual from 'lodash/isEqual';
 import * as WordAlignmentLoadActions from './WordAlignmentLoadActions';
 // helpers
 import * as WordAlignmentHelpers from '../helpers/WordAlignmentHelpers';
+import * as stringHelpers from '../helpers/stringHelpers';
 
 /**
  * moves a source word object to a target box object.
@@ -63,7 +64,7 @@ export const moveBackToWordBank = (wordBankItem) => {
     const { chapter, verse } = contextId.reference;
     let _alignmentData = JSON.parse(JSON.stringify(alignmentData));
     let {alignments, wordBank} = _alignmentData[chapter][verse];
-    let currentVerse = targetLanguage[chapter][verse];
+    let currentVerse = stringHelpers.tokenize(targetLanguage[chapter][verse]).join(' ');
 
     alignments = removeWordBankItemFromAlignments(wordBankItem, alignments, currentVerse);
     wordBank = addWordBankItemToWordBank(wordBank, wordBankItem, currentVerse);

--- a/src/js/actions/WordAlignmentActions.js
+++ b/src/js/actions/WordAlignmentActions.js
@@ -10,7 +10,7 @@ import * as WordAlignmentHelpers from '../helpers/WordAlignmentHelpers';
  * @param {Number} DropBoxItemIndex - index of the target box or greek box item.
  * @param {object} wordBankItem - object of the source item being drop in the target box.
  */
-export function moveWordBankItemToAlignment(newAlignmentIndex, wordBankItem) {
+export const moveWordBankItemToAlignment = (newAlignmentIndex, wordBankItem) => {
   return ((dispatch, getState) => {
     const {
       wordAlignmentReducer: {
@@ -40,12 +40,12 @@ export function moveWordBankItemToAlignment(newAlignmentIndex, wordBankItem) {
 
     dispatch(WordAlignmentLoadActions.updateAlignmentData(_alignmentData));
   });
-}
+};
 /**
  * @description Moves an item from the drop zone area to the word bank area.
  * @param {Object} wordBankItem
  */
-export function moveBackToWordBank(wordBankItem) {
+export const moveBackToWordBank = (wordBankItem) => {
   return ((dispatch, getState) => {
     const {
       wordAlignmentReducer: {
@@ -72,17 +72,17 @@ export function moveBackToWordBank(wordBankItem) {
 
     dispatch(WordAlignmentLoadActions.updateAlignmentData(_alignmentData));
   });
-}
+};
 
-export function addWordBankItemToAlignments(wordBankItem, alignments, alignmentIndex, currentVerseText) {
+export const addWordBankItemToAlignments = (wordBankItem, alignments, alignmentIndex, currentVerseText) => {
   let alignment = alignments[alignmentIndex];
   alignment.bottomWords.push(wordBankItem);
   alignment.bottomWords = WordAlignmentHelpers.sortWordObjectsByString(alignment.bottomWords, currentVerseText);
   alignments[alignmentIndex] = alignment;
   return alignments;
-}
+};
 
-export function removeWordBankItemFromAlignments(wordBankItem, alignments) {
+export const removeWordBankItemFromAlignments = (wordBankItem, alignments) => {
   const {alignmentIndex} = wordBankItem;
   let alignment = alignments[alignmentIndex];
   delete wordBankItem.alignmentIndex;
@@ -92,7 +92,7 @@ export function removeWordBankItemFromAlignments(wordBankItem, alignments) {
   alignment.bottomWords = bottomWords;
   alignments[alignmentIndex] = alignment;
   return alignments;
-}
+};
 /**
  * @description - removes a source word from the word bank.
  * @param {Object} wordBank

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -122,9 +122,11 @@ export const generateBlankAlignments = (verseData) => {
  */
 export const generateWordBank = (verseText) => {
   const verseWords = stringHelpers.tokenize(verseText);
+  // TODO: remove once occurrencesInString uses tokenizer, can't do that until bug is addressed with Greek
+  const _verseText = verseWords.join(' ');
   const wordBank = verseWords.map((word, index) => {
-    let occurrences = WordAlignmentHelpers.occurrencesInString(verseText, word);
-    let occurrence = WordAlignmentHelpers.getOccurrenceInString(verseText, index, word);
+    let occurrences = WordAlignmentHelpers.occurrencesInString(_verseText, word);
+    let occurrence = WordAlignmentHelpers.getOccurrenceInString(_verseText, index, word);
     return {
       word,
       occurrence,

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -22,6 +22,8 @@ export const populateOccurrencesInWordObjects = (wordObjects) => {
  * @param {String} string
  * @param {Number} currentWordIndex
  * @param {String} subString
+ * TODO: Replace with the tokenizer version of this to prevent puctuation issues
+ * Cannot replace with tokenizer until tokenizer handles all greek use cases that broke tokenizer
  */
 export const getOccurrenceInString = (string, currentWordIndex, subString) => {
   let arrayOfStrings = string.split(' ');


### PR DESCRIPTION
#### This pull request addresses:

Addressed duplicates in word bank with temp fix.
The verse had punctuation and not identified properly in the occurrencesInString function.
Long term fix uses the tokenizer in the occurrencesInString function but cannot be yet until the tokenizer handles all greek words.

#### How to test this pull request:

- Import the following project: https://github.com/unfoldingWord-dev/translationCore/files/1360077/fr_tit_text_ulb.tstudio.zip
- Delete alignments data if already imported.
- Ensure that when after dragging the word "Dieu" that only one gets removed from the word bank.
- Align both "Dieu" to the associated greek word for God.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2888)
<!-- Reviewable:end -->
