### PR TITLE
Fixed manifest.json file getting created in translationCore\Projects folder 

### DIFF
--- a/__mocks__/adm-zip.js
+++ b/__mocks__/adm-zip.js
@@ -1,0 +1,25 @@
+'use strict';
+import fs from 'fs-extra';
+import path from 'path-extra';
+// constant
+const TEMP_IMPORT_PATH = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
+
+class AdmZip {
+  constructor(sourcePath) {
+    this.sourcePath = sourcePath;
+  }
+
+  // mocking unzipping a file using fs-extra mock
+  extractAllTo(destinationPath, options) {
+    // using fs to mock saving the files in file system.
+    const fileName = this.sourcePath.split('/').pop();
+    const fileDestinationPath = path.join(destinationPath, fileName);
+    // fileDestinationPath is the path and the array is the files in the path
+    fs.__setMockFS({
+      [TEMP_IMPORT_PATH]: ['id_tit_text_ulb', 'manifest.json', '.DS_Store'],
+      [fileDestinationPath]: ['01', '02', '03', 'front', 'LICENSE.md', 'manifest.json']
+    });
+  }
+}
+
+export default AdmZip;

--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -1,7 +1,7 @@
 'use strict';
 import path from 'path-extra';
 
-const fs = jest.genMockFromModule('fs');
+const fs = jest.genMockFromModule('fs-extra');
 let mockFS = Object.create(null);
 
 
@@ -64,6 +64,16 @@ function existsSync(path) {
   return !!mockFS[path];
 }
 
+function removeSync(path) {
+  Object.keys(mockFS).forEach((element) => {
+    element.includes(path) ? delete mockFS[element] : null;
+  });
+}
+
+function copySync(srcPath, destinationPath) {
+  mockFS[destinationPath] = mockFS[srcPath];
+}
+
 fs.__setMockDirectories = __setMockDirectories;
 fs.__setMockFS = __setMockFS;
 fs.__resetMockFS = __resetMockFS;
@@ -74,5 +84,7 @@ fs.outputJsonSync = outputJsonSync;
 fs.readJsonSync = readJsonSync;
 fs.existsSync = existsSync;
 fs.outputFileSync = outputFileSync;
+fs.removeSync = removeSync;
+fs.copySync = copySync;
 
 module.exports = fs;

--- a/__tests__/ImportLocalHelpers.test.js
+++ b/__tests__/ImportLocalHelpers.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+/* eslint-disable no-console */
+'use strict';
+
+jest.mock('fs-extra');
+jest.mock('adm-zip');
+
+import fs from 'fs-extra';
+import path from 'path-extra';
+// helpers
+import * as ImportLocalHelpers from '../src/js/helpers/ImportLocalHelpers';
+
+describe('ImportLocalHelpers.importProjectAndMoveToMyProjects', () => {
+  const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore', 'projects');
+  const TEMP_IMPORT_PATH = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
+  const projectName = 'id_tit_text_ulb';
+
+  beforeEach(() => {
+    fs.__setMockFS({
+      [DEFAULT_SAVE]: [],
+      [TEMP_IMPORT_PATH]: []
+    });
+  });
+
+  test('importProjectAndMoveToMyProjects should unzip a .tstudio project and move it to projects folder', () => {
+    ImportLocalHelpers.importProjectAndMoveToMyProjects('source/path/to/project/id_tit_text_ulb', projectName);
+    const projectPath = path.join(DEFAULT_SAVE, projectName);
+    expect(fs.existsSync(projectPath)).toBeTruthy();
+  });
+
+  test('importProjectAndMoveToMyProjects should remove the unzzipped files from the imports folder', () => {
+    ImportLocalHelpers.importProjectAndMoveToMyProjects('source/path/to/project/id_tit_text_ulb', projectName);
+    const tempFilesPath = path.join(TEMP_IMPORT_PATH, projectName);
+    expect(fs.existsSync(tempFilesPath)).toBeFalsy();
+    expect(fs.existsSync(TEMP_IMPORT_PATH)).toBeFalsy();
+  });
+});

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import path from 'path-extra';
 import fs from 'fs-extra';
-import AdmZip from 'adm-zip';
 import { ipcRenderer } from 'electron';
 // actions
 import * as AlertModalActions from './AlertModalActions';
@@ -106,12 +105,10 @@ function verifyProject(sourcePath, url) {
   </div>);
 
     if (path.extname(sourcePath) === '.tstudio') {
-      /** Must unzip before project structure is verified */
-      const zip = new AdmZip(sourcePath);
       let oldPath = sourcePath;
       sourcePath = path.join(DEFAULT_SAVE, fileName);
       if (!LoadHelpers.projectAlreadyExists(sourcePath, oldPath)) {
-        ImportLocalHelpers.importProjectAndMoveToMyProjects(zip, fileName);
+        ImportLocalHelpers.importProjectAndMoveToMyProjects(oldPath, fileName);
         tSProject = true;
       } else {
         return reject(

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -13,9 +13,9 @@ import * as BodyUIActions from './BodyUIActions';
 import * as usfmHelpers from '../helpers/usfmHelpers';
 import * as LoadHelpers from '../helpers/LoadHelpers';
 import * as ProjectSelectionHelpers from '../helpers/ProjectSelectionHelpers';
+import * as ImportLocalHelpers from '../helpers/ImportLocalHelpers';
 // contstants
 const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore', 'projects');
-const TEMP_IMPORT_path = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
 
 export const ALERT_MESSAGE = (
   <div>
@@ -111,7 +111,7 @@ function verifyProject(sourcePath, url) {
       let oldPath = sourcePath;
       sourcePath = path.join(DEFAULT_SAVE, fileName);
       if (!LoadHelpers.projectAlreadyExists(sourcePath, oldPath)) {
-        importProjectAndMoveToMyProjects(zip, fileName);
+        ImportLocalHelpers.importProjectAndMoveToMyProjects(zip, fileName);
         tSProject = true;
       } else {
         return reject(
@@ -201,26 +201,3 @@ function detectInvalidProjectStructure(sourcePath) {
     }
   });
 }
-
-
-/**
- * Imports a .tStudio project to a temporary folder path in tC imports folder
- * and then moves it into my projects folder.
- * @param {Object} zip
- * @param {String} fileName
- */
-export const importProjectAndMoveToMyProjects = (zip, projectName) => {
-  // extract .tstudio project to temp folder in tC imports folder
-  zip.extractAllTo(TEMP_IMPORT_path, /*overwrite*/true);
-  // the folder name of the project inside the .studio zip file may be different from
-  // the actual name of the .studio zip file therefore get actual name from folder
-  let currentProjectName = fs.readdirSync(TEMP_IMPORT_path)
-    .filter((element) => element !== 'manifest.json' && element !== '.DS_Store')[0];
-  const srcPath = path.join(TEMP_IMPORT_path, currentProjectName);
-  // projectName is the file name of the .studio file which now allows renaming .tstudio projects
-  const destinationPath = path.join(DEFAULT_SAVE, projectName);
-  // copy project from imports folder to projects folder
-  fs.copySync(srcPath, destinationPath);
-  // remove/delete project folder from temp folder
-  fs.removeSync(TEMP_IMPORT_path);
-};

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -106,7 +106,7 @@ function verifyProject(sourcePath, url) {
   </div>);
 
     if (path.extname(sourcePath) === '.tstudio') {
-      /** Must unzip before the file before project structure is verified */
+      /** Must unzip before project structure is verified */
       const zip = new AdmZip(sourcePath);
       let oldPath = sourcePath;
       sourcePath = path.join(DEFAULT_SAVE, fileName);

--- a/src/js/actions/ImportLocalActions.js
+++ b/src/js/actions/ImportLocalActions.js
@@ -15,6 +15,8 @@ import * as LoadHelpers from '../helpers/LoadHelpers';
 import * as ProjectSelectionHelpers from '../helpers/ProjectSelectionHelpers';
 // contstants
 const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore', 'projects');
+const TEMP_IMPORT_path = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
+
 export const ALERT_MESSAGE = (
   <div>
     No file was selected. Please click on the
@@ -109,13 +111,15 @@ function verifyProject(sourcePath, url) {
       let oldPath = sourcePath;
       sourcePath = path.join(DEFAULT_SAVE, fileName);
       if (!LoadHelpers.projectAlreadyExists(sourcePath, oldPath)) {
-        zip.extractAllTo(DEFAULT_SAVE, /*overwrite*/true);
+        importProjectAndMoveToMyProjects(zip, fileName);
         tSProject = true;
       } else {
         return reject(
-          <div>The project you selected ({sourcePath}) already exists.<br />
+          <div>
+            The project you selected ({sourcePath}) already exists.<br />
             Reimporting existing projects is not currently supported.
-      </div>);
+          </div>
+        );
       }
     }
 
@@ -135,7 +139,8 @@ function verifyProject(sourcePath, url) {
           <div>
             The project you selected ({sourcePath}) already exists.<br />
             Reimporting existing projects is not currently supported.
-      </div>);
+          </div>
+        );
       }
     }
     /** Projects here should be tC fromatted */
@@ -148,7 +153,7 @@ function verifyProject(sourcePath, url) {
           <div>
             The project you selected ({sourcePath}) already exists.<br />
             Reimporting existing projects is not currently supported.
-      </div>
+          </div>
         );
       }
       return resolve({ newProjectPath, type: 'tC' });
@@ -180,9 +185,10 @@ function detectInvalidProjectStructure(sourcePath) {
           return resolve();
         } else {
           return reject(
-            <div>The project you selected has an invalid manifest ({sourcePath})
-            <br />Please select a new project.
-        </div>
+            <div>
+              The project you selected has an invalid manifest ({sourcePath})<br />
+              Please select a new project.
+            </div>
           );
         }
       } else {
@@ -195,3 +201,26 @@ function detectInvalidProjectStructure(sourcePath) {
     }
   });
 }
+
+
+/**
+ * Imports a .tStudio project to a temporary folder path in tC imports folder
+ * and then moves it into my projects folder.
+ * @param {Object} zip
+ * @param {String} fileName
+ */
+export const importProjectAndMoveToMyProjects = (zip, projectName) => {
+  // extract .tstudio project to temp folder in tC imports folder
+  zip.extractAllTo(TEMP_IMPORT_path, /*overwrite*/true);
+  // the folder name of the project inside the .studio zip file may be different from
+  // the actual name of the .studio zip file therefore get actual name from folder
+  let currentProjectName = fs.readdirSync(TEMP_IMPORT_path)
+    .filter((element) => element !== 'manifest.json' && element !== '.DS_Store')[0];
+  const srcPath = path.join(TEMP_IMPORT_path, currentProjectName);
+  // projectName is the file name of the .studio file which now allows renaming .tstudio projects
+  const destinationPath = path.join(DEFAULT_SAVE, projectName);
+  // copy project from imports folder to projects folder
+  fs.copySync(srcPath, destinationPath);
+  // remove/delete project folder from temp folder
+  fs.removeSync(TEMP_IMPORT_path);
+};

--- a/src/js/components/home/projectsManagement/MyProjects.js
+++ b/src/js/components/home/projectsManagement/MyProjects.js
@@ -4,14 +4,19 @@ import PropTypes from 'prop-types';
 import ProjectCard from './ProjectCard';
 
 let MyProjects = ({myProjects, user, actions}) => {
-  let projects = myProjects.map( (projectDetails, index) =>
+  let projects = myProjects.map((projectDetails, index) =>
     <ProjectCard user={user} key={index} projectDetails={projectDetails} actions={actions} />
   );
 
   if(myProjects.length == 0) {
-    projects.push( <p><br/><b>No projects have been found. 
-        Follow instructions at left to import a project.</b></p> );
-  } 
+    projects.push(
+      <p key={0}><br/>
+        <b>
+          No projects have been found. Follow instructions at left to import a project.
+        </b>
+      </p>
+    );
+  }
 
   return (
     <div style={{ height: '100%' }}>

--- a/src/js/helpers/ImportLocalHelpers.js
+++ b/src/js/helpers/ImportLocalHelpers.js
@@ -1,8 +1,9 @@
-import path from 'path-extra';
 import fs from 'fs-extra';
+import path from 'path-extra';
+import AdmZip from 'adm-zip';
 // contstants
 const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore', 'projects');
-const TEMP_IMPORT_path = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
+const TEMP_IMPORT_PATH = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
 
 /**
  * Imports a .tStudio project to a temporary folder path in tC imports folder
@@ -10,18 +11,20 @@ const TEMP_IMPORT_path = path.join(path.homedir(), 'translationCore', 'imports',
  * @param {Object} zip
  * @param {String} fileName
  */
-export const importProjectAndMoveToMyProjects = (zip, projectName) => {
+export const importProjectAndMoveToMyProjects = (sourcePath, projectName) => {
+  /** Must unzip before project structure is verified */
+  const zip = new AdmZip(sourcePath);
   // extract .tstudio project to temp folder in tC imports folder
-  zip.extractAllTo(TEMP_IMPORT_path, /*overwrite*/true);
+  zip.extractAllTo(TEMP_IMPORT_PATH, /*overwrite*/true);
   // the folder name of the project inside the .studio zip file may be different from
   // the actual name of the .studio zip file therefore get actual name from folder
-  let currentProjectName = fs.readdirSync(TEMP_IMPORT_path)
+  let currentProjectName = fs.readdirSync(TEMP_IMPORT_PATH)
     .filter((element) => element !== 'manifest.json' && element !== '.DS_Store')[0];
-  const srcPath = path.join(TEMP_IMPORT_path, currentProjectName);
+  const srcPath = path.join(TEMP_IMPORT_PATH, currentProjectName);
   // projectName is the file name of the .studio file which now allows renaming .tstudio projects
   const destinationPath = path.join(DEFAULT_SAVE, projectName);
   // copy project from imports folder to projects folder
   fs.copySync(srcPath, destinationPath);
   // remove/delete project folder from temp folder
-  fs.removeSync(TEMP_IMPORT_path);
+  fs.removeSync(TEMP_IMPORT_PATH);
 };

--- a/src/js/helpers/ImportLocalHelpers.js
+++ b/src/js/helpers/ImportLocalHelpers.js
@@ -1,0 +1,27 @@
+import path from 'path-extra';
+import fs from 'fs-extra';
+// contstants
+const DEFAULT_SAVE = path.join(path.homedir(), 'translationCore', 'projects');
+const TEMP_IMPORT_path = path.join(path.homedir(), 'translationCore', 'imports', 'temp');
+
+/**
+ * Imports a .tStudio project to a temporary folder path in tC imports folder
+ * and then moves it into my projects folder.
+ * @param {Object} zip
+ * @param {String} fileName
+ */
+export const importProjectAndMoveToMyProjects = (zip, projectName) => {
+  // extract .tstudio project to temp folder in tC imports folder
+  zip.extractAllTo(TEMP_IMPORT_path, /*overwrite*/true);
+  // the folder name of the project inside the .studio zip file may be different from
+  // the actual name of the .studio zip file therefore get actual name from folder
+  let currentProjectName = fs.readdirSync(TEMP_IMPORT_path)
+    .filter((element) => element !== 'manifest.json' && element !== '.DS_Store')[0];
+  const srcPath = path.join(TEMP_IMPORT_path, currentProjectName);
+  // projectName is the file name of the .studio file which now allows renaming .tstudio projects
+  const destinationPath = path.join(DEFAULT_SAVE, projectName);
+  // copy project from imports folder to projects folder
+  fs.copySync(srcPath, destinationPath);
+  // remove/delete project folder from temp folder
+  fs.removeSync(TEMP_IMPORT_path);
+};


### PR DESCRIPTION
#### This pull request addresses:

- Fixed manifest.json file getting created in translationCore\Projects folder 

#### How to test this pull request:
- verify there's no **manifest.json** file in your `projects folder`.
- Load a .studio project and it should not import a **manifest.json** file to your `projects folder`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3231)
<!-- Reviewable:end -->
