### PR TITLE
Strip Leading/Trailing Spaces on Door43 URL

### DIFF
--- a/__tests__/ImportOnlineActions.test.js
+++ b/__tests__/ImportOnlineActions.test.js
@@ -1,0 +1,30 @@
+jest.unmock('fs-extra');
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as ImportOnlineActions from '../src/js/actions/ImportOnlineActions';
+import { importOnlineProjectFromUrl } from '../src/js/helpers/LoadOnlineHelpers';
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+jest.mock('../src/js/helpers/LoadOnlineHelpers', () => ({ importOnlineProjectFromUrl: jest.fn() }));
+
+describe('ImportOnlineActions.importOnlineProject', () => {
+  let initialState = {};
+
+  beforeEach(() => {
+    initialState = {
+      importOnlineReducer: {
+        importLink: ' https://git.door43.org/royalsix/es-419_tit_text_ulb '
+      },
+      settingsReducer: {
+        onlineMode: true
+      }
+    };
+  });
+
+  it('should import a project that has whitespace in string', () => {
+    const store = mockStore(initialState);
+    store.dispatch(ImportOnlineActions.importOnlineProject());
+    expect(importOnlineProjectFromUrl.mock.calls.length).toBe(1);
+    expect(importOnlineProjectFromUrl.mock.calls[0][0]).toBe('https://git.door43.org/royalsix/es-419_tit_text_ulb');
+  });
+});

--- a/src/js/actions/ImportOnlineActions.js
+++ b/src/js/actions/ImportOnlineActions.js
@@ -67,7 +67,8 @@ function handleImportResults(dispatch, url, savePath, errMessage) {
  */
 export function importOnlineProject() {
   return ((dispatch, getState) => {
-    const link = getState().importOnlineReducer.importLink;
+    let link = getState().importOnlineReducer.importLink;
+    link = link.trim();
     dispatch(OnlineModeConfirmActions.confirmOnlineAction(() => {
       dispatch(
         AlertModalActions.openAlertDialog("Importing " + link + " Please wait...", true)


### PR DESCRIPTION
#### This pull request addresses:
This PR makes sure that there are no trailing or leading spaces on the door43 import url so that it can successfully import a project.


#### How to test this pull request:
Test importing a door43 project from a url and try both with leading/trailing spaces and without.
Run ```npm test```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3216)
<!-- Reviewable:end -->
