### PR TITLE
Fix - #2264 - Refactor Verbiage on Tool Cards

### DIFF
--- a/__tests__/ProjectCard.test.js
+++ b/__tests__/ProjectCard.test.js
@@ -23,7 +23,7 @@ describe('Test ProjectCard component',()=>{
     };
     const actions = {
       selectProject: (projectPath) => {
-        dispatch(ProjectSelectionActions.selectProject(projectPath));
+        return null;
       }
     };
     const renderedValue =  renderer.create(

--- a/__tests__/ProjectCard.test.js
+++ b/__tests__/ProjectCard.test.js
@@ -23,7 +23,7 @@ describe('Test ProjectCard component',()=>{
     };
     const actions = {
       selectProject: (projectPath) => {
-        return null;
+        dispatch(ProjectSelectionActions.selectProject(projectPath));
       }
     };
     const renderedValue =  renderer.create(

--- a/__tests__/ToolCard.test.js
+++ b/__tests__/ToolCard.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+
+import React from 'react';
+import ToolCard from '../src/js/components/home/toolsManagement/ToolCard';
+import renderer from 'react-test-renderer';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import consts from '../src/js/actions/ActionTypes';
+
+jest.mock('../src/js/components/home/toolsManagement/ToolCardProgress', () => 'ToolCardProgress');
+
+// Tests for ToolCard React Component
+describe('Test ToolCard component',()=>{
+  test('Comparing ToolCard Component render with snapshot taken 11/07/2017 in __snapshots__ should match', () => {
+    const props = {
+      loggedInUser: true,
+      currentProjectToolsProgress: {
+        test: 100
+      },
+      metadata: {
+        toolName: 'test'
+      },
+      actions: {
+        getProjectProgressForTools: (toolName) => {
+          return () => {
+            return {
+              type: consts.SET_PROJECT_PROGRESS_FOR_TOOL,
+              toolName,
+              progress: 100
+            };
+          };
+        }
+      }
+    };
+    const renderedValue =  renderer.create(
+      <MuiThemeProvider>
+        <ToolCard {...props} />
+      </MuiThemeProvider>
+    ).toJSON();
+    expect(renderedValue).toMatchSnapshot();
+  });
+});

--- a/__tests__/ToolCard.test.js
+++ b/__tests__/ToolCard.test.js
@@ -14,21 +14,13 @@ describe('Test ToolCard component',()=>{
     const props = {
       loggedInUser: true,
       currentProjectToolsProgress: {
-        test: 100
+        test: 0.5
       },
       metadata: {
-        toolName: 'test'
+        name: 'test'
       },
       actions: {
-        getProjectProgressForTools: (toolName) => {
-          return () => {
-            return {
-              type: consts.SET_PROJECT_PROGRESS_FOR_TOOL,
-              toolName,
-              progress: 100
-            };
-          };
-        }
+        getProjectProgressForTools: () => jest.fn()
       }
     };
     const renderedValue =  renderer.create(

--- a/__tests__/ToolCardProgress.test.js
+++ b/__tests__/ToolCardProgress.test.js
@@ -25,4 +25,24 @@ describe('Test ToolCardProgress component',()=>{
     expect(result.props.options.text.style.width).toBe('100%');
     expect(result.props.options.text.style.color).toBe('#000');
   });
+
+  test('Test progress=1.01, which should  not happen, but should keep everything at 100%', () => {
+    const progress = 1.01;
+    const renderer = new ShallowRenderer();
+    renderer.render(<ToolCardProgress progress={progress} />);
+    const result = renderer.getRenderOutput();
+    expect(result.props.options.text.value).toBe('100%');
+    expect(result.props.options.text.style.width).toBe('100%');
+    expect(result.props.options.text.style.color).toBe('#fff');
+  });
+
+  test('Test progress=-0.01, which should  not happen, but should keep everything at 0%', () => {
+    const progress = -0.01;
+    const renderer = new ShallowRenderer();
+    renderer.render(<ToolCardProgress progress={progress} />);
+    const result = renderer.getRenderOutput();
+    expect(result.props.options.text.value).toBe('0%');
+    expect(result.props.options.text.style.width).toBe('100%');
+    expect(result.props.options.text.style.color).toBe('#000');
+  });
 });

--- a/__tests__/ToolCardProgress.test.js
+++ b/__tests__/ToolCardProgress.test.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+
+import React from 'react';
+import ToolCardProgress from '../src/js/components/home/toolsManagement/ToolCardProgress';
+import ShallowRenderer from 'react-test-renderer/shallow'; // ES6
+
+// Tests for ToolCardProgress React Component
+describe('Test ToolCardProgress component',()=>{
+  test('Test progress=.50 to be white text, width of 50% and value of 50%', () => {
+    const progress = .50;
+    const renderer = new ShallowRenderer();
+    renderer.render(<ToolCardProgress progress={progress} />);
+    const result = renderer.getRenderOutput();
+    expect(result.props.options.text.value).toBe('50%');
+    expect(result.props.options.text.style.width).toBe('50%');
+    expect(result.props.options.text.style.color).toBe('#fff');
+  });
+
+  test('Test progress=.20 to be black text, width of 100% and value of 20%', () => {
+    const progress = .20;
+    const renderer = new ShallowRenderer();
+    renderer.render(<ToolCardProgress progress={progress} />);
+    const result = renderer.getRenderOutput();
+    expect(result.props.options.text.value).toBe('20%');
+    expect(result.props.options.text.style.width).toBe('100%');
+    expect(result.props.options.text.style.color).toBe('#000');
+  });
+});

--- a/__tests__/__snapshots__/ToolCard.test.js.snap
+++ b/__tests__/__snapshots__/ToolCard.test.js.snap
@@ -84,7 +84,7 @@ exports[`Test ToolCard component Comparing ToolCard Component render with snapsh
     </div>
     <br />
     <ToolCardProgress
-      progress={0}
+      progress={0.5}
     />
     <div />
     <div

--- a/__tests__/__snapshots__/ToolCard.test.js.snap
+++ b/__tests__/__snapshots__/ToolCard.test.js.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test ToolCard component Comparing ToolCard Component render with snapshot taken 11/07/2017 in __snapshots__ should match 1`] = `
+<div
+  style={
+    Object {
+      "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+      "backgroundColor": "#ffffff",
+      "borderRadius": 2,
+      "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
+         0 1px 4px rgba(0, 0, 0, 0.12)",
+      "boxSizing": "border-box",
+      "color": "rgba(0, 0, 0, 0.87)",
+      "fontFamily": "Roboto, sans-serif",
+      "margin": "6px 0px 10px",
+      "muiPrepared": true,
+      "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+      "zIndex": 1,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "paddingBottom": 0,
+      }
+    }
+  >
+    <img
+      src={undefined}
+      style={
+        Object {
+          "float": "left",
+          "height": "90px",
+          "margin": "10px",
+        }
+      }
+    />
+    <div
+      style={
+        Object {
+          "boxSizing": "border-box",
+          "fontWeight": 500,
+          "muiPrepared": true,
+          "padding": 16,
+          "position": "relative",
+          "whiteSpace": "nowrap",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "muiPrepared": true,
+            "paddingRight": "90px",
+            "verticalAlign": "top",
+            "whiteSpace": "normal",
+          }
+        }
+      >
+        <span
+          style={
+            Object {
+              "color": "rgba(0, 0, 0, 0.87)",
+              "display": "block",
+              "fontSize": 15,
+              "fontWeight": "bold",
+              "muiPrepared": true,
+            }
+          }
+        />
+        <span
+          style={
+            Object {
+              "color": "rgba(0, 0, 0, 0.54)",
+              "display": "block",
+              "fontSize": 14,
+              "muiPrepared": true,
+            }
+          }
+        />
+      </div>
+    </div>
+    <br />
+    <ToolCardProgress
+      progress={0}
+    />
+    <span
+      style={
+        Object {
+          "fontSize": "16px",
+          "fontWeight": "bold",
+          "margin": "0px 10px 10px",
+        }
+      }
+    >
+      Description
+    </span>
+    <div />
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "fontSize": "18px",
+            "padding": "10px 10px 0px",
+          }
+        }
+      >
+        <span>
+          See more
+        </span>
+        <span
+          className="glyphicon glyphicon-chevron-down"
+          style={
+            Object {
+              "fontSize": "18px",
+              "margin": "0px 0px 0px 6px",
+            }
+          }
+        />
+      </div>
+      <button
+        className="btn-prime"
+        onClick={[Function]}
+        style={
+          Object {
+            "margin": "10px",
+            "width": "90px",
+          }
+        }
+      >
+        Launch
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/__tests__/__snapshots__/ToolCard.test.js.snap
+++ b/__tests__/__snapshots__/ToolCard.test.js.snap
@@ -86,17 +86,6 @@ exports[`Test ToolCard component Comparing ToolCard Component render with snapsh
     <ToolCardProgress
       progress={0}
     />
-    <span
-      style={
-        Object {
-          "fontSize": "16px",
-          "fontWeight": "bold",
-          "margin": "0px 10px 10px",
-        }
-      }
-    >
-      Description
-    </span>
     <div />
     <div
       style={

--- a/src/js/components/home/toolsManagement/ToolCard.js
+++ b/src/js/components/home/toolsManagement/ToolCard.js
@@ -36,11 +36,13 @@ export default class ToolsCard extends Component {
             subtitle={version}
           /><br />
           <ToolCardProgress progress={progress} />
-          <span style={{ fontWeight: "bold", fontSize: "16px", margin: "0px 10px 10px" }}>Description</span>
           {this.state.showDescription ? 
-            (<p style={{ padding: "10px" }}>
+            (<div>
+              <span style={{ fontWeight: "bold", fontSize: "16px", margin: "0px 10px 10px" }}>Description</span>
+              <p style={{ padding: "10px" }}>
               {description}
-            </p>) : (<div />)
+              </p>
+            </div>) : (<div />)
           }
           <div style={{ display: "flex", justifyContent: "space-between" }}>
             <div

--- a/src/js/components/home/toolsManagement/ToolCardProgress.js
+++ b/src/js/components/home/toolsManagement/ToolCardProgress.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { Line } from 'react-progressbar.js';
 
 const ToolCardProgress = ({ progress }) => {
+  if(progress > 1)
+    progress = 1;
+  else if(progress < 0)
+    progress = 0;
   const progressPercentage = (progress * 100).toFixed() + '%';
   const strokeColor = 'var(--accent-color-dark)';
   let textColor = '#000';

--- a/src/js/components/home/toolsManagement/ToolCardProgress.js
+++ b/src/js/components/home/toolsManagement/ToolCardProgress.js
@@ -3,18 +3,39 @@ import PropTypes from 'prop-types';
 import { Line } from 'react-progressbar.js';
 
 const ToolCardProgress = ({ progress }) => {
+  const progressPercentage = (progress * 100).toFixed() + '%';
+  const strokeColor = 'var(--accent-color-dark)';
+  let textColor = '#000';
+  let textContainerWidth = '100%';
+  if(progress >= .25) {
+    textColor = '#fff';
+    textContainerWidth = progressPercentage;
+  }
   const options = {
-    strokeWidth: 1, easing: 'easeInOut', duration: 1000,
-    color: 'var(--accent-color-dark)', trailColor: 'var(--background-color-light)',
-    trailWidth: 1, svgStyle: {width: '100%', height: '100%'}
+    strokeWidth: 1, 
+    easing: 'easeInOut', 
+    duration: 1000,
+    color: strokeColor,
+    trailColor: 'var(--background-color-light)',
+    trailWidth: 1, 
+    svgStyle: {width: '100%', height: '100%'},
+    text: {
+      value: progressPercentage,
+      style: {
+        color: textColor,
+        position: 'absolute',
+        top: 0,
+        width: textContainerWidth,
+        textAlign: 'center',
+        marginTop: '-2px'
+      }
+    }
   };
   const containerStyle = { margin: "18px 10px 10px", height: '20px', border: '2px solid var(--accent-color-dark)' };
-  let progressPercentage = progress * 100 ;
 
   return (
     <Line
       progress={progress}
-      text={progressPercentage.toFixed() + '%'}
       options={options}
       initialAnimate={true}
       containerStyle={containerStyle}


### PR DESCRIPTION
#### This pull request addresses:

- Moving the "Description" table on a Tool Card into the "See more" section since that is where the description is.

- Making sure the percentage text in a Tool Card's progress meter (Tools Management page) is readable, that is, < 25% should be black and in the middle, > 25% should be white and position in the middle of the filled in part of the progress bar.

#### How to test this pull request:

- Go to a project's tool selection and verify that "Description" is not visible unless you click "See more"

- Either complete some of tW or WA to see the progress before/after 25%, or edit ToolCardProgress.js and after line 5 add ```  progress = Math.random();```, then start up the app, go to a project's tool page and click the Tool tab over and over to see different percentages in the progress bar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3135)
<!-- Reviewable:end -->
