### PR TITLE
Now setting focus to the first empty required field in the project information check

### DIFF
--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -24,6 +24,21 @@ export function validate() {
     const { projectSaveLocation } = getState().projectDetailsReducer;
     const projectManifestPath = path.join(projectSaveLocation, 'manifest.json');
     const manifest = fs.readJsonSync(projectManifestPath);
+
+    let {
+      translators,
+      checkers,
+      project,
+      target_language
+    } = manifest;
+    // match projectInformationReducer with data in manifest.
+    dispatch(setBookIDInProjectInformationReducer(project.id ? project.id : ''));
+    dispatch(setLanguageIdInProjectInformationReducer(target_language.id ? target_language.id : ''));
+    dispatch(setLanguageNameInProjectInformationReducer(target_language.name ? target_language.name : ''));
+    dispatch(setLanguageDirectionInProjectInformationReducer(target_language.direction ? target_language.direction : ''));
+    dispatch(setContributorsInProjectInformationReducer(translators && translators.length > 0 ? translators : []));
+    dispatch(setCheckersInProjectInformationReducer(checkers && checkers.length > 0 ? checkers : []));
+
     if (ProjectInformationCheckHelpers.checkBookReference(manifest) || ProjectInformationCheckHelpers.checkLanguageDetails(manifest)) {
       // project failed the project information check.
       dispatch(ProjectValidationActions.addProjectValidationStep(PROJECT_INFORMATION_CHECK_NAMESPACE));

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageIdTextBox.js
@@ -7,6 +7,7 @@ import TranslateIcon from 'material-ui/svg-icons/action/translate';
 
 const LanguageIdTextBox = ({
   languageId,
+  languageName,
   updateLanguageId
 }) => {
   return (
@@ -27,7 +28,7 @@ const LanguageIdTextBox = ({
           </div>
         }
         onChange={e => updateLanguageId(e.target.value)}
-        autoFocus={languageId === "" ? true : false }
+        autoFocus={languageId === "" && languageName.length > 0 ? true : false}
       />
     </div>
   );
@@ -35,6 +36,7 @@ const LanguageIdTextBox = ({
 
 LanguageIdTextBox.propTypes = {
   languageId: PropTypes.string.isRequired,
+  languageName: PropTypes.string.isRequired,
   updateLanguageId: PropTypes.func.isRequired
 };
 

--- a/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/LanguageNameTextBox.js
@@ -27,7 +27,7 @@ const LanguageNameTextBox = ({
           </div>
         }
         onChange={e => updateLanguageName(e.target.value)}
-        autoFocus={languageName === "" ? true : false }
+        autoFocus={languageName.length === 0 ? true : false}
       />
     </div>
   );

--- a/src/js/components/projectValidation/ProjectInformationCheck/index.js
+++ b/src/js/components/projectValidation/ProjectInformationCheck/index.js
@@ -10,21 +10,6 @@ import ContributorsArea from './ContributorsArea';
 import CheckersArea from './CheckersArea';
 
 class ProjectInformationCheck extends Component {
-  componentWillMount() {
-    let {
-      translators,
-      checkers,
-      project,
-      target_language
-    } = this.props.reducers.projectDetailsReducer.manifest;
-
-    this.props.actions.setBookIDInProjectInformationReducer(project.id ? project.id : '');
-    this.props.actions.setLanguageIdInProjectInformationReducer(target_language.id ? target_language.id : '');
-    this.props.actions.setLanguageNameInProjectInformationReducer(target_language.name ? target_language.name : '');
-    this.props.actions.setLanguageDirectionInProjectInformationReducer(target_language.direction ? target_language.direction : '');
-    this.props.actions.setContributorsInProjectInformationReducer(translators && translators.length > 0 ? translators : []);
-    this.props.actions.setCheckersInProjectInformationReducer(checkers && checkers.length > 0 ? checkers : []);
-  }
 
   componentDidMount() {
     this.props.actions.changeProjectValidationInstructions(
@@ -119,6 +104,7 @@ class ProjectInformationCheck extends Component {
                 <td style={{ padding: '0px 0px 0px 120px' }}>
                   <LanguageIdTextBox
                     languageId={languageId}
+                    languageName={languageName}
                     updateLanguageId={(languageId) => this.props.actions.setLanguageIdInProjectInformationReducer(languageId)}
                   />
                 </td>


### PR DESCRIPTION
#### This pull request addresses:

- Changed when we populate data to the project information reducer because it was causing weird behaviors in the order props were being propagated.
- Set up the proper order for autofocus for the language name & Id components.


#### How to test this pull request:
- Open a project that is missing the project name (it should autofocus on that empty field).
- Open a project that is missing the project id (it should autofocus on that empty field).
- Open a project that is missing both the project name and id (it should autofocus on the project name field).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2989)
<!-- Reviewable:end -->
