### PR TITLE
Fixed Space In USFM Filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15258,9 +15258,9 @@
       }
     },
     "usfm-js": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.14.tgz",
-      "integrity": "sha512-9dS0wWQbjgHNF+9swfy3SKF9IXgs2RScad2kyQU5CFDCXilTzSD7Mt4STsTbOk07GseZQONTIz7kN0a6bEtjYg==",
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.15.tgz",
+      "integrity": "sha512-bXlPkO3a8Trzo3FB6N0UzHvzFHOnBTkxF0B7HYCuFWla9Nwpt+w2o+wg9SDdpYNx8w2t0SXuztySFAaTnfLlbQ==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rimraf": "^2.6.1",
     "simple-git": "1.43.0",
     "sudo-prompt": "^6.2.1",
-    "usfm-js": "^1.0.0-beta.14",
+    "usfm-js": "^1.0.0-beta.15",
     "xregexp": "^3.2.0",
     "yamljs": "^0.3.0",
     "zip-folder": "^1.0.0"


### PR DESCRIPTION
#### This pull request addresses:
This PR updates the usfm library that has fixes for the regex filtering out footnotes


#### How to test this pull request:
##### Make sure to run ```npm install```
Try the use cases in the story and assure the footnotes are getting filtered correctly and removing one too many spaces.
i.e.
tW Eph Christ check 5:14
tW Php amen 4:23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3162)
<!-- Reviewable:end -->
