### PR TITLE
Fix alert button

### DIFF
--- a/src/js/actions/CopyrightCheckActions.js
+++ b/src/js/actions/CopyrightCheckActions.js
@@ -49,7 +49,7 @@ export function finalize() {
             dispatch(BodyUIActions.goToStep(2));
             dispatch({ type: consts.RESET_PROJECT_DETAIL });
           },
-          'Cancel Import'
+          'Cancel'
         )
       );
     }


### PR DESCRIPTION

#### This pull request addresses:

Wrong verbiage on alert button after selecting None of the Above on the licensing screen #2948


#### How to test this pull request:

Import a Titus project, and then select it, then select "None of the Above" on the licensing screen.  You will see the warning screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2991)
<!-- Reviewable:end -->
