### PR TITLE
Show the full file path and name on import project error alert

### DIFF
--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -79,7 +79,8 @@ function verifyProject(sourcePath, url) {
     if (!sourcePath) return reject(`Unable to load selected project at ${sourcePath}, please choose another.`);
     const fileNameSplit = path.parse(sourcePath).base.split('.') || [''];
     const fileName = fileNameSplit[0];
-    if (!fileName) return reject(`Problem getting project path at ${sourcePath}`);
+    if (!fileName) return reject(`Problem getting path at ${fileName}.\n
+    Please select another.`);
 
     if (path.extname(sourcePath) === '.tstudio') {
       /** Must unzip before the file before project structure is verified */
@@ -90,8 +91,8 @@ function verifyProject(sourcePath, url) {
         zip.extractAllTo(DEFAULT_SAVE, /*overwrite*/true);
         tSProject = true;
       } else {
-        return reject(`A project with the name ${fileName} already exists. Reimporting
-           existing projects is not currently supported. Check project at ${sourcePath}`);
+        return reject(`The project you selected (${sourcePath}) already exists.\n
+        Reimporting existing projects is not currently supported.`);
       }
     }
 
@@ -107,8 +108,8 @@ function verifyProject(sourcePath, url) {
       if (!alreadyImported && homeFolderPath) {
         return resolve({ newProjectPath: homeFolderPath, type: 'usfm' });
       } else if (alreadyImported && homeFolderPath) {
-        return reject(`The project you selected already exists.\
-        Reimporting existing projects is not currently supported. Check project at ${sourcePath}`);
+        return reject(`The project you selected (${sourcePath}) already exists.\n
+        Reimporting existing projects is not currently supported.`);
       }
     }
     /** Projects here should be tC fromatted */
@@ -117,8 +118,8 @@ function verifyProject(sourcePath, url) {
       if (!usfmFilePath && !url && !tSProject) {
         if (!LoadHelpers.projectAlreadyExists(newProjectPath, sourcePath))
           fs.copySync(sourcePath, newProjectPath);
-        else return reject('The project you selected already exists.\
-      Reimporting existing projects is not currently supported.');
+        else return reject(`The project you selected (${sourcePath}) already exists.\n
+        Reimporting existing projects is not currently supported.`);
       }
       return resolve({ newProjectPath, type: 'tC' });
     }).catch(reject);
@@ -148,10 +149,12 @@ function detectInvalidProjectStructure(sourcePath) {
           //Project manifest is valid, not checking for book id because it can be fixed later
           return resolve();
         } else {
-          return reject(`Project manifest invalid. Check project at ${sourcePath}`);
+          return reject(`The project you selected has an invalid manifest (${sourcePath})\n
+          Please select a new project.`);
         }
       } else {
-        return reject(`No valid manifest found in project. Check project at ${sourcePath}`);
+        return reject(`No manifest found for the selected project (${sourcePath})\n
+        Please select a new project.`);
       }
     }
   });

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -76,11 +76,18 @@ export function verifyAndSelectProject(sourcePath, url) {
 function verifyProject(sourcePath, url) {
   return new Promise((resolve, reject) => {
     let tSProject = false;
-    if (!sourcePath) return reject(`Unable to load selected project at ${sourcePath}, please choose another.`);
+    if (!sourcePath) return reject(
+      <div>Unable to load selected project at {sourcePath}
+        <br />Please choose another project.
+    </div>
+    );
     const fileNameSplit = path.parse(sourcePath).base.split('.') || [''];
     const fileName = fileNameSplit[0];
-    if (!fileName) return reject(`Problem getting path at ${fileName}.\n
-    Please select another.`);
+    if (!fileName) return reject(
+      <div>
+        Problem getting path at {fileName}.
+        <br />Please select another project.
+  </div>);
 
     if (path.extname(sourcePath) === '.tstudio') {
       /** Must unzip before the file before project structure is verified */
@@ -91,8 +98,10 @@ function verifyProject(sourcePath, url) {
         zip.extractAllTo(DEFAULT_SAVE, /*overwrite*/true);
         tSProject = true;
       } else {
-        return reject(`The project you selected (${sourcePath}) already exists.\n
-        Reimporting existing projects is not currently supported.`);
+        return reject(
+          <div>The project you selected ({sourcePath}) already exists.<br />
+            Reimporting existing projects is not currently supported.
+      </div>);
       }
     }
 
@@ -108,8 +117,11 @@ function verifyProject(sourcePath, url) {
       if (!alreadyImported && homeFolderPath) {
         return resolve({ newProjectPath: homeFolderPath, type: 'usfm' });
       } else if (alreadyImported && homeFolderPath) {
-        return reject(`The project you selected (${sourcePath}) already exists.\n
-        Reimporting existing projects is not currently supported.`);
+        return reject(
+          <div>
+            The project you selected ({sourcePath}) already exists.<br />
+            Reimporting existing projects is not currently supported.
+      </div>);
       }
     }
     /** Projects here should be tC fromatted */
@@ -118,8 +130,12 @@ function verifyProject(sourcePath, url) {
       if (!usfmFilePath && !url && !tSProject) {
         if (!LoadHelpers.projectAlreadyExists(newProjectPath, sourcePath))
           fs.copySync(sourcePath, newProjectPath);
-        else return reject(`The project you selected (${sourcePath}) already exists.\n
-        Reimporting existing projects is not currently supported.`);
+        else return reject(
+          <div>
+            The project you selected ({sourcePath}) already exists.<br />
+            Reimporting existing projects is not currently supported.
+      </div>
+        );
       }
       return resolve({ newProjectPath, type: 'tC' });
     }).catch(reject);
@@ -149,12 +165,18 @@ function detectInvalidProjectStructure(sourcePath) {
           //Project manifest is valid, not checking for book id because it can be fixed later
           return resolve();
         } else {
-          return reject(`The project you selected has an invalid manifest (${sourcePath})\n
-          Please select a new project.`);
+          return reject(
+            <div>The project you selected has an invalid manifest ({sourcePath})
+            <br />Please select a new project.
+        </div>
+          );
         }
       } else {
-        return reject(`No manifest found for the selected project (${sourcePath})\n
-        Please select a new project.`);
+        return reject(
+          <div>No manifest found for the selected project ({sourcePath})
+           <br />Please select a new project.
+          </div>
+        );
       }
     }
   });

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -76,10 +76,10 @@ export function verifyAndSelectProject(sourcePath, url) {
 function verifyProject(sourcePath, url) {
   return new Promise((resolve, reject) => {
     let tSProject = false;
-    if (!sourcePath) return reject('Unable to load selected project, please choose another.');
+    if (!sourcePath) return reject(`Unable to load selected project at ${sourcePath}, please choose another.`);
     const fileNameSplit = path.parse(sourcePath).base.split('.') || [''];
     const fileName = fileNameSplit[0];
-    if (!fileName) return reject('Problem getting project path');
+    if (!fileName) return reject(`Problem getting project path at ${sourcePath}`);
 
     if (path.extname(sourcePath) === '.tstudio') {
       /** Must unzip before the file before project structure is verified */
@@ -91,7 +91,7 @@ function verifyProject(sourcePath, url) {
         tSProject = true;
       } else {
         return reject(`A project with the name ${fileName} already exists. Reimporting
-           existing projects is not currently supported.`);
+           existing projects is not currently supported. Check project at ${sourcePath}`);
       }
     }
 
@@ -107,8 +107,8 @@ function verifyProject(sourcePath, url) {
       if (!alreadyImported && homeFolderPath) {
         return resolve({ newProjectPath: homeFolderPath, type: 'usfm' });
       } else if (alreadyImported && homeFolderPath) {
-        return reject('The project you selected already exists.\
-        Reimporting existing projects is not currently supported.');
+        return reject(`The project you selected already exists.\
+        Reimporting existing projects is not currently supported. Check project at ${sourcePath}`);
       }
     }
     /** Projects here should be tC fromatted */
@@ -148,10 +148,10 @@ function detectInvalidProjectStructure(sourcePath) {
           //Project manifest is valid, not checking for book id because it can be fixed later
           return resolve();
         } else {
-          return reject('Project manifest invalid.');
+          return reject(`Project manifest invalid. Check project at ${sourcePath}`);
         }
       } else {
-        return reject('No valid manifest found in project.');
+        return reject(`No valid manifest found in project. Check project at ${sourcePath}`);
       }
     }
   });

--- a/src/js/helpers/updateManifest.js
+++ b/src/js/helpers/updateManifest.js
@@ -15,7 +15,7 @@ export function updateManifest(projectPath, remoteLink, showAlert) {
       if (err !== null) console.error(err);
     });
   } catch (err) {
-    showAlert("There's something wrong with your project's files.");
+    showAlert(`There's something wrong with your project's files. Check project at ${projectPath}`);
     console.error(err);
   }
 }

--- a/src/js/helpers/updateManifest.js
+++ b/src/js/helpers/updateManifest.js
@@ -15,7 +15,7 @@ export function updateManifest(projectPath, remoteLink, showAlert) {
       if (err !== null) console.error(err);
     });
   } catch (err) {
-    showAlert(`There's something wrong with your project's files. Check project at ${projectPath}`);
+    showAlert("There's something wrong with your project's files.");
     console.error(err);
   }
 }


### PR DESCRIPTION
#### This pull request addresses:
This PR fixes the import alert messages to include the full path


#### How to test this pull request:
Try importing a project with error and make sure the full path to the selected project is shown.
A few ways to get this error to show is
Use an invalid manifest, use a project with no manifest, or try importing a project that has already been imported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/2998)
<!-- Reviewable:end -->
