### PR TITLE
Tweaked npm scripts for managing git submodules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ install:                            # Install scripts. (runs after repo cloning)
   - npm --version
   - npm install                     # install modules
   - npm install -g electron-mocha@4.0.0
-  - npm run install-apps
+  - npm run load-apps
 skip_non_tags: true                 # Only build tags (we use travis-ci for tests)
 test_script:
   - npm test                        # run tests

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "plugins": [
-    "react"
+    "react",
+    "jest"
   ],
   "settings": {
     "react": {
@@ -27,16 +28,8 @@
   },
   "env": {
     "browser": true,
-    "node": true
-  },
-  "globals": {
-    "console": true,
-    "window": true,
-    "setTimeout": true,
-    "Promise": true,
-    "process": true,
-    "__dirname": true,
-    "localStorage": true,
-    "document": true
+    "node": true,
+    "es6": true,
+    "jest/globals": true
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - npm i             # Run npm install
   - npm i -g electron-mocha@4.0.0 # Install electron-mocha with -g to install cli
   - npm i -g jest coveralls codecov
+  - npm run load-apps
 script:
   - eslint ./src && jest --coverage
   - cat ./coverage/lcov.info | coveralls # submit coverage to coveralls

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,39 +178,6 @@
         "normalize-path": "2.1.1"
       }
     },
-    "appdmg": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.4.5.tgz",
-      "integrity": "sha1-R6gnhluKC+SKuzUiVn40k9LxuDg=",
-      "optional": true,
-      "requires": {
-        "async": "1.5.2",
-        "cp-file": "3.2.0",
-        "ds-store": "0.1.6",
-        "execa": "0.4.0",
-        "fs-temp": "1.1.2",
-        "fs-xattr": "0.1.17",
-        "image-size": "0.5.5",
-        "is-my-json-valid": "2.16.0",
-        "minimist": "1.2.0",
-        "parse-color": "1.0.0",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "optional": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "optional": true
-        }
-      }
-    },
     "append-transform": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -332,12 +299,6 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
-    "array-buffer-from-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/array-buffer-from-string/-/array-buffer-from-string-0.1.0.tgz",
-      "integrity": "sha1-OxQ1H4YUnYTvxhLFrafthRadewc=",
-      "optional": true
-    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -357,18 +318,6 @@
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0"
-      }
-    },
-    "array-like-slice-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/array-like-slice-x/-/array-like-slice-x-1.1.0.tgz",
-      "integrity": "sha512-hIE4qTc8NUWgHwIGIIHTgDK+gK8zw20zgg/qZkrwwwM8R1i94i96Olr3RmP0GfQF5ffqehvAcutdTsyWj1XSdg==",
-      "requires": {
-        "split-if-boxed-bug-x": "1.0.0",
-        "to-integer-x": "2.1.0",
-        "to-length-x": "2.1.0",
-        "to-object-x": "1.4.1",
-        "validate.io-undefined": "1.0.3"
       }
     },
     "array-union": {
@@ -470,14 +419,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "attempt-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.0.tgz",
-      "integrity": "sha512-0ZFSBkMhMwsvNr/t7f7fw7rIB9060k6rEWd40A5PIiCddWuvI8kbKuNtF9rYy/74Ef0ORY7cwJfZ2gJxZxGCdA==",
-      "requires": {
-        "array-like-slice-x": "1.1.0"
-      }
     },
     "author-regex": {
       "version": "1.0.0",
@@ -660,6 +601,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -670,6 +612,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
@@ -680,6 +623,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -691,6 +635,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -702,6 +647,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-traverse": "6.25.0",
@@ -712,6 +658,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -724,6 +671,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -733,6 +681,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -742,6 +691,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -751,6 +701,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
@@ -761,6 +712,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -773,6 +725,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
@@ -819,6 +772,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -854,7 +808,8 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
@@ -865,32 +820,38 @@
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -901,6 +862,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -909,6 +871,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -917,6 +880,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-template": "6.25.0",
@@ -929,6 +893,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
       "requires": {
         "babel-helper-define-map": "6.24.1",
         "babel-helper-function-name": "6.24.1",
@@ -945,6 +910,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-template": "6.25.0"
@@ -954,6 +920,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -962,6 +929,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -971,6 +939,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -979,6 +948,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -989,6 +959,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -997,6 +968,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1007,6 +979,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1018,6 +991,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1028,6 +1002,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1038,6 +1013,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
         "babel-runtime": "6.25.0"
@@ -1047,6 +1023,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
@@ -1060,6 +1037,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -1069,6 +1047,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -1077,6 +1056,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1087,6 +1067,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -1095,6 +1076,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -1103,6 +1085,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.24.1",
         "babel-runtime": "6.25.0",
@@ -1113,6 +1096,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -1123,6 +1107,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-flow": "6.18.0",
         "babel-runtime": "6.25.0"
@@ -1132,6 +1117,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "6.13.0",
         "babel-runtime": "6.25.0"
@@ -1141,6 +1127,7 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -1149,6 +1136,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-react-jsx": "6.24.1",
         "babel-plugin-syntax-jsx": "6.18.0",
@@ -1159,6 +1147,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-runtime": "6.25.0"
@@ -1168,6 +1157,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-runtime": "6.25.0"
@@ -1177,6 +1167,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+      "dev": true,
       "requires": {
         "regenerator-transform": "0.9.11"
       }
@@ -1185,6 +1176,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
@@ -1205,6 +1197,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
       "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1242,6 +1235,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -1290,6 +1284,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-flow-strip-types": "6.22.0"
       }
@@ -1307,6 +1302,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-plugin-transform-react-display-name": "6.25.0",
@@ -1388,12 +1384,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "base32-encode": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-0.1.0.tgz",
-      "integrity": "sha1-HrxcnM+r9sJ4yGOSiLpOUO4rsfU=",
-      "optional": true
-    },
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
@@ -1464,15 +1454,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.7.1.tgz",
       "integrity": "sha1-pN6PGKGg3JUx6yqSoVIftqm6lqU="
     },
-    "bplist-creator": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
-      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
-      "optional": true,
-      "requires": {
-        "stream-buffers": "2.2.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1520,6 +1501,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.1.tgz",
       "integrity": "sha512-YSRvpyaxDBBAPkwYO0THouUmA+cvYbyBHZrP/byJEUGDT9r/6TQcDASBtrAj4S45Le6JZbV8oeUAPR9wT8tisg==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000713",
         "electron-to-chromium": "1.3.18"
@@ -1560,15 +1542,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-    },
-    "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "optional": true,
-      "requires": {
-        "is-array-buffer-x": "1.7.0"
-      }
     },
     "buffers": {
       "version": "0.1.1",
@@ -1654,7 +1627,8 @@
     "caniuse-lite": {
       "version": "1.0.30000713",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000713.tgz",
-      "integrity": "sha1-M5V+y0ohVKXUCmDRPYvxz6CIGoo="
+      "integrity": "sha1-M5V+y0ohVKXUCmDRPYvxz6CIGoo=",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -1741,7 +1715,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2124,53 +2097,6 @@
         }
       }
     },
-    "cp-file": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-3.2.0.tgz",
-      "integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "crc32-stream": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
@@ -2187,16 +2113,6 @@
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cross-spawn-async": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "optional": true,
-      "requires": {
-        "lru-cache": "4.1.1",
         "which": "1.3.0"
       }
     },
@@ -2748,17 +2664,6 @@
         "domelementtype": "1.3.0"
       }
     },
-    "ds-store": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
-      "integrity": "sha1-0QJO90btDBPw9/7IXH6FjoxLfKc=",
-      "optional": true,
-      "requires": {
-        "bplist-creator": "0.0.7",
-        "macos-alias": "0.2.11",
-        "tn1150": "0.1.0"
-      }
-    },
     "eachr": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
@@ -3226,7 +3131,6 @@
       "integrity": "sha1-3oNfAgCbg/guQIA2rDFGLD1sskk=",
       "optional": true,
       "requires": {
-        "appdmg": "0.4.5",
         "debug": "2.6.8",
         "minimist": "1.2.0"
       },
@@ -3697,7 +3601,8 @@
     "electron-to-chromium": {
       "version": "1.3.18",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
-      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
+      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
+      "dev": true
     },
     "electron-window": {
       "version": "0.8.1",
@@ -4244,6 +4149,12 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.2.0.tgz",
+      "integrity": "sha512-pe7JWoZiXWHfVCBArxX5o3laRZp24tkBSeIHImJJyX2mDIqzlrXkUGkfbC6tPKER3WbcQ3YxKDMgp8uqt8fjfw==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.2.0.tgz",
@@ -4348,20 +4259,6 @@
       "dev": true,
       "requires": {
         "merge": "1.2.0"
-      }
-    },
-    "execa": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-      "optional": true,
-      "requires": {
-        "cross-spawn-async": "2.2.5",
-        "is-stream": "1.1.0",
-        "npm-run-path": "1.0.0",
-        "object-assign": "4.1.1",
-        "path-key": "1.0.0",
-        "strip-eof": "1.0.0"
       }
     },
     "exit-hook": {
@@ -4706,15 +4603,6 @@
         }
       }
     },
-    "fmix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
-      "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
-      "optional": true,
-      "requires": {
-        "imul": "1.0.1"
-      }
-    },
     "follow-redirects": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
@@ -4775,928 +4663,10 @@
       "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
       "dev": true
     },
-    "fs-temp": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.1.2.tgz",
-      "integrity": "sha1-zFLwOLvv5RD2vNCexZK3nQ9pJT8=",
-      "optional": true,
-      "requires": {
-        "random-path": "0.1.1"
-      }
-    },
-    "fs-xattr": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.1.17.tgz",
-      "integrity": "sha512-SpBbnN1lkSgBjELpnxnxfcl236ceCu6LnrfrT4CREsux4LP4PvKU37IpceJqAInnTTOWmeVHi9c8lKXIdfynPg==",
-      "optional": true,
-      "requires": {
-        "buffer-from": "0.1.1",
-        "nan": "2.7.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -5733,12 +4703,14 @@
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
       "requires": {
         "is-property": "1.0.2"
       }
@@ -6084,39 +5056,11 @@
         "ansi-regex": "2.1.1"
       }
     },
-    "has-boxed-string-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-boxed-string-x/-/has-boxed-string-x-1.0.1.tgz",
-      "integrity": "sha512-Pik18dmNOFZZAvai2l+NAjTY708Ou9Dvb6tsd+QFJv++KbAbOoTZ4GbBhSnU983l7hrNuGW50qSf1GcExq8GhQ=="
-    },
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
-    },
-    "has-own-property-x": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz",
-      "integrity": "sha512-1L+yagK0h8YedH/bkwoiY+PdCr6SadmjgMudQ2SjiPdxXGdPhFybpln3yJ41EpuETz33ITNxTMHdYfeM79W03Q==",
-      "optional": true,
-      "requires": {
-        "to-object-x": "1.4.1",
-        "to-property-key-x": "2.0.1"
-      }
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1"
-      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -6277,12 +5221,8 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true,
       "optional": true
-    },
-    "imul": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
-      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -6372,19 +5312,6 @@
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-      "optional": true,
-      "requires": {
-        "attempt-x": "1.1.0",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.5.1",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.1"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6431,7 +5358,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -6466,15 +5394,6 @@
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
-    "is-falsey-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
-      "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
-      "optional": true,
-      "requires": {
-        "to-boolean-x": "1.0.1"
-      }
-    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -6483,32 +5402,12 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-finite-x": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.1.tgz",
-      "integrity": "sha512-moPNeMjJ81/DSTmQbZrwAblpgi8JK/7jmb8VaZIpyoTZlVtpZb4M61gmi5TY6fizYnVE5dahZ0K+9nMi1Q05dw==",
-      "requires": {
-        "is-nan-x": "1.0.1"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "1.0.1"
-      }
-    },
-    "is-function-x": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.1.tgz",
-      "integrity": "sha512-klx9TzyFpj8D1aNMSHi6y0+inn2gOmtPQQkVkxTVv5Oa8YNWFJJ5QpIe09p79zHxeJ5FzyA7Ms2vQH2PLXt4OQ==",
-      "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "1.3.3",
-        "replace-comments-x": "1.0.3",
-        "to-string-tag-x": "1.4.1"
       }
     },
     "is-glob": {
@@ -6520,42 +5419,16 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-index-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz",
-      "integrity": "sha512-BJ7vtw0jvcjBX4UsT7KkpZUliAMX3vJugZimDKy4W6ilGDtvUZ8nYsYnROVrrsjNjg5LJ3MN9NvyRVALfDW/wQ==",
-      "optional": true,
-      "requires": {
-        "math-clamp-x": "1.1.0",
-        "max-safe-integer": "1.0.1",
-        "safe-to-string-x": "2.0.1",
-        "to-integer-x": "2.1.0",
-        "to-number-x": "1.1.0"
-      }
-    },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
-      }
-    },
-    "is-nan-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
-      "integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw=="
-    },
-    "is-nil-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
-      "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
       }
     },
     "is-number": {
@@ -6565,16 +5438,6 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
-      }
-    },
-    "is-object-like-x": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz",
-      "integrity": "sha512-AtUeYE4Xs8EbuHuG6yBHiLdIlWRPPFidcIs3JE6PJZ/mzUQFOK8X5J1OA+3cVi0rlrdUCjiX52obtCV2hxs+HA==",
-      "optional": true,
-      "requires": {
-        "is-function-x": "3.1.1",
-        "is-primitive": "2.0.0"
       }
     },
     "is-path-cwd": {
@@ -6616,7 +5479,8 @@
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -6626,7 +5490,8 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -6657,11 +5522,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
-    },
     "is-svg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
@@ -6674,7 +5534,8 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -8154,7 +7015,8 @@
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -8201,7 +7063,8 @@
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -8470,11 +7333,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -8624,15 +7482,6 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
-    "macos-alias": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
-      "integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
-      "optional": true,
-      "requires": {
-        "nan": "2.7.0"
-      }
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -8666,34 +7515,11 @@
         "warning": "3.0.0"
       }
     },
-    "math-clamp-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz",
-      "integrity": "sha512-c7Hxz6Ji4HtwUSMI1HU3Y7pcWQyuINlnCeE1675ZfNbEELFHeqHnEQXrWB7kLiiNTMi6QM38txFAfKq2IYqZpQ==",
-      "optional": true,
-      "requires": {
-        "to-number-x": "1.1.0"
-      }
-    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
-    },
-    "math-sign-x": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz",
-      "integrity": "sha512-3shFG0Ea5vOMCgQCrylyzu3POQRTvvaclb4VArnICToTgshMfA4Dlb9q9lZO1SD/rUD9mOTJZ7dTtlfCq7I91A==",
-      "requires": {
-        "is-nan-x": "1.0.1",
-        "to-number-x": "1.1.0"
-      }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
     },
     "mem": {
       "version": "1.1.0",
@@ -8907,27 +7733,11 @@
         "strip-indent": "1.0.1"
       }
     },
-    "murmur-32": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz",
-      "integrity": "sha1-waedT8X6vwQFdJ0K/3fEFAIFWGE=",
-      "optional": true,
-      "requires": {
-        "array-buffer-from-string": "0.1.0",
-        "fmix": "0.1.0",
-        "imul": "1.0.1"
-      }
-    },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
     "natives": {
       "version": "1.1.0",
@@ -8939,15 +7749,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nested-error-stacks": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "optional": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "netrc": {
       "version": "0.1.4",
@@ -9064,15 +7865,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
-    },
-    "normalize-space-x": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.3.tgz",
-      "integrity": "sha512-9q953GogZSw2Ba1Pj3rI9T3xIPq5PtQBXEX2T/nKCaRuj8scAicXCsYMBKfKDtohTWaKGrZmBF9h53GJzfZ8TQ==",
-      "requires": {
-        "trim-x": "1.0.3",
-        "white-space-x": "2.0.3"
-      }
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -12034,15 +10826,6 @@
         }
       }
     },
-    "npm-run-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "optional": true,
-      "requires": {
-        "path-key": "1.0.0"
-      }
-    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -12115,24 +10898,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-difference/-/object-difference-0.1.0.tgz",
       "integrity": "sha1-mIDTBSWWW1L5UXm9JLsRBqtVu5A="
-    },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-      "optional": true,
-      "requires": {
-        "attempt-x": "1.1.0",
-        "has-own-property-x": "3.1.1",
-        "has-symbol-support-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-index-x": "1.0.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.4.1",
-        "to-property-key-x": "2.0.1"
-      }
     },
     "object-keys": {
       "version": "0.4.0",
@@ -12328,23 +11093,6 @@
         "author-regex": "1.0.0"
       }
     },
-    "parse-color": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
-      "optional": true,
-      "requires": {
-        "color-convert": "0.5.3"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-          "optional": true
-        }
-      }
-    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -12399,11 +11147,6 @@
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
-    },
-    "path-key": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -12905,16 +11648,6 @@
         "loose-envify": "1.3.1"
       }
     },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-      "optional": true,
-      "requires": {
-        "to-object-x": "1.4.1",
-        "to-property-key-x": "2.0.1"
-      }
-    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -12975,16 +11708,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "random-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
-      "integrity": "sha1-+PTTb3WhNMoV/TnH11BfvxY7Y0w=",
-      "optional": true,
-      "requires": {
-        "base32-encode": "0.1.0",
-        "murmur-32": "0.1.0"
-      }
     },
     "randomatic": {
       "version": "1.1.7",
@@ -13422,7 +12145,8 @@
     "regenerate": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.10.5",
@@ -13433,6 +12157,7 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0",
@@ -13453,6 +12178,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
       "requires": {
         "regenerate": "1.3.2",
         "regjsgen": "0.2.0",
@@ -13462,12 +12188,14 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       }
@@ -13496,7 +12224,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -13504,14 +12233,6 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "replace-comments-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.3.tgz",
-      "integrity": "sha512-9i7cX4w+QmkEAelyYVofBP+lLgJZkZ40imH9txxOQVX5F12vDccF+paHIQpDB2LNZY4gjkGbljintKCjUcflow==",
-      "requires": {
-        "is-string": "1.0.4"
       }
     },
     "request": {
@@ -13552,14 +12273,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "require-object-coercible-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
-      "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
-      "requires": {
-        "is-nil-x": "1.4.1"
-      }
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -13745,17 +12458,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
-    "safe-to-string-x": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.1.tgz",
-      "integrity": "sha512-CZEjtSlZnZXAa47Msj1HRp7dLO/qWJ17+7iTIg7D4Hy+hqhP7cSmhRrXE7huFDKXPmcSWtntte+KaEJCcRKaxw==",
-      "optional": true,
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "is-symbol": "1.0.1",
-        "to-string-x": "1.4.1"
-      }
-    },
     "safefs": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
@@ -13795,7 +12497,6 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.1.2",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -14048,15 +12749,6 @@
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
       "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
     },
-    "split-if-boxed-bug-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split-if-boxed-bug-x/-/split-if-boxed-bug-x-1.0.0.tgz",
-      "integrity": "sha512-EHUdMqDOpULook9NWmfKUN9G54wlHXXSMLVnfqXuiSNTwZC+2g+ay8Zmim5XUfPPP8FtGQeLS83v0pupQzI+Pg==",
-      "requires": {
-        "has-boxed-string-x": "1.0.1",
-        "is-string": "1.0.4"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -14083,12 +12775,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
-    },
-    "stream-buffers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
-      "optional": true
     },
     "stream-consume": {
       "version": "0.1.0",
@@ -14593,104 +13279,10 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
-    "tn1150": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
-      "integrity": "sha1-ZzUD0k1WuH3ouMd/7j/AhT1ZoY0=",
-      "optional": true,
-      "requires": {
-        "unorm": "1.4.1"
-      }
-    },
-    "to-boolean-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-      "integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ==",
-      "optional": true
-    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "to-integer-x": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz",
-      "integrity": "sha512-M9iETTi+xMMZtUC70q4VE63XL2mXmNABxwxsIebOfd8K4ZHKCJLD9GyE6RlEPnbOPZj21QinuoVkqWsBsBknRA==",
-      "requires": {
-        "is-finite-x": "3.0.1",
-        "is-nan-x": "1.0.1",
-        "math-sign-x": "2.1.0",
-        "to-number-x": "1.1.0"
-      }
-    },
-    "to-length-x": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-length-x/-/to-length-x-2.1.0.tgz",
-      "integrity": "sha512-92jH0FU52g34/vMtGKuZS6xS7Ooo/6mOxbNNvbOfNDVgHUtQ9wAqConQ8YwAwVaVAwBt6O/WSeyY/DbBVLNCyg==",
-      "requires": {
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "2.1.0"
-      }
-    },
-    "to-number-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.1.0.tgz",
-      "integrity": "sha512-m0v+VykgXsJ8JUSDKcvaASl977pSx5U1D6kyApFxP/KarJr7ZzVWrlHYTOxGDDodytsyh+iwZXpxBZpaWOvv4g==",
-      "requires": {
-        "to-primitive-x": "1.0.1",
-        "trim-x": "1.0.3"
-      }
-    },
-    "to-object-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.4.1.tgz",
-      "integrity": "sha512-8Md/Q8E8Svkz/wQ2orCxN27OWKl2j6I5Ho7Wu0WzCB3XqzkRzLYP05grdm4BBB5978fggSKKOX4uBgZ/2wailA==",
-      "requires": {
-        "require-object-coercible-x": "1.4.1"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.0.1.tgz",
-      "integrity": "sha512-2TJTFCZBdXtTBwvq+S63UnPVIlv0+zZMaka+n3ELhfSLqMB5aDhh2JmIKpzpvDigWQ45leukoAGBLCuIAeYkIA==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.1.1",
-        "is-nil-x": "1.4.1",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.1",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.1.tgz",
-      "integrity": "sha512-ccIUkUCML03zRkNk+2k8jxzObOepBZiL9Z4qVeK0c0e/CXsvF8rVAhgnNe7W+qdCOSB8vcq/FTBZL6/ccGKfsg==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "to-primitive-x": "1.0.1",
-        "to-string-x": "1.4.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-hPekHIGkkJowH45vGmYHLYe335PUnY0XAHa1tomdRpNVZT8wDsbWAbykRvJ81YKjyeBVN4smoNMLtJOWrQj7ZA==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.1.tgz",
-      "integrity": "sha512-63i4+t2/xWQCTYTTSFvQJcQzlXAL+0xLSJhOARh6XyDfv2AI5oKcQIVUQ9HwrbeHVLZ1fH+vWnoVLQpQIH/HaQ==",
-      "requires": {
-        "is-symbol": "1.0.1"
-      }
     },
     "touch": {
       "version": "0.0.3",
@@ -14801,15 +13393,6 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
-    "trim-left-x": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.5.tgz",
-      "integrity": "sha512-aAp+6wECRhtaGWp44PKbxilvjY+kFPJ2RRweEtleLAZ9hYtM7DL1ShEPl/KF6lu6lAYb8xISF/h9egGjiJpZFQ==",
-      "requires": {
-        "to-string-x": "1.4.1",
-        "white-space-x": "2.0.3"
-      }
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -14819,24 +13402,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "trim-right-x": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.3.tgz",
-      "integrity": "sha512-a0Moq+2fFdRXcVjqtDgxtDYx3bRTvsLMmwiK9vEVWuc8Y557oZjA3A6eJ0UcyNEa8DE57KMFSRGPUzrLLDJukg==",
-      "requires": {
-        "to-string-x": "1.4.1",
-        "white-space-x": "2.0.3"
-      }
-    },
-    "trim-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.3.tgz",
-      "integrity": "sha512-+fXcHQ+pV3uL/wmuFZGL2uWh4hO7maqPf/534GyV4HAtVe/JE0IX4dFWNgYwGwqMvWztBSW6jrqQSslLggQbOg==",
-      "requires": {
-        "trim-left-x": "1.3.5",
-        "trim-right-x": "1.3.3"
-      }
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -15011,12 +13576,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
-    "unorm": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
-      "optional": true
-    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -15114,11 +13673,6 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
-    },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
     },
     "vendors": {
       "version": "1.0.1",
@@ -15275,11 +13829,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "white-space-x": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz",
-      "integrity": "sha512-An6uHDfZizY0t7x8iyY8nLej1lnqyaFSyTKjwwqS0VIhvV4tof6a+Et4uJVFlZh7HUAOgKoZfm5hFzl/D4xDgw=="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,9 @@
     "update-version": "node ./scripts/versionScript.js",
     "test": "eslint ./src && jest",
     "coverage": "jest --coverage && cat ./coverage/lcov.info | coveralls",
-    "install-apps": "git submodule update --init --recursive",
+    "load-apps": "git submodule update --init --recursive",
+    "update-apps": "git submodule foreach --recursive 'git checkout master && git pull'",
     "install-electron-forge": "npm i -g electron-forge@3.2.0",
-    "pull-apps": "npm run apps-master && npm run git-pull",
-    "git-pull": "git submodule foreach --recursive git pull",
-    "apps-master": "git submodule foreach --recursive git checkout master",
-    "update-resource": "babel-node scripts/resources/index.js",
-    "update-en-resource": "babel-node scripts/resources/index.js en",
     "prettier-resource": "prettier --single-quote --print-width 80 --trailing-comma all --write 'tC_resources/**/*.json'"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "electron-mocha": "^4.0.0",
     "electron-prebuilt-compile": "1.6.11",
     "eslint": "^2.13.1",
+    "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-react": "^7.1.0",
     "glob": "^7.1.2",
     "jest": "^21.1.0",
@@ -72,17 +73,17 @@
     "react-addons-test-utils": "15.4.2",
     "redux-mock-store": "^1.2.3",
     "redux-test-utils": "^0.1.1",
-    "spec-xunit-file": "0.0.1-3"
-  },
-  "dependencies": {
-    "adm-zip": "^0.4.7",
-    "axios": "^0.16.2",
+    "spec-xunit-file": "0.0.1-3",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "babel-register": "^6.11.6",
+    "babel-register": "^6.11.6"
+  },
+  "dependencies": {
+    "adm-zip": "^0.4.7",
+    "axios": "^0.16.2",
     "crypto-js": "^3.1.8",
     "csv": "^1.1.1",
     "electron-compile": "^6.4.1",


### PR DESCRIPTION
#### This pull request addresses:

This contains some minor tweaks to the lint config and improves the clarity of npm scripts used for managing the submodules.

now:
* `npm run load-apps` will check out versioned submodule commit
* `npm run update-apps` will pull down the latest submodule commit

appveyor and travis now run `load-apps` before running tests and building.

If you want to get app updates into tC you'll need to manually run `update-apps` then perform a git add+commit. Or, if you just to update a single app you can cd into the app directory and perform a manually pull.

## Important!
Submodules may become out of sync in the following two cases:
* after pulling the latest tC code
* after changing branches

**you must get in the habit of running `npm run load-apps` after either of the above scenarios**

#### How to test this pull request:

not much to test here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2946)
<!-- Reviewable:end -->
