### PR TITLE
Added importing alert back to local imports

### DIFF
--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -31,14 +31,15 @@ const ALERT_MESSAGE = (
  */
 export function loadProjectFromFS() {
   return ((dispatch) => {
+    dispatch(BodyUIActions.toggleProjectsFAB());
     dialog.showOpenDialog({ properties: ['openFile', 'openDirectory'] }, (filePaths) => {
       dispatch(AlertModalActions.openAlertDialog(`Importing local project`, true));
-      dispatch(BodyUIActions.toggleProjectsFAB());
-      //no file path given
       if (filePaths === undefined || !filePaths[0]) {
         return dispatch(AlertModalActions.openAlertDialog(ALERT_MESSAGE));
       }
-      dispatch(verifyAndSelectProject(filePaths[0]));
+      setTimeout(() => {
+        dispatch(verifyAndSelectProject(filePaths[0]));
+      }, 100);
     });
   });
 }

--- a/src/js/containers/home/ProjectsManagementContainer.js
+++ b/src/js/containers/home/ProjectsManagementContainer.js
@@ -84,7 +84,6 @@ const mapDispatchToProps = (dispatch) => {
         dispatch(ProjectSelectionActions.selectProject(projectPath));
       },
       loadProjectFromFS: () => {
-        dispatch(BodyUIActions.toggleProjectsFAB());
         dispatch(ImportLocalActions.loadProjectFromFS());
       },
       exportToCSV: (projectPath) => {


### PR DESCRIPTION
#### This pull request addresses:

- Added importing alert back to local imports


#### How to test this pull request:
- Import a local project and you should see the `importing alert`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2985)
<!-- Reviewable:end -->
