### PR TITLE
Fix - #2297 - Fixes issues that failed in QA

### DIFF
--- a/__tests__/ProjectCard.test.js
+++ b/__tests__/ProjectCard.test.js
@@ -3,36 +3,33 @@
 import React from 'react';
 import ProjectCard from '../src/js/components/home/projectsManagement/ProjectCard';
 import renderer from 'react-test-renderer';
-import * as ProjectSelectionActions from '../src/js/actions/ProjectSelectionActions';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 // Tests for ProjectCard React Component
 describe('Test ProjectCard component',()=>{
   test('Comparing ProjectCard Component render with snapshot taken 11/06/2017 in __snapshots__ should match', () => {
-    const projectDetails = {
-      projectName: 'en_1co_ulb', 
-      projectSaveLocation: '/tmp/en_1co_ulb', 
-      accessTimeAgo: '5 days ago', 
-      bookAbbr: '1co', 
-      bookName: '1 Corinthians', 
-      target_language: {
-        id: 'en',
-        name: 'English'
-      }, 
-      isSelected: false
-    };
-    const actions = {
-      selectProject: (projectPath) => {
-        dispatch(ProjectSelectionActions.selectProject(projectPath));
+    const props = {
+      user: "johndoe", 
+      key: "en_1co", 
+      projectDetails: {
+        projectName: 'en_1co_ulb', 
+        projectSaveLocation: '/tmp/en_1co_ulb', 
+        accessTimeAgo: '5 days ago', 
+        bookAbbr: '1co', 
+        bookName: '1 Corinthians', 
+        target_language: {
+          id: 'en',
+          name: 'English'
+        }, 
+        isSelected: false
+      },
+      actions: {
+        selectProject: () => jest.fn()
       }
     };
     const renderedValue =  renderer.create(
       <MuiThemeProvider>
-        <ProjectCard 
-          user={"johndoe"} 
-          key={"en_1co"} 
-          projectDetails={projectDetails} 
-          actions={actions} />
+        <ProjectCard {...props} />
       </MuiThemeProvider>
     ).toJSON();
     expect(renderedValue).toMatchSnapshot();

--- a/__tests__/__snapshots__/ProjectCard.test.js.snap
+++ b/__tests__/__snapshots__/ProjectCard.test.js.snap
@@ -106,6 +106,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                     <td
                       style={
                         Object {
+                          "verticalAlign": "top",
                           "width": "30%",
                         }
                       }
@@ -122,6 +123,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                             <td
                               style={
                                 Object {
+                                  "verticalAlign": "top",
                                   "width": "1px",
                                 }
                               }
@@ -136,7 +138,14 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                                 }
                               />
                             </td>
-                            <td>
+                            <td
+                              style={
+                                Object {
+                                  "paddingRight": "3px",
+                                  "verticalAlign": "top",
+                                }
+                              }
+                            >
                               5 days ago
                             </td>
                           </tr>
@@ -146,6 +155,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                     <td
                       style={
                         Object {
+                          "verticalAlign": "top",
                           "width": "30%",
                         }
                       }
@@ -162,6 +172,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                             <td
                               style={
                                 Object {
+                                  "verticalAlign": "top",
                                   "width": "1px",
                                 }
                               }
@@ -176,7 +187,14 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                                 }
                               />
                             </td>
-                            <td>
+                            <td
+                              style={
+                                Object {
+                                  "paddingRight": "3px",
+                                  "verticalAlign": "top",
+                                }
+                              }
+                            >
                               1 Corinthians (1co)
                             </td>
                           </tr>
@@ -186,6 +204,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                     <td
                       style={
                         Object {
+                          "verticalAlign": "top",
                           "width": "40%",
                         }
                       }
@@ -202,6 +221,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                             <td
                               style={
                                 Object {
+                                  "verticalAlign": "top",
                                   "width": "1px",
                                 }
                               }
@@ -216,7 +236,14 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render with 
                                 }
                               />
                             </td>
-                            <td>
+                            <td
+                              style={
+                                Object {
+                                  "paddingRight": "3px",
+                                  "verticalAlign": "top",
+                                }
+                              }
+                            >
                               English (en)
                             </td>
                           </tr>

--- a/src/js/components/home/projectsManagement/ProjectCard.js
+++ b/src/js/components/home/projectsManagement/ProjectCard.js
@@ -38,7 +38,7 @@ let ProjectCard = (props) => {
           }}> {projectName} </strong>
         </Hint>
         <div style={{ display: 'flex', justifyContent: 'space-between', width: '410px', marginBottom: '6px' }}>
-          <table style={{width: "100%"}}>
+          <table style={{width: '100%'}}>
             <tbody>
               <tr>
               {
@@ -46,7 +46,7 @@ let ProjectCard = (props) => {
                   let width;
                   switch(cardDetail.glyph){
                     case 'globe':
-                      width = "40%";
+                      width = '40%';
                       break;
                     case 'time':
                     case 'book':
@@ -55,14 +55,14 @@ let ProjectCard = (props) => {
                       break;
                   }
                   return (
-                    <td style={{width: width}} key={cardDetail.glyph}>
-                      <table style={{width: "100%"}}>
+                    <td style={{width: width, verticalAlign: 'top'}} key={cardDetail.glyph}>
+                      <table style={{width: '100%'}}>
                         <tbody>
                           <tr>
-                            <td style={{width: "1px"}}>
+                            <td style={{width: '1px', verticalAlign: 'top'}}>
                               <Glyphicon glyph={cardDetail.glyph} style={{ marginRight: '5px', top: '2px' }} />
                             </td>
-                            <td>
+                            <td style={{verticalAlign: 'top', paddingRight: '3px'}}>
                               {cardDetail.text}
                             </td>
                           </tr>


### PR DESCRIPTION
#### This pull request addresses:

The vertical alignment of the icon in the project card should not be at the top if more than one line, and there should be padding between each column.


#### How to test this pull request:

Go to the project page and add multiple projects with different languages and books. A project for Ephesians should have (eph) wrapped to the second line, rather than being smashed against the language (word) icon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3138)
<!-- Reviewable:end -->
