### PR TITLE
Adding initial CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3265 @@
+# Change Log
+
+## [Unreleased](https://github.com/unfoldingWord-dev/translationCore/tree/HEAD)
+
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.12...HEAD)
+
+**Implemented enhancements:**
+
+- Allow importing projects when the project's name does not match the name in the manifest the proj [\#2551](https://github.com/unfoldingWord-dev/translationCore/issues/2551)
+- Make FAB words clickable [\#2216](https://github.com/unfoldingWord-dev/translationCore/issues/2216)
+
+**Fixed bugs:**
+
+- Project opens to blank tW checking screen [\#3281](https://github.com/unfoldingWord-dev/translationCore/issues/3281)
+- Project opens to blank screen in both tW and WA [\#3062](https://github.com/unfoldingWord-dev/translationCore/issues/3062)
+- Dragging a single TopWord allows it to be dropped to an empty alignment and deletes it [\#2883](https://github.com/unfoldingWord-dev/translationCore/issues/2883)
+- AIignment data is not getting reset when importing and opening a new project [\#2881](https://github.com/unfoldingWord-dev/translationCore/issues/2881)
+- Errors when importing/opening Hindi and English Titus alignment projects [\#2855](https://github.com/unfoldingWord-dev/translationCore/issues/2855)
+- App breaks when reopening a project with alignment tool [\#2827](https://github.com/unfoldingWord-dev/translationCore/issues/2827)
+- Wrong message issued when repo is not found [\#2740](https://github.com/unfoldingWord-dev/translationCore/issues/2740)
+- Exporting a project with merge conflicts corrupts export [\#2688](https://github.com/unfoldingWord-dev/translationCore/issues/2688)
+- Problems with missing verse detection when importing tstudio projects [\#2642](https://github.com/unfoldingWord-dev/translationCore/issues/2642)
+- Search for online projects does not return results [\#2631](https://github.com/unfoldingWord-dev/translationCore/issues/2631)
+- Project Import Problems \(merge conflicts\) [\#2607](https://github.com/unfoldingWord-dev/translationCore/issues/2607)
+- Don't wrap the edit reason codes unless necessary [\#2606](https://github.com/unfoldingWord-dev/translationCore/issues/2606)
+
+**Closed issues:**
+
+- Null [\#3254](https://github.com/unfoldingWord-dev/translationCore/issues/3254)
+- Fix v0.8.1-alpha.10 white screen bug [\#3220](https://github.com/unfoldingWord-dev/translationCore/issues/3220)
+- Fix Tests Failling [\#3167](https://github.com/unfoldingWord-dev/translationCore/issues/3167)
+- Fix Tests Failing Locally [\#3147](https://github.com/unfoldingWord-dev/translationCore/issues/3147)
+- Add period to second sentence [\#3072](https://github.com/unfoldingWord-dev/translationCore/issues/3072)
+- tC should strip leading and trailing spaces on URL entered for import from Door43 [\#3039](https://github.com/unfoldingWord-dev/translationCore/issues/3039)
+- Research & Practice Writing tests [\#3032](https://github.com/unfoldingWord-dev/translationCore/issues/3032)
+- manifest.json file getting created in translationCore\Projects folder [\#2980](https://github.com/unfoldingWord-dev/translationCore/issues/2980)
+- Fix group menu bug that stops tW from rendering [\#2967](https://github.com/unfoldingWord-dev/translationCore/issues/2967)
+- No alert is displayed during the importing local files [\#2964](https://github.com/unfoldingWord-dev/translationCore/issues/2964)
+- Windows only: menu bar shows full path of the current project [\#2955](https://github.com/unfoldingWord-dev/translationCore/issues/2955)
+- Windows only: Can only view folders when importing local projects [\#2954](https://github.com/unfoldingWord-dev/translationCore/issues/2954)
+- Wrong verbiage on alert button after selecting None of the Above on the licensing screen [\#2948](https://github.com/unfoldingWord-dev/translationCore/issues/2948)
+- Set focus to the first empty required field on the project info card [\#2944](https://github.com/unfoldingWord-dev/translationCore/issues/2944)
+- version info misspelled  [\#2941](https://github.com/unfoldingWord-dev/translationCore/issues/2941)
+- Extraneous text on User card [\#2940](https://github.com/unfoldingWord-dev/translationCore/issues/2940)
+- Make it more obvious what to do after logging in when there are no existing project [\#2938](https://github.com/unfoldingWord-dev/translationCore/issues/2938)
+- Preparing Presentation In React [\#2934](https://github.com/unfoldingWord-dev/translationCore/issues/2934)
+- For Alignment Tool: display the Greek & the target language in the Scripture Pane by default [\#2911](https://github.com/unfoldingWord-dev/translationCore/issues/2911)
+- Prepare Redux presentation [\#2905](https://github.com/unfoldingWord-dev/translationCore/issues/2905)
+- Long Term Fix For USFM3 Project Loading [\#2902](https://github.com/unfoldingWord-dev/translationCore/issues/2902)
+- Make release branch `v0.8.0` [\#2893](https://github.com/unfoldingWord-dev/translationCore/issues/2893)
+- % Complete not showing in chapter circle in verse menu [\#2873](https://github.com/unfoldingWord-dev/translationCore/issues/2873)
+- Alignment tool - Automatically scroll target area to the top when moving to new verse [\#2867](https://github.com/unfoldingWord-dev/translationCore/issues/2867)
+- % complete not showing on Alignment tool card [\#2866](https://github.com/unfoldingWord-dev/translationCore/issues/2866)
+- Add "\(Current project\)" next to the project's language in the scripture pane dropdown [\#2865](https://github.com/unfoldingWord-dev/translationCore/issues/2865)
+- Project card pop up error  [\#2848](https://github.com/unfoldingWord-dev/translationCore/issues/2848)
+- Make it more obvious when the Greek text is not available [\#2843](https://github.com/unfoldingWord-dev/translationCore/issues/2843)
+- Remove one off usfm parsing and use usfm.js library [\#2821](https://github.com/unfoldingWord-dev/translationCore/issues/2821)
+- Refactor WIndows build process to create a Windows installer output [\#2808](https://github.com/unfoldingWord-dev/translationCore/issues/2808)
+- Provide a better description on the Word Alignment tool card [\#2806](https://github.com/unfoldingWord-dev/translationCore/issues/2806)
+- Refactor verbiage on log in instructions card [\#2799](https://github.com/unfoldingWord-dev/translationCore/issues/2799)
+- Update BHP \(Greek NT\) for Titus [\#2741](https://github.com/unfoldingWord-dev/translationCore/issues/2741)
+- The main tC screen should be dimmed & disabled when Finder or Explorer is open [\#2715](https://github.com/unfoldingWord-dev/translationCore/issues/2715)
+- Automatically assign CC BY-SA to projects coming from Door43 [\#2711](https://github.com/unfoldingWord-dev/translationCore/issues/2711)
+- Do not default to Select mode when the verse is blank [\#2634](https://github.com/unfoldingWord-dev/translationCore/issues/2634)
+- Reorder the result cards on the Door43 import search screen to match the search field order [\#2605](https://github.com/unfoldingWord-dev/translationCore/issues/2605)
+- Change the text on the "must be logged in with door43 account" message [\#2517](https://github.com/unfoldingWord-dev/translationCore/issues/2517)
+- Add a spinner or other method to indicate something is happening when searching for projects on Doo43 [\#2474](https://github.com/unfoldingWord-dev/translationCore/issues/2474)
+- Remove the old setup modal [\#2471](https://github.com/unfoldingWord-dev/translationCore/issues/2471)
+- Gray out \(disable\) sources that have already be loaded in Scripture Pane [\#2470](https://github.com/unfoldingWord-dev/translationCore/issues/2470)
+- Limit which files are selectable for importing locally [\#2468](https://github.com/unfoldingWord-dev/translationCore/issues/2468)
+- Solidify Mac build process [\#2417](https://github.com/unfoldingWord-dev/translationCore/issues/2417)
+- Show the full file path and name on the "There is something wrong with the project..." alert [\#2305](https://github.com/unfoldingWord-dev/translationCore/issues/2305)
+- Refactor text on project cards [\#2297](https://github.com/unfoldingWord-dev/translationCore/issues/2297)
+- Alignment Tool: Create D&D Interface for aligning words/phrases between source/target. [\#2277](https://github.com/unfoldingWord-dev/translationCore/issues/2277)
+- Refactor the verbiage on the tools cards [\#2264](https://github.com/unfoldingWord-dev/translationCore/issues/2264)
+- Inconsistent use of icons for language [\#2251](https://github.com/unfoldingWord-dev/translationCore/issues/2251)
+- Change the text wrapping format on the project card details line [\#2132](https://github.com/unfoldingWord-dev/translationCore/issues/2132)
+- Automatically set focus to username field on login dialogs [\#2130](https://github.com/unfoldingWord-dev/translationCore/issues/2130)
+- No title on expanded panels [\#1279](https://github.com/unfoldingWord-dev/translationCore/issues/1279)
+
+## [v0.8.1-alpha.12](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.12) (2017-11-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.11...v0.8.1-alpha.12)
+
+**Fixed bugs:**
+
+- Cannot import local tstudio projects on Windows [\#3061](https://github.com/unfoldingWord-dev/translationCore/issues/3061)
+- Importing tstudio project reports the last verse as missing when it is not [\#3058](https://github.com/unfoldingWord-dev/translationCore/issues/3058)
+- Bookmark switch and menu icons do not match [\#2516](https://github.com/unfoldingWord-dev/translationCore/issues/2516)
+- Inconsistencies with "Some selections have become invalid" processing [\#2293](https://github.com/unfoldingWord-dev/translationCore/issues/2293)
+
+**Closed issues:**
+
+- Round trip USFM import to Door43 to translationStudio to tstudio import does not work [\#3038](https://github.com/unfoldingWord-dev/translationCore/issues/3038)
+- When a project is selected that has missing verses, the app returns to the projects screen after running the project validation. [\#2957](https://github.com/unfoldingWord-dev/translationCore/issues/2957)
+- It takes more than 7 minutes to install and open tC on my Windows machine [\#2933](https://github.com/unfoldingWord-dev/translationCore/issues/2933)
+- Windows desktop shortcut has wrong tC icon [\#2932](https://github.com/unfoldingWord-dev/translationCore/issues/2932)
+- translationCore does not appear in the Windows app menu [\#2931](https://github.com/unfoldingWord-dev/translationCore/issues/2931)
+- Wrong Windows taskbar icon for tC [\#2930](https://github.com/unfoldingWord-dev/translationCore/issues/2930)
+- Remaining Alignment Tool issues [\#2744](https://github.com/unfoldingWord-dev/translationCore/issues/2744)
+
+**Merged pull requests:**
+
+- File Renamed  [\#3247](https://github.com/unfoldingWord-dev/translationCore/pull/3247) ([mannycolon](https://github.com/mannycolon))
+- Word Alignment: Using Verses For % Complete [\#3243](https://github.com/unfoldingWord-dev/translationCore/pull/3243) ([RoyalSix](https://github.com/RoyalSix))
+- Fixed manifest.json file getting created in translationCore\Projects folder  [\#3231](https://github.com/unfoldingWord-dev/translationCore/pull/3231) ([mannycolon](https://github.com/mannycolon))
+- QA Fail Fix - 2130 - Username now only focuses once [\#3227](https://github.com/unfoldingWord-dev/translationCore/pull/3227) ([richmahn](https://github.com/richmahn))
+
+## [v0.8.1-alpha.11](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.11) (2017-11-17)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.10...v0.8.1-alpha.11)
+
+**Merged pull requests:**
+
+- added missing babel-preset-es2015 [\#3219](https://github.com/unfoldingWord-dev/translationCore/pull/3219) ([mannycolon](https://github.com/mannycolon))
+- Strip Leading/Trailing Spaces on Door43 URL [\#3216](https://github.com/unfoldingWord-dev/translationCore/pull/3216) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.8.1-alpha.10](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.10) (2017-11-17)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.9...v0.8.1-alpha.10)
+
+## [v0.8.1-alpha.9](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.9) (2017-11-17)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.8...v0.8.1-alpha.9)
+
+**Merged pull requests:**
+
+- Fixes white screen [\#3215](https://github.com/unfoldingWord-dev/translationCore/pull/3215) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.8.1-alpha.8](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.8) (2017-11-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.7...v0.8.1-alpha.8)
+
+**Merged pull requests:**
+
+- Bugfix bspidel 2938 [\#3212](https://github.com/unfoldingWord-dev/translationCore/pull/3212) ([bspidel](https://github.com/bspidel))
+- Feature - \#2130 - Auto-focuses on the Username field of Door43 and Guest Login [\#3208](https://github.com/unfoldingWord-dev/translationCore/pull/3208) ([richmahn](https://github.com/richmahn))
+
+## [v0.8.1-alpha.7](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.7) (2017-11-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.6...v0.8.1-alpha.7)
+
+**Fixed bugs:**
+
+- Console error when changing projects [\#2124](https://github.com/unfoldingWord-dev/translationCore/issues/2124)
+
+**Closed issues:**
+
+- Clean up navigation buttons in stepper [\#2464](https://github.com/unfoldingWord-dev/translationCore/issues/2464)
+- Set up & document environment to use for devs to test on Windows [\#1848](https://github.com/unfoldingWord-dev/translationCore/issues/1848)
+- Technical Debt [\#1753](https://github.com/unfoldingWord-dev/translationCore/issues/1753)
+
+**Merged pull requests:**
+
+- added dependency install for dmg script [\#3207](https://github.com/unfoldingWord-dev/translationCore/pull/3207) ([neutrinog](https://github.com/neutrinog))
+- Bug fix/mcleanb/2715/windows import fix \(QA fail\) [\#3201](https://github.com/unfoldingWord-dev/translationCore/pull/3201) ([PhotoNomad0](https://github.com/PhotoNomad0))
+
+## [v0.8.1-alpha.6](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.6) (2017-11-15)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.5...v0.8.1-alpha.6)
+
+**Merged pull requests:**
+
+- Now assigning CC BY-SA license to projects imported from door43 [\#3166](https://github.com/unfoldingWord-dev/translationCore/pull/3166) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.8.1-alpha.5](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.5) (2017-11-15)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.4...v0.8.1-alpha.5)
+
+**Closed issues:**
+
+- Pre-Flight Check: USFM formatting Check [\#1713](https://github.com/unfoldingWord-dev/translationCore/issues/1713)
+
+**Merged pull requests:**
+
+- fixed dmg script not finding DS\_Store file [\#3202](https://github.com/unfoldingWord-dev/translationCore/pull/3202) ([neutrinog](https://github.com/neutrinog))
+- Added Fixes For Some Tests [\#3174](https://github.com/unfoldingWord-dev/translationCore/pull/3174) ([RoyalSix](https://github.com/RoyalSix))
+- Fixes For Stepper Colors [\#3156](https://github.com/unfoldingWord-dev/translationCore/pull/3156) ([RoyalSix](https://github.com/RoyalSix))
+- Improved door43 project search actions to return more results [\#3132](https://github.com/unfoldingWord-dev/translationCore/pull/3132) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.8.1-alpha.4](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.4) (2017-11-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.3...v0.8.1-alpha.4)
+
+## [v0.8.1-alpha.3](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.3) (2017-11-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.1-alpha.1...v0.8.1-alpha.3)
+
+**Implemented enhancements:**
+
+- Greek lexical information pop-up [\#689](https://github.com/unfoldingWord-dev/translationCore/issues/689)
+
+**Closed issues:**
+
+- Import aligned Hindi UDB - Titus [\#2469](https://github.com/unfoldingWord-dev/translationCore/issues/2469)
+- Complete Greek Support [\#2077](https://github.com/unfoldingWord-dev/translationCore/issues/2077)
+- Writing test for existing code [\#1775](https://github.com/unfoldingWord-dev/translationCore/issues/1775)
+
+**Merged pull requests:**
+
+- Added right commit for tW [\#3172](https://github.com/unfoldingWord-dev/translationCore/pull/3172) ([mannycolon](https://github.com/mannycolon))
+- Fixed Space In USFM Filtering [\#3162](https://github.com/unfoldingWord-dev/translationCore/pull/3162) ([RoyalSix](https://github.com/RoyalSix))
+- bugFix/3042 Fix upload bug. [\#3161](https://github.com/unfoldingWord-dev/translationCore/pull/3161) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- added .editorconfig to tC repo to maintain same editor settings among devs [\#3150](https://github.com/unfoldingWord-dev/translationCore/pull/3150) ([mannycolon](https://github.com/mannycolon))
+- Fixed Tests Passing Locally \(Project Details Bug\) [\#3149](https://github.com/unfoldingWord-dev/translationCore/pull/3149) ([RoyalSix](https://github.com/RoyalSix))
+- Improves builds [\#3146](https://github.com/unfoldingWord-dev/translationCore/pull/3146) ([neutrinog](https://github.com/neutrinog))
+- Bug fix/\#2955 windows menu bar shows full path of the current project [\#3143](https://github.com/unfoldingWord-dev/translationCore/pull/3143) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Added an 'n' to traslation [\#3141](https://github.com/unfoldingWord-dev/translationCore/pull/3141) ([bspidel](https://github.com/bspidel))
+- Bugfix bspidel 3072 [\#3140](https://github.com/unfoldingWord-dev/translationCore/pull/3140) ([bspidel](https://github.com/bspidel))
+- Fix - \#2297 - Fixes issues that failed in QA [\#3138](https://github.com/unfoldingWord-dev/translationCore/pull/3138) ([richmahn](https://github.com/richmahn))
+- Fix - \#2264 - Refactor Verbiage on Tool Cards [\#3135](https://github.com/unfoldingWord-dev/translationCore/pull/3135) ([richmahn](https://github.com/richmahn))
+- Feature/2251 Inconsistent use of icons for language [\#3134](https://github.com/unfoldingWord-dev/translationCore/pull/3134) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Feature/2468 limit which files are selectable for importing locally [\#3131](https://github.com/unfoldingWord-dev/translationCore/pull/3131) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Added Support For tStudio Single Chunks [\#3128](https://github.com/unfoldingWord-dev/translationCore/pull/3128) ([RoyalSix](https://github.com/RoyalSix))
+- Removing all text within footnotes \(and other filtered markers\) [\#3078](https://github.com/unfoldingWord-dev/translationCore/pull/3078) ([RoyalSix](https://github.com/RoyalSix))
+- Projects With Merge Conflicts Cannot Be Exported [\#3056](https://github.com/unfoldingWord-dev/translationCore/pull/3056) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.8.1-alpha.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.1-alpha.1) (2017-11-09)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.97...v0.8.1-alpha.1)
+
+**Fixed bugs:**
+
+- Clicking the Project icon in the menu bar takes the user back to the projects page with the FAB open [\#2737](https://github.com/unfoldingWord-dev/translationCore/issues/2737)
+
+**Closed issues:**
+
+- Uploaded Projects Need to Follow Door43 Registry Naming Convention [\#3129](https://github.com/unfoldingWord-dev/translationCore/issues/3129)
+- Extra warning message when opening new tC build for the second time [\#2877](https://github.com/unfoldingWord-dev/translationCore/issues/2877)
+
+**Merged pull requests:**
+
+- Disabled the linting rule and refactor extraneous html from codebase [\#3069](https://github.com/unfoldingWord-dev/translationCore/pull/3069) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.97](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.97) (2017-11-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.96...v0.7.1-beta.97)
+
+**Closed issues:**
+
+- Console error when selecting project [\#2947](https://github.com/unfoldingWord-dev/translationCore/issues/2947)
+
+**Merged pull requests:**
+
+- Fix - \#2132 & \#2297 -  Project Card column line-up and text wrapping [\#3060](https://github.com/unfoldingWord-dev/translationCore/pull/3060) ([richmahn](https://github.com/richmahn))
+- Feature \#2605/Reorder the result cards on the Door43 import search screen [\#3051](https://github.com/unfoldingWord-dev/translationCore/pull/3051) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Tests for Feature/nomad 2474 add search status indications [\#3042](https://github.com/unfoldingWord-dev/translationCore/pull/3042) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Feature - Issue \#2216 - Makes FAB words clickable [\#3028](https://github.com/unfoldingWord-dev/translationCore/pull/3028) ([richmahn](https://github.com/richmahn))
+- Percentage Complete For Word Alignment Tool [\#3013](https://github.com/unfoldingWord-dev/translationCore/pull/3013) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.96](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.96) (2017-11-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.95...v0.7.1-beta.96)
+
+**Fixed bugs:**
+
+- beta.94 builds are broken [\#3025](https://github.com/unfoldingWord-dev/translationCore/issues/3025)
+
+**Merged pull requests:**
+
+- White Screen Of Death [\#3047](https://github.com/unfoldingWord-dev/translationCore/pull/3047) ([neutrinog](https://github.com/neutrinog))
+- Search for online projects returns results [\#3026](https://github.com/unfoldingWord-dev/translationCore/pull/3026) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.95](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.95) (2017-11-01)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.94...v0.7.1-beta.95)
+
+**Closed issues:**
+
+- manifest.json file getting created in translationCore\Projects folder [\#3024](https://github.com/unfoldingWord-dev/translationCore/issues/3024)
+- "&quote" showing up on guest login alert [\#2937](https://github.com/unfoldingWord-dev/translationCore/issues/2937)
+- It takes 5 seconds to open the expanded scripture pane on Windows [\#2880](https://github.com/unfoldingWord-dev/translationCore/issues/2880)
+- Lots of console errors thrown when importing tstudio project [\#2854](https://github.com/unfoldingWord-dev/translationCore/issues/2854)
+- Gracefully Handling App Crashes And Errors [\#2702](https://github.com/unfoldingWord-dev/translationCore/issues/2702)
+- Non-Webpack build work [\#1782](https://github.com/unfoldingWord-dev/translationCore/issues/1782)
+
+**Merged pull requests:**
+
+- WIP: ImportOnlineActions - Added popup with spinner while searching. [\#3029](https://github.com/unfoldingWord-dev/translationCore/pull/3029) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Version update for build [\#3023](https://github.com/unfoldingWord-dev/translationCore/pull/3023) ([mannycolon](https://github.com/mannycolon))
+- LoadOnlineHelpers - change clone warning when repo is not found [\#3014](https://github.com/unfoldingWord-dev/translationCore/pull/3014) ([PhotoNomad0](https://github.com/PhotoNomad0))
+
+## [v0.7.1-beta.94](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.94) (2017-10-31)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.0...v0.7.1-beta.94)
+
+**Closed issues:**
+
+- Create 0.8.0 build [\#2965](https://github.com/unfoldingWord-dev/translationCore/issues/2965)
+- Project GL does not change when changing projects [\#2956](https://github.com/unfoldingWord-dev/translationCore/issues/2956)
+- Lexicon Not Showing Up In Popup Consistently [\#2897](https://github.com/unfoldingWord-dev/translationCore/issues/2897)
+- Wrong taskbar icon displayed for tC on Windows [\#2878](https://github.com/unfoldingWord-dev/translationCore/issues/2878)
+- Push tC tag into Description Field on Repo in DCS [\#2817](https://github.com/unfoldingWord-dev/translationCore/issues/2817)
+- Windows app doesn't use normal Windows installer [\#2475](https://github.com/unfoldingWord-dev/translationCore/issues/2475)
+- Refactor build process - Part 3 \(Windows\) [\#2100](https://github.com/unfoldingWord-dev/translationCore/issues/2100)
+
+**Merged pull requests:**
+
+- The main tC screen should be dimmed & disabled when Finder or Explorer is open [\#3011](https://github.com/unfoldingWord-dev/translationCore/pull/3011) ([mannycolon](https://github.com/mannycolon))
+- Show the full file path and name on import project error alert [\#2998](https://github.com/unfoldingWord-dev/translationCore/pull/2998) ([RoyalSix](https://github.com/RoyalSix))
+-  changed text message [\#2992](https://github.com/unfoldingWord-dev/translationCore/pull/2992) ([bspidel](https://github.com/bspidel))
+- Fix alert button [\#2991](https://github.com/unfoldingWord-dev/translationCore/pull/2991) ([PhotoNomad0](https://github.com/PhotoNomad0))
+- Now setting focus to the first empty required field in the project information check [\#2989](https://github.com/unfoldingWord-dev/translationCore/pull/2989) ([mannycolon](https://github.com/mannycolon))
+- Added importing alert back to local imports [\#2985](https://github.com/unfoldingWord-dev/translationCore/pull/2985) ([mannycolon](https://github.com/mannycolon))
+- Updated verbiage on log in instructions [\#2984](https://github.com/unfoldingWord-dev/translationCore/pull/2984) ([mannycolon](https://github.com/mannycolon))
+- Removed old modal files [\#2983](https://github.com/unfoldingWord-dev/translationCore/pull/2983) ([mannycolon](https://github.com/mannycolon))
+- Added USFM-JS library to target language actions [\#2976](https://github.com/unfoldingWord-dev/translationCore/pull/2976) ([mannycolon](https://github.com/mannycolon))
+- Added translationWords, Fixed Many USFM Workflow Issues [\#2971](https://github.com/unfoldingWord-dev/translationCore/pull/2971) ([RoyalSix](https://github.com/RoyalSix))
+- Fixed group menu bug with tw [\#2968](https://github.com/unfoldingWord-dev/translationCore/pull/2968) ([mannycolon](https://github.com/mannycolon))
+- Added Unit Tests [\#2960](https://github.com/unfoldingWord-dev/translationCore/pull/2960) ([neutrinog](https://github.com/neutrinog))
+- Tweaked npm scripts for managing git submodules [\#2946](https://github.com/unfoldingWord-dev/translationCore/pull/2946) ([neutrinog](https://github.com/neutrinog))
+- Windows Installation Improvements [\#2886](https://github.com/unfoldingWord-dev/translationCore/pull/2886) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.8.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.0) (2017-10-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.0-rc.2...v0.8.0)
+
+## [v0.8.0-rc.2](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.0-rc.2) (2017-10-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.93...v0.8.0-rc.2)
+
+## [v0.7.1-beta.93](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.93) (2017-10-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.8.0-rc.1...v0.7.1-beta.93)
+
+## [v0.8.0-rc.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.8.0-rc.1) (2017-10-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.92...v0.8.0-rc.1)
+
+**Merged pull requests:**
+
+- Fixed USFM 3 To JSON Method [\#2922](https://github.com/unfoldingWord-dev/translationCore/pull/2922) ([RoyalSix](https://github.com/RoyalSix))
+- Added Uses Cases For USFM 3 Target Language [\#2896](https://github.com/unfoldingWord-dev/translationCore/pull/2896) ([RoyalSix](https://github.com/RoyalSix))
+- Resetting alignment reducer data [\#2894](https://github.com/unfoldingWord-dev/translationCore/pull/2894) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.92](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.92) (2017-10-10)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.91...v0.7.1-beta.92)
+
+**Fixed bugs:**
+
+- We need to deal gracefully with projects that are not individual books of the Bible [\#2524](https://github.com/unfoldingWord-dev/translationCore/issues/2524)
+
+**Closed issues:**
+
+- Fix tests  [\#2875](https://github.com/unfoldingWord-dev/translationCore/issues/2875)
+- Multiple Greek choices are available in the alignment scripture panel [\#2845](https://github.com/unfoldingWord-dev/translationCore/issues/2845)
+- Update ULB [\#2834](https://github.com/unfoldingWord-dev/translationCore/issues/2834)
+- Alignment Tool: Add green checkbox when all word bank words are used [\#2832](https://github.com/unfoldingWord-dev/translationCore/issues/2832)
+- Alignment: Open more than one project, fix index [\#2760](https://github.com/unfoldingWord-dev/translationCore/issues/2760)
+- Alignment: Show Greek popup in the dropboxes [\#2758](https://github.com/unfoldingWord-dev/translationCore/issues/2758)
+- Alignment: Strip out punctuation [\#2757](https://github.com/unfoldingWord-dev/translationCore/issues/2757)
+- Alignment WordBank: Drag words back to the word bank [\#2756](https://github.com/unfoldingWord-dev/translationCore/issues/2756)
+- Alignment: Unmerging Greek words [\#2755](https://github.com/unfoldingWord-dev/translationCore/issues/2755)
+- Alignment: Merging Greek words [\#2754](https://github.com/unfoldingWord-dev/translationCore/issues/2754)
+- Alignment Persistence: targetLanguage verse Data persistence [\#2753](https://github.com/unfoldingWord-dev/translationCore/issues/2753)
+- Alignment: Create helper to sort word objects in proper order [\#2752](https://github.com/unfoldingWord-dev/translationCore/issues/2752)
+- Alignment: WordBank generated from project [\#2751](https://github.com/unfoldingWord-dev/translationCore/issues/2751)
+- Add "X" to close UGNT popup [\#2730](https://github.com/unfoldingWord-dev/translationCore/issues/2730)
+- Hide all non-alignment tools for 0.8 [\#2725](https://github.com/unfoldingWord-dev/translationCore/issues/2725)
+- Integrate new USFM3 parser into tC [\#2723](https://github.com/unfoldingWord-dev/translationCore/issues/2723)
+- Style target Boxes to include a checkbox to allow Greek words to switch places with other Greek words [\#2655](https://github.com/unfoldingWord-dev/translationCore/issues/2655)
+- Console opens along with tC [\#2172](https://github.com/unfoldingWord-dev/translationCore/issues/2172)
+
+**Merged pull requests:**
+
+- Addressed duplicates in word bank with temp fix. [\#2888](https://github.com/unfoldingWord-dev/translationCore/pull/2888) ([klappy](https://github.com/klappy))
+- Fix solo TopWord from disappearing when dropped on empty alignment [\#2885](https://github.com/unfoldingWord-dev/translationCore/pull/2885) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.91](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.91) (2017-10-09)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.90...v0.7.1-beta.91)
+
+**Merged pull requests:**
+
+- Fixing tests [\#2874](https://github.com/unfoldingWord-dev/translationCore/pull/2874) ([mannycolon](https://github.com/mannycolon))
+- Unmerge without empty alignment persisted [\#2872](https://github.com/unfoldingWord-dev/translationCore/pull/2872) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.90](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.90) (2017-10-08)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.89...v0.7.1-beta.90)
+
+**Closed issues:**
+
+- Extra letter card found in alignment word list [\#2871](https://github.com/unfoldingWord-dev/translationCore/issues/2871)
+
+**Merged pull requests:**
+
+- Multiple USFM Fixes [\#2869](https://github.com/unfoldingWord-dev/translationCore/pull/2869) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.89](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.89) (2017-10-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.88...v0.7.1-beta.89)
+
+**Closed issues:**
+
+- tN Tool should not be available even when in developer mode [\#2783](https://github.com/unfoldingWord-dev/translationCore/issues/2783)
+
+**Merged pull requests:**
+
+- Updated ULB [\#2864](https://github.com/unfoldingWord-dev/translationCore/pull/2864) ([mannycolon](https://github.com/mannycolon))
+- Unmerging TopWords in Alignment [\#2857](https://github.com/unfoldingWord-dev/translationCore/pull/2857) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.88](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.88) (2017-10-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.87...v0.7.1-beta.88)
+
+**Merged pull requests:**
+
+- Displaying check mark when all words from the word bank are used [\#2861](https://github.com/unfoldingWord-dev/translationCore/pull/2861) ([mannycolon](https://github.com/mannycolon))
+- Sorting bottom words in word alignment tool [\#2859](https://github.com/unfoldingWord-dev/translationCore/pull/2859) ([mannycolon](https://github.com/mannycolon))
+- Removed Unnecessary Console Warnings [\#2858](https://github.com/unfoldingWord-dev/translationCore/pull/2858) ([RoyalSix](https://github.com/RoyalSix))
+- Hide Non-Alignment Tools [\#2828](https://github.com/unfoldingWord-dev/translationCore/pull/2828) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.87](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.87) (2017-10-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.86...v0.7.1-beta.87)
+
+**Closed issues:**
+
+- Alignment tool is only available when in developer mode [\#2782](https://github.com/unfoldingWord-dev/translationCore/issues/2782)
+
+**Merged pull requests:**
+
+- Updated UGNT reference to BHP [\#2856](https://github.com/unfoldingWord-dev/translationCore/pull/2856) ([mannycolon](https://github.com/mannycolon))
+- Merge Conflict Fixes [\#2853](https://github.com/unfoldingWord-dev/translationCore/pull/2853) ([RoyalSix](https://github.com/RoyalSix))
+- fixed bug with the Hint component  [\#2849](https://github.com/unfoldingWord-dev/translationCore/pull/2849) ([mannycolon](https://github.com/mannycolon))
+- Created action for merging TopWords and aligned bottom words [\#2846](https://github.com/unfoldingWord-dev/translationCore/pull/2846) ([klappy](https://github.com/klappy))
+- Drag words back to the word bank area [\#2844](https://github.com/unfoldingWord-dev/translationCore/pull/2844) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.86](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.86) (2017-10-04)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.85...v0.7.1-beta.86)
+
+## [v0.7.1-beta.85](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.85) (2017-10-04)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.84...v0.7.1-beta.85)
+
+**Merged pull requests:**
+
+- Add Close Button To Popovers [\#2825](https://github.com/unfoldingWord-dev/translationCore/pull/2825) ([RoyalSix](https://github.com/RoyalSix))
+- Finished linting [\#2824](https://github.com/unfoldingWord-dev/translationCore/pull/2824) ([neutrinog](https://github.com/neutrinog))
+- AlignmentData save/load to fs [\#2822](https://github.com/unfoldingWord-dev/translationCore/pull/2822) ([klappy](https://github.com/klappy))
+- Populate wordBank with targetLanguage [\#2816](https://github.com/unfoldingWord-dev/translationCore/pull/2816) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.84](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.84) (2017-10-02)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.83...v0.7.1-beta.84)
+
+**Merged pull requests:**
+
+- Removed Code To Automatically Open The Dev Console [\#2820](https://github.com/unfoldingWord-dev/translationCore/pull/2820) ([RoyalSix](https://github.com/RoyalSix))
+- Integrate USFM3 Parser [\#2818](https://github.com/unfoldingWord-dev/translationCore/pull/2818) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.83](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.83) (2017-10-02)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.82...v0.7.1-beta.83)
+
+**Merged pull requests:**
+
+- Fixed Unittests [\#2815](https://github.com/unfoldingWord-dev/translationCore/pull/2815) ([neutrinog](https://github.com/neutrinog))
+- Bugfix/klappy/camel case [\#2814](https://github.com/unfoldingWord-dev/translationCore/pull/2814) ([klappy](https://github.com/klappy))
+- Feature/klappy/default index/2760 [\#2813](https://github.com/unfoldingWord-dev/translationCore/pull/2813) ([klappy](https://github.com/klappy))
+- Fixes Door43 Importing [\#2812](https://github.com/unfoldingWord-dev/translationCore/pull/2812) ([RoyalSix](https://github.com/RoyalSix))
+- Enabled Linting Rules [\#2804](https://github.com/unfoldingWord-dev/translationCore/pull/2804) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.7.1-beta.82](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.82) (2017-09-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.81...v0.7.1-beta.82)
+
+**Fixed bugs:**
+
+- Project validation stepper problems when processing project with merge conflicts [\#2748](https://github.com/unfoldingWord-dev/translationCore/issues/2748)
+- Corrupted manifest file [\#2633](https://github.com/unfoldingWord-dev/translationCore/issues/2633)
+- Cannot add Bible to scripture pane [\#2621](https://github.com/unfoldingWord-dev/translationCore/issues/2621)
+- Checks are skipped [\#2613](https://github.com/unfoldingWord-dev/translationCore/issues/2613)
+- RTL not working in expanded Scripture Pane [\#2608](https://github.com/unfoldingWord-dev/translationCore/issues/2608)
+- Projects with long names overflow off of the project card [\#2604](https://github.com/unfoldingWord-dev/translationCore/issues/2604)
+- FAB options should be disabled when file finder/explorer is displayed [\#2550](https://github.com/unfoldingWord-dev/translationCore/issues/2550)
+- tHelps panel is cut off when window width is minimized [\#2512](https://github.com/unfoldingWord-dev/translationCore/issues/2512)
+- Projects screen is empty, no way to import a project \(Windows beta.45\) [\#2477](https://github.com/unfoldingWord-dev/translationCore/issues/2477)
+- Inconsistencies in displaying selections [\#2406](https://github.com/unfoldingWord-dev/translationCore/issues/2406)
+- Wrong text gets selected when double-clicking [\#2178](https://github.com/unfoldingWord-dev/translationCore/issues/2178)
+- Multiple issues with Export to CSV [\#1637](https://github.com/unfoldingWord-dev/translationCore/issues/1637)
+- Problems selecting verse text [\#1577](https://github.com/unfoldingWord-dev/translationCore/issues/1577)
+- Overlapping Selection/Highlight Bug [\#1554](https://github.com/unfoldingWord-dev/translationCore/issues/1554)
+
+**Closed issues:**
+
+- Implement Greek Titus USFM [\#2650](https://github.com/unfoldingWord-dev/translationCore/issues/2650)
+- Building data bridge between alignment and MAP [\#2648](https://github.com/unfoldingWord-dev/translationCore/issues/2648)
+- Get current Greek Lexicon working with the new UGNT [\#2647](https://github.com/unfoldingWord-dev/translationCore/issues/2647)
+- Do not add the loggged in user as a checker when creating the manifest for imported USFM projects [\#2587](https://github.com/unfoldingWord-dev/translationCore/issues/2587)
+- Change header on tools page from "ToolsManagementContainer" to "Tools" [\#2508](https://github.com/unfoldingWord-dev/translationCore/issues/2508)
+- Action Card verbiage clean-up [\#2465](https://github.com/unfoldingWord-dev/translationCore/issues/2465)
+- Edit Project Details [\#2416](https://github.com/unfoldingWord-dev/translationCore/issues/2416)
+- ProjectValidation: Missing Verses [\#2356](https://github.com/unfoldingWord-dev/translationCore/issues/2356)
+- Update Core for DCS API v3 Resources [\#2310](https://github.com/unfoldingWord-dev/translationCore/issues/2310)
+- Selection Refinement [\#2300](https://github.com/unfoldingWord-dev/translationCore/issues/2300)
+- App hangs when importing corrupted project [\#2288](https://github.com/unfoldingWord-dev/translationCore/issues/2288)
+- Alignment Tool: Style UI components [\#2279](https://github.com/unfoldingWord-dev/translationCore/issues/2279)
+- Alignment Tool: Create Actions/Reducers for storing/retrieving alignment data.  [\#2278](https://github.com/unfoldingWord-dev/translationCore/issues/2278)
+- Verbiage in Guest Terms & Conditions [\#2017](https://github.com/unfoldingWord-dev/translationCore/issues/2017)
+- Rebrand "Local User" as "Guest" [\#2015](https://github.com/unfoldingWord-dev/translationCore/issues/2015)
+
+**Merged pull requests:**
+
+- added tokenizer in stringHelpers and tests [\#2810](https://github.com/unfoldingWord-dev/translationCore/pull/2810) ([klappy](https://github.com/klappy))
+- sortWordObjectsByString [\#2805](https://github.com/unfoldingWord-dev/translationCore/pull/2805) ([klappy](https://github.com/klappy))
+- bhp added [\#2803](https://github.com/unfoldingWord-dev/translationCore/pull/2803) ([klappy](https://github.com/klappy))
+- Updated USFM Module For Footnote Filtering [\#2800](https://github.com/unfoldingWord-dev/translationCore/pull/2800) ([RoyalSix](https://github.com/RoyalSix))
+- no-undef linting [\#2798](https://github.com/unfoldingWord-dev/translationCore/pull/2798) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.7.1-beta.81](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.81) (2017-09-25)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.80...v0.7.1-beta.81)
+
+**Merged pull requests:**
+
+- semicolon linting [\#2750](https://github.com/unfoldingWord-dev/translationCore/pull/2750) ([neutrinog](https://github.com/neutrinog))
+- Added Use Case For Dealing With Non-Books Of Bible Projects [\#2749](https://github.com/unfoldingWord-dev/translationCore/pull/2749) ([RoyalSix](https://github.com/RoyalSix))
+- Fixed Merge Conflict Bug On Import [\#2747](https://github.com/unfoldingWord-dev/translationCore/pull/2747) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.80](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.80) (2017-09-25)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-76...v0.7.1-beta.80)
+
+**Fixed bugs:**
+
+- unexpected behavior when making a selection that includes special characters \(? ! $ &\)  [\#2704](https://github.com/unfoldingWord-dev/translationCore/issues/2704)
+
+**Merged pull requests:**
+
+- fixed project information check validation [\#2743](https://github.com/unfoldingWord-dev/translationCore/pull/2743) ([RoyalSix](https://github.com/RoyalSix))
+- Updated Naming Convention, Allow words to be moved after drop. [\#2742](https://github.com/unfoldingWord-dev/translationCore/pull/2742) ([klappy](https://github.com/klappy))
+- Changed project details edit mode verbiage per QA request [\#2739](https://github.com/unfoldingWord-dev/translationCore/pull/2739) ([mannycolon](https://github.com/mannycolon))
+- Linting [\#2738](https://github.com/unfoldingWord-dev/translationCore/pull/2738) ([neutrinog](https://github.com/neutrinog))
+- Rebranded 'local user' as 'guest' [\#2732](https://github.com/unfoldingWord-dev/translationCore/pull/2732) ([mannycolon](https://github.com/mannycolon))
+- Handling Single Chunk USFM From TS [\#2728](https://github.com/unfoldingWord-dev/translationCore/pull/2728) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta-76](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-76) (2017-09-22)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.79...v0.7.1-beta-76)
+
+## [v0.7.1-beta.79](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.79) (2017-09-22)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.78...v0.7.1-beta.79)
+
+**Fixed bugs:**
+
+- Problem with import from Door43 using URL [\#2698](https://github.com/unfoldingWord-dev/translationCore/issues/2698)
+
+**Merged pull requests:**
+
+- Added Text Overflow To Project Name [\#2729](https://github.com/unfoldingWord-dev/translationCore/pull/2729) ([RoyalSix](https://github.com/RoyalSix))
+- Edit project details from the 3-dot menu in a project card [\#2726](https://github.com/unfoldingWord-dev/translationCore/pull/2726) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.78](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.78) (2017-09-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.77...v0.7.1-beta.78)
+
+**Merged pull requests:**
+
+- Support for new new UGNT v0.2 and lexicon [\#2722](https://github.com/unfoldingWord-dev/translationCore/pull/2722) ([klappy](https://github.com/klappy))
+- Alignment tool backend implementation  [\#2721](https://github.com/unfoldingWord-dev/translationCore/pull/2721) ([mannycolon](https://github.com/mannycolon))
+- Coverage Support [\#2718](https://github.com/unfoldingWord-dev/translationCore/pull/2718) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.7.1-beta.77](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.77) (2017-09-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.76...v0.7.1-beta.77)
+
+**Fixed bugs:**
+
+- User is not prevented from opening projects that have merge conflicts [\#2307](https://github.com/unfoldingWord-dev/translationCore/issues/2307)
+
+**Closed issues:**
+
+- Project Import Stepper [\#1750](https://github.com/unfoldingWord-dev/translationCore/issues/1750)
+- Project Import Check: Merge Conflicts Check [\#1712](https://github.com/unfoldingWord-dev/translationCore/issues/1712)
+- Project Import Check: Manifest Check [\#1711](https://github.com/unfoldingWord-dev/translationCore/issues/1711)
+- Project Import Check: License Check [\#1710](https://github.com/unfoldingWord-dev/translationCore/issues/1710)
+- Project Import Check [\#691](https://github.com/unfoldingWord-dev/translationCore/issues/691)
+- Project Import: Missing Verses Check [\#247](https://github.com/unfoldingWord-dev/translationCore/issues/247)
+
+**Merged pull requests:**
+
+- Handling Projects That Are Not Strictly Made For tC [\#2716](https://github.com/unfoldingWord-dev/translationCore/pull/2716) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.76](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.76) (2017-09-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.75...v0.7.1-beta.76)
+
+**Merged pull requests:**
+
+- Removed Username As Default Checker [\#2712](https://github.com/unfoldingWord-dev/translationCore/pull/2712) ([RoyalSix](https://github.com/RoyalSix))
+- Closing Tab When Import Local Finder Shows [\#2710](https://github.com/unfoldingWord-dev/translationCore/pull/2710) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.75](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.75) (2017-09-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.74...v0.7.1-beta.75)
+
+## [v0.7.1-beta.74](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.74) (2017-09-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.73...v0.7.1-beta.74)
+
+## [v0.7.1-beta.73](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.73) (2017-09-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.72...v0.7.1-beta.73)
+
+## [v0.7.1-beta.72](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.72) (2017-09-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.71...v0.7.1-beta.72)
+
+## [v0.7.1-beta.71](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.71) (2017-09-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.70...v0.7.1-beta.71)
+
+## [v0.7.1-beta.70](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.70) (2017-09-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.69...v0.7.1-beta.70)
+
+**Merged pull requests:**
+
+- fixed builds CI support [\#2708](https://github.com/unfoldingWord-dev/translationCore/pull/2708) ([neutrinog](https://github.com/neutrinog))
+
+## [v0.7.1-beta.69](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.69) (2017-09-15)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.68...v0.7.1-beta.69)
+
+**Fixed bugs:**
+
+- Different behavior when importing using the URL vs using the Door43 search. [\#2619](https://github.com/unfoldingWord-dev/translationCore/issues/2619)
+
+**Merged pull requests:**
+
+- Don't skip invalid checks [\#2706](https://github.com/unfoldingWord-dev/translationCore/pull/2706) ([klappy](https://github.com/klappy))
+- CSV: create empty files for checkdata [\#2705](https://github.com/unfoldingWord-dev/translationCore/pull/2705) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.68](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.68) (2017-09-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.67...v0.7.1-beta.68)
+
+## [v0.7.1-beta.67](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.67) (2017-09-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.66...v0.7.1-beta.67)
+
+**Merged pull requests:**
+
+- Fix For Old Data Which Causes App To Hang [\#2703](https://github.com/unfoldingWord-dev/translationCore/pull/2703) ([RoyalSix](https://github.com/RoyalSix))
+- Removed static folder and added resources submodule [\#2630](https://github.com/unfoldingWord-dev/translationCore/pull/2630) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.66](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.66) (2017-09-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.65...v0.7.1-beta.66)
+
+**Fixed bugs:**
+
+- Cannot export to USFM [\#2478](https://github.com/unfoldingWord-dev/translationCore/issues/2478)
+- Newly imported projects do not appear initially in the project list [\#2192](https://github.com/unfoldingWord-dev/translationCore/issues/2192)
+
+**Closed issues:**
+
+- Fix 3-dot menu on project card in Home [\#2466](https://github.com/unfoldingWord-dev/translationCore/issues/2466)
+- ProjectValidation: Merge Conflicts [\#2355](https://github.com/unfoldingWord-dev/translationCore/issues/2355)
+- Remove menu bar in the Stepper and make stepper steps clickable [\#2309](https://github.com/unfoldingWord-dev/translationCore/issues/2309)
+- Rework Select mode [\#2290](https://github.com/unfoldingWord-dev/translationCore/issues/2290)
+- Alignment Tool:  Evaluate React D&D for creating drag and drop UI. [\#2276](https://github.com/unfoldingWord-dev/translationCore/issues/2276)
+- Alignment Tool: Create Initial Layout for UI [\#2275](https://github.com/unfoldingWord-dev/translationCore/issues/2275)
+- Create a new blank tool \(alignment tool\) [\#2274](https://github.com/unfoldingWord-dev/translationCore/issues/2274)
+
+**Merged pull requests:**
+
+- Corrupted Manifest Fix And New Manifest Tests [\#2651](https://github.com/unfoldingWord-dev/translationCore/pull/2651) ([RoyalSix](https://github.com/RoyalSix))
+- Alignment Tool implementation [\#2646](https://github.com/unfoldingWord-dev/translationCore/pull/2646) ([mannycolon](https://github.com/mannycolon))
+- Tools Management Container Header Rename [\#2632](https://github.com/unfoldingWord-dev/translationCore/pull/2632) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.65](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.65) (2017-09-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.64...v0.7.1-beta.65)
+
+**Merged pull requests:**
+
+- Missing Verses Fix [\#2618](https://github.com/unfoldingWord-dev/translationCore/pull/2618) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.64](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.64) (2017-09-11)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.63...v0.7.1-beta.64)
+
+**Fixed bugs:**
+
+- Project validation steps are skipped and checking screen is blank [\#2544](https://github.com/unfoldingWord-dev/translationCore/issues/2544)
+- Missing verses check is bypassed and project hangs when opening [\#2505](https://github.com/unfoldingWord-dev/translationCore/issues/2505)
+- Multiple problems with missing verses [\#2472](https://github.com/unfoldingWord-dev/translationCore/issues/2472)
+- Fix missing verses bug [\#2033](https://github.com/unfoldingWord-dev/translationCore/issues/2033)
+
+## [v0.7.1-beta.63](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.63) (2017-09-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.62...v0.7.1-beta.63)
+
+**Merged pull requests:**
+
+- USFM Export Fixes [\#2622](https://github.com/unfoldingWord-dev/translationCore/pull/2622) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.62](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.62) (2017-09-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.60...v0.7.1-beta.62)
+
+**Merged pull requests:**
+
+- Added 3 Dot Functionality To Project Overview [\#2625](https://github.com/unfoldingWord-dev/translationCore/pull/2625) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.60](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.60) (2017-09-01)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.59...v0.7.1-beta.60)
+
+**Merged pull requests:**
+
+- Truncate Stepper Labels [\#2616](https://github.com/unfoldingWord-dev/translationCore/pull/2616) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.59](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.59) (2017-08-31)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.57...v0.7.1-beta.59)
+
+**Implemented enhancements:**
+
+- Reset the "do not show this warning again" flag when the user logs out [\#2181](https://github.com/unfoldingWord-dev/translationCore/issues/2181)
+
+**Fixed bugs:**
+
+- Cannot import local tstudio projects [\#2444](https://github.com/unfoldingWord-dev/translationCore/issues/2444)
+- Clicking on the V in the group header does not close the group [\#2401](https://github.com/unfoldingWord-dev/translationCore/issues/2401)
+- I am able to load non-Titus projects when not in developer mode [\#2399](https://github.com/unfoldingWord-dev/translationCore/issues/2399)
+- Empty project card [\#2393](https://github.com/unfoldingWord-dev/translationCore/issues/2393)
+- Import from USFM overwrites an existing project without any warning [\#2304](https://github.com/unfoldingWord-dev/translationCore/issues/2304)
+- Scripture Pane: Chapter View shows target language text for all Bibles. [\#2296](https://github.com/unfoldingWord-dev/translationCore/issues/2296)
+- Text overflows left panel of select area [\#2291](https://github.com/unfoldingWord-dev/translationCore/issues/2291)
+- Wrong email address appears on user card [\#2247](https://github.com/unfoldingWord-dev/translationCore/issues/2247)
+- Text overwrite in scripture pane [\#2189](https://github.com/unfoldingWord-dev/translationCore/issues/2189)
+- Wrong error message displayed when logged in as a local user and attempting to upload a project [\#2180](https://github.com/unfoldingWord-dev/translationCore/issues/2180)
+- Determine/implement best way to avoid special characters appearing in exported csv files [\#2152](https://github.com/unfoldingWord-dev/translationCore/issues/2152)
+- Skip / Close dialog is not dismissed when user clicks Skip [\#2131](https://github.com/unfoldingWord-dev/translationCore/issues/2131)
+- Overlapping of reason codes on verse edit [\#2128](https://github.com/unfoldingWord-dev/translationCore/issues/2128)
+- App is still looking for the uhb for NT projects [\#2127](https://github.com/unfoldingWord-dev/translationCore/issues/2127)
+
+**Closed issues:**
+
+- tW Quotes in GroupData have Headers not Quotes [\#2493](https://github.com/unfoldingWord-dev/translationCore/issues/2493)
+- Reorder top menu [\#2410](https://github.com/unfoldingWord-dev/translationCore/issues/2410)
+- ProjectValidation: Project Information [\#2354](https://github.com/unfoldingWord-dev/translationCore/issues/2354)
+- ProjectValidation: CopyrightCheck [\#2353](https://github.com/unfoldingWord-dev/translationCore/issues/2353)
+- ProjectValidation Stepper UI [\#2352](https://github.com/unfoldingWord-dev/translationCore/issues/2352)
+- Typo on "You are logged in as..." alert [\#2302](https://github.com/unfoldingWord-dev/translationCore/issues/2302)
+- Suggest changing the text on the Save Changes button to just "Save" [\#2294](https://github.com/unfoldingWord-dev/translationCore/issues/2294)
+- Change the text on the Titus only alert dialog [\#2252](https://github.com/unfoldingWord-dev/translationCore/issues/2252)
+- Update the text on the import from Door43 modal [\#2248](https://github.com/unfoldingWord-dev/translationCore/issues/2248)
+- Typo on Internet use warning dialog [\#2179](https://github.com/unfoldingWord-dev/translationCore/issues/2179)
+- Data Planning: Blocking: Plan data format and structure for alignments [\#2153](https://github.com/unfoldingWord-dev/translationCore/issues/2153)
+- Find alignment tool mockups & evaluate [\#2146](https://github.com/unfoldingWord-dev/translationCore/issues/2146)
+- 2. Project: Import Online Project [\#971](https://github.com/unfoldingWord-dev/translationCore/issues/971)
+- 2. Project: Main Page [\#969](https://github.com/unfoldingWord-dev/translationCore/issues/969)
+- Import latest tHelps [\#720](https://github.com/unfoldingWord-dev/translationCore/issues/720)
+
+**Merged pull requests:**
+
+- Changed the file we use to get access to the tool [\#2611](https://github.com/unfoldingWord-dev/translationCore/pull/2611) ([mannycolon](https://github.com/mannycolon))
+- Added local import dialog and USFM tests [\#2586](https://github.com/unfoldingWord-dev/translationCore/pull/2586) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.57](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.57) (2017-08-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.56...v0.7.1-beta.57)
+
+**Merged pull requests:**
+
+- USFM Import TL Bible Fix [\#2572](https://github.com/unfoldingWord-dev/translationCore/pull/2572) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.56](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.56) (2017-08-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.55...v0.7.1-beta.56)
+
+**Merged pull requests:**
+
+- Addressed QA issues in the project validation stepper UI [\#2557](https://github.com/unfoldingWord-dev/translationCore/pull/2557) ([mannycolon](https://github.com/mannycolon))
+- Missing Verses Tests [\#2556](https://github.com/unfoldingWord-dev/translationCore/pull/2556) ([RoyalSix](https://github.com/RoyalSix))
+- node csv - \#2434 [\#2553](https://github.com/unfoldingWord-dev/translationCore/pull/2553) ([klappy](https://github.com/klappy))
+- Project information Check QA issues [\#2547](https://github.com/unfoldingWord-dev/translationCore/pull/2547) ([mannycolon](https://github.com/mannycolon))
+- Updated Home Stepper To Suggested Fixes [\#2542](https://github.com/unfoldingWord-dev/translationCore/pull/2542) ([RoyalSix](https://github.com/RoyalSix))
+- Merge Conflict Testing [\#2523](https://github.com/unfoldingWord-dev/translationCore/pull/2523) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.55](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.55) (2017-08-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.54...v0.7.1-beta.55)
+
+**Fixed bugs:**
+
+- "Cloning into 'C:\\Users\\come2\_000\\translationCore\\ml-ulb'...\nfatal: unable to access 'https://git.door43.org/benVar/ml-ulb.git/': error setting certificate verify locations:\n  CAfile: C:/Program Files \(x86\)/Git/mingw32/ssl/certs/ca-bundle.crt\n  CAp [\#2481](https://github.com/unfoldingWord-dev/translationCore/issues/2481)
+- "Cloning into 'C:\\Users\\come2\_000\\translationCore\\ml\_phm\_text\_reg'...\nfatal: unable to access 'https://git.door43.org/benVar/ml\_phm\_text\_reg.git/': error setting certificate verify locations:\n  CAfile: C:/Program Files \(x86\)/Git/mingw32/ssl/certs/ca [\#2480](https://github.com/unfoldingWord-dev/translationCore/issues/2480)
+- Uncaught Error: Object has been destroyed
+Error: Object has been destroyed
+    at EventEmitter.\<anonymous\> \(C:\Program Files \(x86\)\translationCore\resources\electron.asar\browser\rpc-server.js:387:55\)
+    at emitThree \(events.js:116:13\)
+    at EventEmitte [\#2476](https://github.com/unfoldingWord-dev/translationCore/issues/2476)
+- Only able to select Titus projects [\#2473](https://github.com/unfoldingWord-dev/translationCore/issues/2473)
+- Autographa shows up on the Tools page when in developer mode [\#2397](https://github.com/unfoldingWord-dev/translationCore/issues/2397)
+- Link in tHelps brings up empty window [\#1700](https://github.com/unfoldingWord-dev/translationCore/issues/1700)
+- Funky links showing up in check info card [\#1678](https://github.com/unfoldingWord-dev/translationCore/issues/1678)
+- Improper links in tHelps [\#1553](https://github.com/unfoldingWord-dev/translationCore/issues/1553)
+
+**Closed issues:**
+
+- Unable to select any project after an online import [\#2545](https://github.com/unfoldingWord-dev/translationCore/issues/2545)
+- Weird link in tHelps, Metaphor [\#1699](https://github.com/unfoldingWord-dev/translationCore/issues/1699)
+
+**Merged pull requests:**
+
+- improved copy right cards layout and made it radio buttons per QA request [\#2541](https://github.com/unfoldingWord-dev/translationCore/pull/2541) ([mannycolon](https://github.com/mannycolon))
+- updated strings in the door43 import modal and the Titus only alert dialog [\#2540](https://github.com/unfoldingWord-dev/translationCore/pull/2540) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.54](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.54) (2017-08-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.53...v0.7.1-beta.54)
+
+**Merged pull requests:**
+
+- Fixed Empty project cards [\#2518](https://github.com/unfoldingWord-dev/translationCore/pull/2518) ([mannycolon](https://github.com/mannycolon))
+- Fixed bug with copyright check [\#2515](https://github.com/unfoldingWord-dev/translationCore/pull/2515) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.53](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.53) (2017-08-22)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.52...v0.7.1-beta.53)
+
+**Merged pull requests:**
+
+- Updated the order of the top menu buttons and link them to the home screen [\#2509](https://github.com/unfoldingWord-dev/translationCore/pull/2509) ([mannycolon](https://github.com/mannycolon))
+- Temp fix until UGNT is implemented. [\#2502](https://github.com/unfoldingWord-dev/translationCore/pull/2502) ([klappy](https://github.com/klappy))
+- Stepper Steps Clickable / Remove Statusbar in Stepper [\#2501](https://github.com/unfoldingWord-dev/translationCore/pull/2501) ([RoyalSix](https://github.com/RoyalSix))
+- Fix Dialog Message For Local User Upload [\#2499](https://github.com/unfoldingWord-dev/translationCore/pull/2499) ([RoyalSix](https://github.com/RoyalSix))
+- Fixed bugs with local and online project import [\#2498](https://github.com/unfoldingWord-dev/translationCore/pull/2498) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.52](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.52) (2017-08-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.51...v0.7.1-beta.52)
+
+**Merged pull requests:**
+
+- Now Resetting the online alert message when user logs out [\#2500](https://github.com/unfoldingWord-dev/translationCore/pull/2500) ([mannycolon](https://github.com/mannycolon))
+- Now only looking for the UHB for OT projects [\#2496](https://github.com/unfoldingWord-dev/translationCore/pull/2496) ([mannycolon](https://github.com/mannycolon))
+- Added collapsible submenu to Group Menu [\#2490](https://github.com/unfoldingWord-dev/translationCore/pull/2490) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.51](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.51) (2017-08-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.50...v0.7.1-beta.51)
+
+**Merged pull requests:**
+
+- Prevent import and selection of non-titus books [\#2487](https://github.com/unfoldingWord-dev/translationCore/pull/2487) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.50](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.50) (2017-08-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.49...v0.7.1-beta.50)
+
+**Fixed bugs:**
+
+- Project opens to blank checking screen [\#2188](https://github.com/unfoldingWord-dev/translationCore/issues/2188)
+
+**Closed issues:**
+
+- Wrong check being displayed from menu [\#2394](https://github.com/unfoldingWord-dev/translationCore/issues/2394)
+- User is again able to highlight \(but not select\) text in left pane when in edit and comment mode. [\#2295](https://github.com/unfoldingWord-dev/translationCore/issues/2295)
+- Select mode should expand vertically over the Save & Previous and Save & Continue buttons [\#2176](https://github.com/unfoldingWord-dev/translationCore/issues/2176)
+- Data Planning: Non-blocking: Determine how alignment data should be stored in uW API. [\#2154](https://github.com/unfoldingWord-dev/translationCore/issues/2154)
+- Support for USFM Export [\#1690](https://github.com/unfoldingWord-dev/translationCore/issues/1690)
+- Unexpected behavior when deleting all of the text in a verse [\#1299](https://github.com/unfoldingWord-dev/translationCore/issues/1299)
+- 2. Project: Upload to Door43 [\#974](https://github.com/unfoldingWord-dev/translationCore/issues/974)
+
+## [v0.7.1-beta.49](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.49) (2017-08-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.48...v0.7.1-beta.49)
+
+**Merged pull requests:**
+
+- Updated text for door43 modal [\#2492](https://github.com/unfoldingWord-dev/translationCore/pull/2492) ([mannycolon](https://github.com/mannycolon))
+- Enhanced the text on the Titus only alert dialog [\#2491](https://github.com/unfoldingWord-dev/translationCore/pull/2491) ([mannycolon](https://github.com/mannycolon))
+- Project Information Check  [\#2489](https://github.com/unfoldingWord-dev/translationCore/pull/2489) ([mannycolon](https://github.com/mannycolon))
+- Multiple Project Import Workflow Fixes [\#2488](https://github.com/unfoldingWord-dev/translationCore/pull/2488) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.48](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.48) (2017-08-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.47...v0.7.1-beta.48)
+
+**Merged pull requests:**
+
+- Removed Email Address From Overview\(user\) Card [\#2483](https://github.com/unfoldingWord-dev/translationCore/pull/2483) ([RoyalSix](https://github.com/RoyalSix))
+- fixed checks that don't load [\#2463](https://github.com/unfoldingWord-dev/translationCore/pull/2463) ([klappy](https://github.com/klappy))
+- Missing Verses Check [\#2445](https://github.com/unfoldingWord-dev/translationCore/pull/2445) ([RoyalSix](https://github.com/RoyalSix))
+- Copyright Check [\#2412](https://github.com/unfoldingWord-dev/translationCore/pull/2412) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.47](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.47) (2017-08-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.46...v0.7.1-beta.47)
+
+**Merged pull requests:**
+
+- fixed capitalization [\#2462](https://github.com/unfoldingWord-dev/translationCore/pull/2462) ([klappy](https://github.com/klappy))
+- Updated Internet warning verbiage [\#2461](https://github.com/unfoldingWord-dev/translationCore/pull/2461) ([klappy](https://github.com/klappy))
+- removed dashed border of 3-dot glyph, updated text of supported imports. [\#2460](https://github.com/unfoldingWord-dev/translationCore/pull/2460) ([klappy](https://github.com/klappy))
+- Project Import Check Container Fixes [\#2411](https://github.com/unfoldingWord-dev/translationCore/pull/2411) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.46](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.46) (2017-08-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.45...v0.7.1-beta.46)
+
+## [v0.7.1-beta.45](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.45) (2017-08-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.44...v0.7.1-beta.45)
+
+**Fixed bugs:**
+
+- Checks are skipped [\#2405](https://github.com/unfoldingWord-dev/translationCore/issues/2405)
+- Bug Report: [\#2311](https://github.com/unfoldingWord-dev/translationCore/issues/2311)
+
+**Closed issues:**
+
+- Hide or enable 3-dot menu on the project card on Home page [\#2446](https://github.com/unfoldingWord-dev/translationCore/issues/2446)
+- Speed up builds and cloning by removing old source files from git repo [\#2060](https://github.com/unfoldingWord-dev/translationCore/issues/2060)
+
+## [v0.7.1-beta.44](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.44) (2017-08-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.43...v0.7.1-beta.44)
+
+**Fixed bugs:**
+
+- User is forced through the project checking stepper when attempting to open a Door43 project [\#2398](https://github.com/unfoldingWord-dev/translationCore/issues/2398)
+
+**Closed issues:**
+
+- I think the text should always be grayed in the left section of the select panel. [\#2177](https://github.com/unfoldingWord-dev/translationCore/issues/2177)
+- UGNT 0.2 [\#715](https://github.com/unfoldingWord-dev/translationCore/issues/715)
+
+**Merged pull requests:**
+
+- increase timeouts for gitapi tests [\#2415](https://github.com/unfoldingWord-dev/translationCore/pull/2415) ([klappy](https://github.com/klappy))
+- Project import QA issues  [\#2414](https://github.com/unfoldingWord-dev/translationCore/pull/2414) ([mannycolon](https://github.com/mannycolon))
+- Fix USFM Project Overwrite Dialog [\#2408](https://github.com/unfoldingWord-dev/translationCore/pull/2408) ([RoyalSix](https://github.com/RoyalSix))
+- Added testing for USFM import, organized helpers [\#2404](https://github.com/unfoldingWord-dev/translationCore/pull/2404) ([klappy](https://github.com/klappy))
+- updated to correct submodules \(tools\) [\#2403](https://github.com/unfoldingWord-dev/translationCore/pull/2403) ([mannycolon](https://github.com/mannycolon))
+- Fix Check Selection [\#2396](https://github.com/unfoldingWord-dev/translationCore/pull/2396) ([RoyalSix](https://github.com/RoyalSix))
+- Merge Conflict Check [\#2392](https://github.com/unfoldingWord-dev/translationCore/pull/2392) ([RoyalSix](https://github.com/RoyalSix))
+- Updated \(ulb, udb, translationWords\) to latest resources [\#2387](https://github.com/unfoldingWord-dev/translationCore/pull/2387) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.43](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.43) (2017-08-07)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.42...v0.7.1-beta.43)
+
+## [v0.7.1-beta.42](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.42) (2017-08-07)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.41...v0.7.1-beta.42)
+
+**Fixed bugs:**
+
+- Clicking on the Tool button on the Home screen takes me to the User screen [\#2263](https://github.com/unfoldingWord-dev/translationCore/issues/2263)
+- Clicking the "Change Project" link on the home page takes me to the User dialog [\#2254](https://github.com/unfoldingWord-dev/translationCore/issues/2254)
+- Logging out sometimes does not result in expected behavior [\#2133](https://github.com/unfoldingWord-dev/translationCore/issues/2133)
+- Error saving project: fatal: Not a git repository \(or any of the parent directories\): .git [\#1948](https://github.com/unfoldingWord-dev/translationCore/issues/1948)
+- Resources folder shows up on My Projects screen [\#1937](https://github.com/unfoldingWord-dev/translationCore/issues/1937)
+- Unable to import projects in 0.7.1-beta.3 [\#1856](https://github.com/unfoldingWord-dev/translationCore/issues/1856)
+
+**Closed issues:**
+
+- Update Project Details Reducer \(manifest\) [\#2349](https://github.com/unfoldingWord-dev/translationCore/issues/2349)
+- Test story [\#2345](https://github.com/unfoldingWord-dev/translationCore/issues/2345)
+- We need a way for the user to designate the language for USFM imports [\#2303](https://github.com/unfoldingWord-dev/translationCore/issues/2303)
+- Package script to run as an NPM script. [\#2283](https://github.com/unfoldingWord-dev/translationCore/issues/2283)
+- Package download/import script to be run as an NPM script. [\#2281](https://github.com/unfoldingWord-dev/translationCore/issues/2281)
+- Check Not Loading Initially [\#2235](https://github.com/unfoldingWord-dev/translationCore/issues/2235)
+- Polish off Home Screen [\#2187](https://github.com/unfoldingWord-dev/translationCore/issues/2187)
+- Add UGL info to Check info card for tW tool [\#2175](https://github.com/unfoldingWord-dev/translationCore/issues/2175)
+- No information is displayed when clicking on the \(i\) following the version number on the main page [\#2174](https://github.com/unfoldingWord-dev/translationCore/issues/2174)
+- Discrepancies between what is on instruction card and action card on the "you are logged in as" screen [\#2173](https://github.com/unfoldingWord-dev/translationCore/issues/2173)
+- Put all tools behind the Konami Code except for tW Part I [\#2145](https://github.com/unfoldingWord-dev/translationCore/issues/2145)
+- Put Ephesians behind Konami code [\#2144](https://github.com/unfoldingWord-dev/translationCore/issues/2144)
+- Refactor home Screen navigation buttons [\#2027](https://github.com/unfoldingWord-dev/translationCore/issues/2027)
+- Improper message on log in screen [\#1985](https://github.com/unfoldingWord-dev/translationCore/issues/1985)
+- Select Mode [\#1748](https://github.com/unfoldingWord-dev/translationCore/issues/1748)
+- 3. Tool: Main Page [\#976](https://github.com/unfoldingWord-dev/translationCore/issues/976)
+
+**Merged pull requests:**
+
+- Bugfix for RecentProjectsActions.js [\#2388](https://github.com/unfoldingWord-dev/translationCore/pull/2388) ([RoyalSix](https://github.com/RoyalSix))
+- Project Validation Stepper Main Container \(Import Check\) [\#2386](https://github.com/unfoldingWord-dev/translationCore/pull/2386) ([RoyalSix](https://github.com/RoyalSix))
+- contextId Validatation [\#2385](https://github.com/unfoldingWord-dev/translationCore/pull/2385) ([klappy](https://github.com/klappy))
+- Prohibit Previously Imported USFM Projects [\#2384](https://github.com/unfoldingWord-dev/translationCore/pull/2384) ([RoyalSix](https://github.com/RoyalSix))
+- Fix Tool Not Showing On First Load [\#2348](https://github.com/unfoldingWord-dev/translationCore/pull/2348) ([RoyalSix](https://github.com/RoyalSix))
+- USFM Exporting Fixes [\#2301](https://github.com/unfoldingWord-dev/translationCore/pull/2301) ([RoyalSix](https://github.com/RoyalSix))
+- Project Instructions Card Fixes [\#2298](https://github.com/unfoldingWord-dev/translationCore/pull/2298) ([RoyalSix](https://github.com/RoyalSix))
+- Upload Project Message Fix [\#2272](https://github.com/unfoldingWord-dev/translationCore/pull/2272) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.41](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.41) (2017-07-25)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.40...v0.7.1-beta.41)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property 'name' of undefined [\#2147](https://github.com/unfoldingWord-dev/translationCore/issues/2147)
+- Uncaught Error: ENOENT: no such file or directory, stat 'C:\Users\tlpri\translationCore\rmr-x-bsa\_mat\_text\_udb\.apps\translationCore' [\#2108](https://github.com/unfoldingWord-dev/translationCore/issues/2108)
+
+**Closed issues:**
+
+- tC Alignment Tool: TACT/MAP [\#2171](https://github.com/unfoldingWord-dev/translationCore/issues/2171)
+- tC Alignment Tool: Tool in tC [\#2170](https://github.com/unfoldingWord-dev/translationCore/issues/2170)
+- tC Alignment Tool: Prerequisites [\#2169](https://github.com/unfoldingWord-dev/translationCore/issues/2169)
+- Style UI components [\#2161](https://github.com/unfoldingWord-dev/translationCore/issues/2161)
+- Create Actions/Reducers for storing/retrieving alignment data. [\#2160](https://github.com/unfoldingWord-dev/translationCore/issues/2160)
+- Create D&D Interface for aligning words/phrases between source/target. [\#2159](https://github.com/unfoldingWord-dev/translationCore/issues/2159)
+- Evaluate React D&D for creating drag and drop UI. [\#2158](https://github.com/unfoldingWord-dev/translationCore/issues/2158)
+- Create Initial Layout for UI [\#2157](https://github.com/unfoldingWord-dev/translationCore/issues/2157)
+- UI: Create a new blank tool that brings in Scripture Pane and a new area for the rest of the checking area to be used for alignment. [\#2156](https://github.com/unfoldingWord-dev/translationCore/issues/2156)
+- tC Alignment Tool [\#2141](https://github.com/unfoldingWord-dev/translationCore/issues/2141)
+
+**Merged pull requests:**
+
+- Addressed QA issue with dev mode not showing tN [\#2271](https://github.com/unfoldingWord-dev/translationCore/pull/2271) ([mannycolon](https://github.com/mannycolon))
+- Cleaned up the home screen implementation [\#2250](https://github.com/unfoldingWord-dev/translationCore/pull/2250) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.40](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.40) (2017-07-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.39...v0.7.1-beta.40)
+
+**Merged pull requests:**
+
+- Added correct instructions for tools main page and login main page [\#2241](https://github.com/unfoldingWord-dev/translationCore/pull/2241) ([mannycolon](https://github.com/mannycolon))
+- Only show tW part 1 in non-developer mode [\#2240](https://github.com/unfoldingWord-dev/translationCore/pull/2240) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.39](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.39) (2017-07-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.38...v0.7.1-beta.39)
+
+**Merged pull requests:**
+
+- Fixes for builds. [\#2246](https://github.com/unfoldingWord-dev/translationCore/pull/2246) ([klappy](https://github.com/klappy))
+- Fixed Valid Project Test [\#2244](https://github.com/unfoldingWord-dev/translationCore/pull/2244) ([RoyalSix](https://github.com/RoyalSix))
+- USFM Export [\#2185](https://github.com/unfoldingWord-dev/translationCore/pull/2185) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.38](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.38) (2017-07-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.37...v0.7.1-beta.38)
+
+## [v0.7.1-beta.37](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.37) (2017-07-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.36...v0.7.1-beta.37)
+
+## [v0.7.1-beta.36](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.36) (2017-07-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.35...v0.7.1-beta.36)
+
+## [v0.7.1-beta.35](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.35) (2017-07-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.34...v0.7.1-beta.35)
+
+**Fixed bugs:**
+
+- Target language not available in scripture pane dropdown list [\#1952](https://github.com/unfoldingWord-dev/translationCore/issues/1952)
+- Electron icon is displayed instead of the tC icon [\#1920](https://github.com/unfoldingWord-dev/translationCore/issues/1920)
+- The splash screen displayed while loading no longer displays the version number [\#1855](https://github.com/unfoldingWord-dev/translationCore/issues/1855)
+- Problems with formatting of Helps text [\#1282](https://github.com/unfoldingWord-dev/translationCore/issues/1282)
+
+**Closed issues:**
+
+- Fix Todd's projects [\#2117](https://github.com/unfoldingWord-dev/translationCore/issues/2117)
+- Refactor build process - part 2 \(Mac\) [\#2101](https://github.com/unfoldingWord-dev/translationCore/issues/2101)
+- Remove/Archive Offline Mode [\#2007](https://github.com/unfoldingWord-dev/translationCore/issues/2007)
+- New field in CSV exports [\#1986](https://github.com/unfoldingWord-dev/translationCore/issues/1986)
+- Builds and Tests not working on TravisCI [\#1954](https://github.com/unfoldingWord-dev/translationCore/issues/1954)
+- Multiple problems with export to csv [\#1854](https://github.com/unfoldingWord-dev/translationCore/issues/1854)
+-  Refactor Build Process - Part 1 \(Research\) [\#1780](https://github.com/unfoldingWord-dev/translationCore/issues/1780)
+- Organize Reducers [\#1771](https://github.com/unfoldingWord-dev/translationCore/issues/1771)
+- Rewrite Project/Tool loading [\#1767](https://github.com/unfoldingWord-dev/translationCore/issues/1767)
+- Performance on Loading [\#1763](https://github.com/unfoldingWord-dev/translationCore/issues/1763)
+- Show edit/comment/bookmark status indicators [\#1722](https://github.com/unfoldingWord-dev/translationCore/issues/1722)
+- Show \(truncated\) highlighted text in the side menu [\#1691](https://github.com/unfoldingWord-dev/translationCore/issues/1691)
+- Support for USFM import [\#1689](https://github.com/unfoldingWord-dev/translationCore/issues/1689)
+- Always keep the group header on the screen unless the group overflows the check menu [\#1642](https://github.com/unfoldingWord-dev/translationCore/issues/1642)
+- Multiple tC icons created in Windows start menu most used list [\#1457](https://github.com/unfoldingWord-dev/translationCore/issues/1457)
+- Some links in tHelps open external links [\#1264](https://github.com/unfoldingWord-dev/translationCore/issues/1264)
+- 0. Home Screen [\#989](https://github.com/unfoldingWord-dev/translationCore/issues/989)
+- 2. Project: Import Local Project [\#970](https://github.com/unfoldingWord-dev/translationCore/issues/970)
+- 1. User: User Page - signed in [\#968](https://github.com/unfoldingWord-dev/translationCore/issues/968)
+- 1. User: Local User [\#966](https://github.com/unfoldingWord-dev/translationCore/issues/966)
+- 1. User: Login with Door43 [\#964](https://github.com/unfoldingWord-dev/translationCore/issues/964)
+
+**Merged pull requests:**
+
+- Only allow Titus projects in non-developer mode [\#2239](https://github.com/unfoldingWord-dev/translationCore/pull/2239) ([mannycolon](https://github.com/mannycolon))
+- Online Import Modal [\#2217](https://github.com/unfoldingWord-dev/translationCore/pull/2217) ([mannycolon](https://github.com/mannycolon))
+- Moving Project Save Location to ~/tC/projects [\#2199](https://github.com/unfoldingWord-dev/translationCore/pull/2199) ([RoyalSix](https://github.com/RoyalSix))
+- Refactor HomeScreen Navigation Buttons [\#2186](https://github.com/unfoldingWord-dev/translationCore/pull/2186) ([RoyalSix](https://github.com/RoyalSix))
+- init git repo, little cleanup for git module [\#2184](https://github.com/unfoldingWord-dev/translationCore/pull/2184) ([klappy](https://github.com/klappy))
+- Bugfix/klappy/remove finished chunks/2182 [\#2183](https://github.com/unfoldingWord-dev/translationCore/pull/2183) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.34](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.34) (2017-07-17)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-33...v0.7.1-beta.34)
+
+**Merged pull requests:**
+
+- USFM Import [\#2151](https://github.com/unfoldingWord-dev/translationCore/pull/2151) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta-33](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-33) (2017-07-14)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-32...v0.7.1-beta-33)
+
+## [v0.7.1-beta-32](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-32) (2017-07-13)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-31...v0.7.1-beta-32)
+
+## [v0.7.1-beta-31](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-31) (2017-07-13)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-30...v0.7.1-beta-31)
+
+## [v0.7.1-beta-30](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-30) (2017-07-13)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.29...v0.7.1-beta-30)
+
+**Implemented enhancements:**
+
+- Highlighting should be disabled during edit and comment [\#1598](https://github.com/unfoldingWord-dev/translationCore/issues/1598)
+- Scripture Pane updates - All verses across translations should line up [\#930](https://github.com/unfoldingWord-dev/translationCore/issues/930)
+
+**Fixed bugs:**
+
+- Don't reset tHelps to the top when user clicks on a link [\#1701](https://github.com/unfoldingWord-dev/translationCore/issues/1701)
+
+**Closed issues:**
+
+- Import Highlights for the UGNT [\#1994](https://github.com/unfoldingWord-dev/translationCore/issues/1994)
+- Refactor moduleSettings generation for scripturePane [\#1881](https://github.com/unfoldingWord-dev/translationCore/issues/1881)
+- Refactor stepper for new UI [\#1880](https://github.com/unfoldingWord-dev/translationCore/issues/1880)
+- Rewrite data/resource parsing [\#1765](https://github.com/unfoldingWord-dev/translationCore/issues/1765)
+- Book/Chapter/verse breakdown [\#1764](https://github.com/unfoldingWord-dev/translationCore/issues/1764)
+- Export location should not default to the translationCore folder [\#1693](https://github.com/unfoldingWord-dev/translationCore/issues/1693)
+- Strong's numbers showing in definition pane [\#1654](https://github.com/unfoldingWord-dev/translationCore/issues/1654)
+- Once a project is selected, it's full name should be shown in the menu bar [\#1346](https://github.com/unfoldingWord-dev/translationCore/issues/1346)
+
+**Merged pull requests:**
+
+- Add Group Name to CSV Export [\#2140](https://github.com/unfoldingWord-dev/translationCore/pull/2140) ([RoyalSix](https://github.com/RoyalSix))
+- Truncated Selection In Menu [\#2135](https://github.com/unfoldingWord-dev/translationCore/pull/2135) ([RoyalSix](https://github.com/RoyalSix))
+- Refactoring of Build Process [\#2120](https://github.com/unfoldingWord-dev/translationCore/pull/2120) ([klappy](https://github.com/klappy))
+- Completed Tool Main Page \(HomeScreen\) [\#2119](https://github.com/unfoldingWord-dev/translationCore/pull/2119) ([mannycolon](https://github.com/mannycolon))
+- Fix Action bug [\#2118](https://github.com/unfoldingWord-dev/translationCore/pull/2118) ([RoyalSix](https://github.com/RoyalSix))
+- New Online Mode Workflow [\#2116](https://github.com/unfoldingWord-dev/translationCore/pull/2116) ([RoyalSix](https://github.com/RoyalSix))
+- Local project import Implementation [\#2114](https://github.com/unfoldingWord-dev/translationCore/pull/2114) ([mannycolon](https://github.com/mannycolon))
+- Fixed user page instructions based on QA [\#2107](https://github.com/unfoldingWord-dev/translationCore/pull/2107) ([mannycolon](https://github.com/mannycolon))
+- ProjectCardMenu [\#2051](https://github.com/unfoldingWord-dev/translationCore/pull/2051) ([klappy](https://github.com/klappy))
+- Missing Verse Check Update To New Structure [\#2034](https://github.com/unfoldingWord-dev/translationCore/pull/2034) ([RoyalSix](https://github.com/RoyalSix))
+- First & Last Check Navigation Fix [\#2025](https://github.com/unfoldingWord-dev/translationCore/pull/2025) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.29](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.29) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.28...v0.7.1-beta.29)
+
+## [v0.7.1-beta.28](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.28) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.27...v0.7.1-beta.28)
+
+## [v0.7.1-beta.27](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.27) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.26...v0.7.1-beta.27)
+
+## [v0.7.1-beta.26](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.26) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.25...v0.7.1-beta.26)
+
+## [v0.7.1-beta.25](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.25) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.24...v0.7.1-beta.25)
+
+## [v0.7.1-beta.24](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.24) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.23...v0.7.1-beta.24)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#2035](https://github.com/unfoldingWord-dev/translationCore/issues/2035)
+- Uncaught TypeError: GetDataActions.clearPreviousData is not a function [\#2023](https://github.com/unfoldingWord-dev/translationCore/issues/2023)
+- Uncaught Error: ENOENT: no such file or directory, stat '/Users/cckozie/translationCore/es-419\_eph\_text\_ulb/.apps/translationCore' [\#2022](https://github.com/unfoldingWord-dev/translationCore/issues/2022)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#2021](https://github.com/unfoldingWord-dev/translationCore/issues/2021)
+- Uncaught TypeError: GetDataActions.clearPreviousData is not a function [\#1984](https://github.com/unfoldingWord-dev/translationCore/issues/1984)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#1983](https://github.com/unfoldingWord-dev/translationCore/issues/1983)
+- Uncaught TypeError: GetDataActions.clearPreviousData is not a function [\#1942](https://github.com/unfoldingWord-dev/translationCore/issues/1942)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1938](https://github.com/unfoldingWord-dev/translationCore/issues/1938)
+- Uncaught Error: ENOENT: no such file or directory, scandir './static/resources/bibles' [\#1930](https://github.com/unfoldingWord-dev/translationCore/issues/1930)
+- Uncaught TypeError: GetDataActions.clearPreviousData is not a function [\#1922](https://github.com/unfoldingWord-dev/translationCore/issues/1922)
+- Uncaught TypeError: Cannot read property '9' of undefined [\#1919](https://github.com/unfoldingWord-dev/translationCore/issues/1919)
+- Uncaught TypeError: Cannot read property '24' of undefined [\#1918](https://github.com/unfoldingWord-dev/translationCore/issues/1918)
+- Uncaught Error: ENOENT: no such file or directory, scandir './static/resources/bibles' [\#1917](https://github.com/unfoldingWord-dev/translationCore/issues/1917)
+- Uncaught Error: Cannot find module './CheckDataLoadActions' [\#1850](https://github.com/unfoldingWord-dev/translationCore/issues/1850)
+
+**Merged pull requests:**
+
+- Now dimming the rest of the screen when clicking the project FAB [\#2036](https://github.com/unfoldingWord-dev/translationCore/pull/2036) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.23](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.23) (2017-07-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.22...v0.7.1-beta.23)
+
+**Fixed bugs:**
+
+- Cannot open any project in 0.7.1-beta.7 [\#1982](https://github.com/unfoldingWord-dev/translationCore/issues/1982)
+- Blank checking screen with v0.7.1-beta.2 [\#1921](https://github.com/unfoldingWord-dev/translationCore/issues/1921)
+- Blank screen after loading project [\#1842](https://github.com/unfoldingWord-dev/translationCore/issues/1842)
+- Entire tC window went blank [\#1572](https://github.com/unfoldingWord-dev/translationCore/issues/1572)
+
+**Merged pull requests:**
+
+- addressed QA issues for \#964 and \#966 [\#2032](https://github.com/unfoldingWord-dev/translationCore/pull/2032) ([mannycolon](https://github.com/mannycolon))
+- MyProjects Actions/Reducers [\#2026](https://github.com/unfoldingWord-dev/translationCore/pull/2026) ([klappy](https://github.com/klappy))
+- Created my projects FAB [\#2024](https://github.com/unfoldingWord-dev/translationCore/pull/2024) ([mannycolon](https://github.com/mannycolon))
+- Basic Layout and design of ProjectsManagement page. \#969 [\#2020](https://github.com/unfoldingWord-dev/translationCore/pull/2020) ([klappy](https://github.com/klappy))
+- Rewrote Project/Tool loading [\#2018](https://github.com/unfoldingWord-dev/translationCore/pull/2018) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.22](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.22) (2017-06-30)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.21...v0.7.1-beta.22)
+
+**Merged pull requests:**
+
+- Updated upload to Door43 confirmation message [\#2019](https://github.com/unfoldingWord-dev/translationCore/pull/2019) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.7.1-beta.21](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.21) (2017-06-30)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.20...v0.7.1-beta.21)
+
+## [v0.7.1-beta.20](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.20) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.19...v0.7.1-beta.20)
+
+## [v0.7.1-beta.19](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.19) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.18...v0.7.1-beta.19)
+
+## [v0.7.1-beta.18](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.18) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.17...v0.7.1-beta.18)
+
+## [v0.7.1-beta.17](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.17) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.16...v0.7.1-beta.17)
+
+## [v0.7.1-beta.16](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.16) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.15...v0.7.1-beta.16)
+
+## [v0.7.1-beta.15](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.15) (2017-06-29)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.14...v0.7.1-beta.15)
+
+**Fixed bugs:**
+
+- Scrollbar on wrong side of resource in scripture pane [\#1951](https://github.com/unfoldingWord-dev/translationCore/issues/1951)
+- Build 0.7.1-beta.3 causes Windows error on first startup [\#1933](https://github.com/unfoldingWord-dev/translationCore/issues/1933)
+
+**Closed issues:**
+
+- Make tHelps a movable window, not a modal  [\#2012](https://github.com/unfoldingWord-dev/translationCore/issues/2012)
+- Add support for OT [\#2008](https://github.com/unfoldingWord-dev/translationCore/issues/2008)
+- Add indications/warnings about activities that use the Internet [\#1707](https://github.com/unfoldingWord-dev/translationCore/issues/1707)
+
+**Merged pull requests:**
+
+- Fixes for edited verses to save via reducer/savemethod [\#2013](https://github.com/unfoldingWord-dev/translationCore/pull/2013) ([klappy](https://github.com/klappy))
+- Refactor of Reducers [\#1989](https://github.com/unfoldingWord-dev/translationCore/pull/1989) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.14](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.14) (2017-06-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.13...v0.7.1-beta.14)
+
+## [v0.7.1-beta.13](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.13) (2017-06-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.12...v0.7.1-beta.13)
+
+## [v0.7.1-beta.12](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.12) (2017-06-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.11...v0.7.1-beta.12)
+
+## [v0.7.1-beta.11](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.11) (2017-06-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.10...v0.7.1-beta.11)
+
+## [v0.7.1-beta.10](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.10) (2017-06-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.9...v0.7.1-beta.10)
+
+## [v0.7.1-beta.9](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.9) (2017-06-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-build.8...v0.7.1-beta.9)
+
+## [v0.7.1-build.8](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-build.8) (2017-06-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.7...v0.7.1-build.8)
+
+## [v0.7.1-beta.7](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.7) (2017-06-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta-4...v0.7.1-beta.7)
+
+## [v0.7.1-beta-4](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta-4) (2017-06-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.3...v0.7.1-beta-4)
+
+**Fixed bugs:**
+
+- Check has been completed, but bookmark icon is displayed instead of check [\#1747](https://github.com/unfoldingWord-dev/translationCore/issues/1747)
+
+**Closed issues:**
+
+- Rewrite tool loading [\#1768](https://github.com/unfoldingWord-dev/translationCore/issues/1768)
+
+**Merged pull requests:**
+
+- User Card Section [\#1956](https://github.com/unfoldingWord-dev/translationCore/pull/1956) ([RoyalSix](https://github.com/RoyalSix))
+- HomeScreen: ToolCard styled and dynamic progress \#1908 [\#1955](https://github.com/unfoldingWord-dev/translationCore/pull/1955) ([klappy](https://github.com/klappy))
+- Updated .eslintrc to fit our project. [\#1950](https://github.com/unfoldingWord-dev/translationCore/pull/1950) ([klappy](https://github.com/klappy))
+- HomeScreen ProjectCard Styled and dynamic info with mock timestamp. \#1903 [\#1945](https://github.com/unfoldingWord-dev/translationCore/pull/1945) ([klappy](https://github.com/klappy))
+- UserCard with giant Glyph [\#1944](https://github.com/unfoldingWord-dev/translationCore/pull/1944) ([klappy](https://github.com/klappy))
+- Refactored the moduleSettings generation for scripturePane  [\#1943](https://github.com/unfoldingWord-dev/translationCore/pull/1943) ([mannycolon](https://github.com/mannycolon))
+- Updated Layout for Home Screen \#1895 [\#1940](https://github.com/unfoldingWord-dev/translationCore/pull/1940) ([klappy](https://github.com/klappy))
+- Created actions and/or helpers to load all bibles manifest files [\#1939](https://github.com/unfoldingWord-dev/translationCore/pull/1939) ([mannycolon](https://github.com/mannycolon))
+- Fixed bug with stepper where it would go over limit of steps [\#1934](https://github.com/unfoldingWord-dev/translationCore/pull/1934) ([mannycolon](https://github.com/mannycolon))
+- fixed small bug with status bar  [\#1932](https://github.com/unfoldingWord-dev/translationCore/pull/1932) ([mannycolon](https://github.com/mannycolon))
+- Instructions functioning with actions/reducers \#1907 [\#1931](https://github.com/unfoldingWord-dev/translationCore/pull/1931) ([klappy](https://github.com/klappy))
+- New Stepper Implementation [\#1929](https://github.com/unfoldingWord-dev/translationCore/pull/1929) ([mannycolon](https://github.com/mannycolon))
+- Updating navigation based on stepper [\#1928](https://github.com/unfoldingWord-dev/translationCore/pull/1928) ([klappy](https://github.com/klappy))
+- Added Check For Blank Fields CSV [\#1925](https://github.com/unfoldingWord-dev/translationCore/pull/1925) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.3](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.3) (2017-06-21)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.2...v0.7.1-beta.3)
+
+**Closed issues:**
+
+- Make builds for Windows and Mac [\#1851](https://github.com/unfoldingWord-dev/translationCore/issues/1851)
+
+**Merged pull requests:**
+
+- Fix Static Folder Reference [\#1927](https://github.com/unfoldingWord-dev/translationCore/pull/1927) ([RoyalSix](https://github.com/RoyalSix))
+- Proposed changes for Home screen to work. [\#1923](https://github.com/unfoldingWord-dev/translationCore/pull/1923) ([klappy](https://github.com/klappy))
+
+## [v0.7.1-beta.2](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.2) (2017-06-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.1-beta.1...v0.7.1-beta.2)
+
+**Closed issues:**
+
+- Make sure NT and OT projects don't try to open opposite UGNT/UHB. [\#1882](https://github.com/unfoldingWord-dev/translationCore/issues/1882)
+- Remove unnecessary action constants [\#1800](https://github.com/unfoldingWord-dev/translationCore/issues/1800)
+- Refactor Reducers [\#1799](https://github.com/unfoldingWord-dev/translationCore/issues/1799)
+- Change Folder Name From ULB [\#1796](https://github.com/unfoldingWord-dev/translationCore/issues/1796)
+- Rename Original Bible File [\#1790](https://github.com/unfoldingWord-dev/translationCore/issues/1790)
+- Refactor wordList [\#1788](https://github.com/unfoldingWord-dev/translationCore/issues/1788)
+- Remove Requirements.js [\#1785](https://github.com/unfoldingWord-dev/translationCore/issues/1785)
+- Deleting unnecessary files \(other work\) [\#1784](https://github.com/unfoldingWord-dev/translationCore/issues/1784)
+- Codebase folder structure [\#1774](https://github.com/unfoldingWord-dev/translationCore/issues/1774)
+- Requirements.js [\#1773](https://github.com/unfoldingWord-dev/translationCore/issues/1773)
+- Reorganize the actions [\#1772](https://github.com/unfoldingWord-dev/translationCore/issues/1772)
+- Remove module API [\#1770](https://github.com/unfoldingWord-dev/translationCore/issues/1770)
+- Codebase Cleanup [\#1769](https://github.com/unfoldingWord-dev/translationCore/issues/1769)
+- Dataflow consistency [\#1762](https://github.com/unfoldingWord-dev/translationCore/issues/1762)
+- Diagram Data Flow Architecture [\#1761](https://github.com/unfoldingWord-dev/translationCore/issues/1761)
+- USFM parsing library [\#1760](https://github.com/unfoldingWord-dev/translationCore/issues/1760)
+- Change CoreActionConsts.js to ActionTypes.js and change it to ES6 [\#1731](https://github.com/unfoldingWord-dev/translationCore/issues/1731)
+- Write tests for Redux Action Creators [\#1716](https://github.com/unfoldingWord-dev/translationCore/issues/1716)
+- Stepper [\#980](https://github.com/unfoldingWord-dev/translationCore/issues/980)
+
+**Merged pull requests:**
+
+- Merge Develop into Master Branch [\#1916](https://github.com/unfoldingWord-dev/translationCore/pull/1916) ([klappy](https://github.com/klappy))
+- removed unnecessary resources saving functions from codebase [\#1878](https://github.com/unfoldingWord-dev/translationCore/pull/1878) ([mannycolon](https://github.com/mannycolon))
+- Populate tH resources actions/reducers \#1871 [\#1876](https://github.com/unfoldingWord-dev/translationCore/pull/1876) ([klappy](https://github.com/klappy))
+- Now Copying translationHelps from User Resources to Project Resources [\#1875](https://github.com/unfoldingWord-dev/translationCore/pull/1875) ([mannycolon](https://github.com/mannycolon))
+- Fix index.json [\#1874](https://github.com/unfoldingWord-dev/translationCore/pull/1874) ([RoyalSix](https://github.com/RoyalSix))
+- Bugfix/jay/valid project/1866 [\#1870](https://github.com/unfoldingWord-dev/translationCore/pull/1870) ([RoyalSix](https://github.com/RoyalSix))
+- Now Copying translationHelps from Static folder to User Resources folder [\#1869](https://github.com/unfoldingWord-dev/translationCore/pull/1869) ([mannycolon](https://github.com/mannycolon))
+- Added bible loading action to app.js [\#1865](https://github.com/unfoldingWord-dev/translationCore/pull/1865) ([mannycolon](https://github.com/mannycolon))
+- create function to copy bibles from static folder to local user folder [\#1864](https://github.com/unfoldingWord-dev/translationCore/pull/1864) ([mannycolon](https://github.com/mannycolon))
+- Refactor Project Loading [\#1862](https://github.com/unfoldingWord-dev/translationCore/pull/1862) ([RoyalSix](https://github.com/RoyalSix))
+- bible chapter breakdown [\#1861](https://github.com/unfoldingWord-dev/translationCore/pull/1861) ([mannycolon](https://github.com/mannycolon))
+- Version Name For Resource [\#1859](https://github.com/unfoldingWord-dev/translationCore/pull/1859) ([RoyalSix](https://github.com/RoyalSix))
+- Add openOptionDialog and closeAlertDialog to ToolsContainer \#1818 [\#1858](https://github.com/unfoldingWord-dev/translationCore/pull/1858) ([klappy](https://github.com/klappy))
+- Add Project Name To Status Bar [\#1857](https://github.com/unfoldingWord-dev/translationCore/pull/1857) ([RoyalSix](https://github.com/RoyalSix))
+- Parsed Resources [\#1852](https://github.com/unfoldingWord-dev/translationCore/pull/1852) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.1-beta.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.1-beta.1) (2017-06-15)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.7.0...v0.7.1-beta.1)
+
+**Implemented enhancements:**
+
+- Trim the white space at the beginning and end of user entered URL [\#1579](https://github.com/unfoldingWord-dev/translationCore/issues/1579)
+- Clear the URL text field on the Import Online Projects page when the user clicks the Refresh button [\#1566](https://github.com/unfoldingWord-dev/translationCore/issues/1566)
+- Show some indication that work is being done when the user clicks Refresh on the Import Online Projects page [\#1565](https://github.com/unfoldingWord-dev/translationCore/issues/1565)
+- Make our terms and conditions and the software licenses available when a user is logged in [\#1545](https://github.com/unfoldingWord-dev/translationCore/issues/1545)
+- Gracefully handle incomplete projects [\#1536](https://github.com/unfoldingWord-dev/translationCore/issues/1536)
+- Add tooltips to the checking page [\#1522](https://github.com/unfoldingWord-dev/translationCore/issues/1522)
+- Revise the text on the Add Resources dialog [\#1520](https://github.com/unfoldingWord-dev/translationCore/issues/1520)
+- Usability enhancement on the My Projects page [\#1519](https://github.com/unfoldingWord-dev/translationCore/issues/1519)
+- Auto choosing language direction [\#353](https://github.com/unfoldingWord-dev/translationCore/issues/353)
+
+**Fixed bugs:**
+
+- Bug Report: [\#1813](https://github.com/unfoldingWord-dev/translationCore/issues/1813)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1756](https://github.com/unfoldingWord-dev/translationCore/issues/1756)
+- Uncaught SyntaxError: Invalid regular expression: /सारा कीमे उसकै पांया तळै कर दिया; अर उस ताही सारी चीज्जां पै सारा तै ऊँचा\(शिरो/: Unterminated group [\#1755](https://github.com/unfoldingWord-dev/translationCore/issues/1755)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1754](https://github.com/unfoldingWord-dev/translationCore/issues/1754)
+- Uncaught SyntaxError: Invalid regular expression: /कीहके लो दा फल सारे चाल्ली दी पलाई, अते तार्मिकता, अते सचाई ऐ \),/: Unmatched '\)' [\#1751](https://github.com/unfoldingWord-dev/translationCore/issues/1751)
+- Uncaught TypeError: Cannot read property 'remove' of undefined [\#1746](https://github.com/unfoldingWord-dev/translationCore/issues/1746)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1745](https://github.com/unfoldingWord-dev/translationCore/issues/1745)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1744](https://github.com/unfoldingWord-dev/translationCore/issues/1744)
+- "error: could not lock config file .git/config: No such file or directory\n" [\#1743](https://github.com/unfoldingWord-dev/translationCore/issues/1743)
+- "fatal: Not a git repository \(or any of the parent directories\): .git\n" [\#1742](https://github.com/unfoldingWord-dev/translationCore/issues/1742)
+- "error: could not lock config file .git/config: No such file or directory\nerror: could not lock config file .git/config: Invalid argument\n" [\#1741](https://github.com/unfoldingWord-dev/translationCore/issues/1741)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1739](https://github.com/unfoldingWord-dev/translationCore/issues/1739)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1738](https://github.com/unfoldingWord-dev/translationCore/issues/1738)
+- General Feedback: [\#1737](https://github.com/unfoldingWord-dev/translationCore/issues/1737)
+- Bug Report: [\#1736](https://github.com/unfoldingWord-dev/translationCore/issues/1736)
+- "Cloning into 'C:\\Users\\joshy\\translationCore\\hi\_eph\_text\_reg'...\nfatal: unable to access 'https://git.door43.org/Ludhiana/hi\_eph\_text\_reg.git/': Failed to connect to git.door43.org port 443: Timed out\n" [\#1734](https://github.com/unfoldingWord-dev/translationCore/issues/1734)
+- "Cloning into 'C:\\Users\\Russ\\translationCore\\id\_act\_text\_ulb'...\nfatal: early EOF\nfatal: The remote end hung up unexpectedly\nfatal: index-pack failed\nerror: RPC failed; curl 18 transfer closed with outstanding read data remaining\n" [\#1729](https://github.com/unfoldingWord-dev/translationCore/issues/1729)
+- Uncaught TypeError: Cannot read property '10' of undefined [\#1728](https://github.com/unfoldingWord-dev/translationCore/issues/1728)
+- Uncaught TypeError: Cannot read property '8' of undefined [\#1727](https://github.com/unfoldingWord-dev/translationCore/issues/1727)
+- Uncaught TypeError: Cannot read property '9' of undefined [\#1726](https://github.com/unfoldingWord-dev/translationCore/issues/1726)
+- Uncaught TypeError: Cannot read property '7' of undefined [\#1725](https://github.com/unfoldingWord-dev/translationCore/issues/1725)
+- Uncaught TypeError: Cannot read property '24' of undefined [\#1724](https://github.com/unfoldingWord-dev/translationCore/issues/1724)
+- Uncaught TypeError: Cannot read property 'name' of undefined [\#1723](https://github.com/unfoldingWord-dev/translationCore/issues/1723)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1705](https://github.com/unfoldingWord-dev/translationCore/issues/1705)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1704](https://github.com/unfoldingWord-dev/translationCore/issues/1704)
+- Select button for project is disabled after importing it from Door43 [\#1703](https://github.com/unfoldingWord-dev/translationCore/issues/1703)
+- Fail to push [\#1698](https://github.com/unfoldingWord-dev/translationCore/issues/1698)
+- Uncaught TypeError: Cannot read property 'findIndex' of undefined [\#1697](https://github.com/unfoldingWord-dev/translationCore/issues/1697)
+- Uncaught Javascript error [\#1696](https://github.com/unfoldingWord-dev/translationCore/issues/1696)
+- Received "Error uploading: Unkown Error message" when attempting to upload project. [\#1694](https://github.com/unfoldingWord-dev/translationCore/issues/1694)
+- Project imports from user's repo, but not using the URL [\#1682](https://github.com/unfoldingWord-dev/translationCore/issues/1682)
+- Error message when uploading [\#1681](https://github.com/unfoldingWord-dev/translationCore/issues/1681)
+- "fatal: could not read Password for 'https://undefined@git.door43.org': Device not configured\n" [\#1680](https://github.com/unfoldingWord-dev/translationCore/issues/1680)
+- Clicking Skip invalidates next check [\#1677](https://github.com/unfoldingWord-dev/translationCore/issues/1677)
+- Uncaught TypeError: Cannot read property '21' of undefined [\#1675](https://github.com/unfoldingWord-dev/translationCore/issues/1675)
+- Uncaught TypeError: Cannot read property '5' of undefined [\#1674](https://github.com/unfoldingWord-dev/translationCore/issues/1674)
+- Uncaught TypeError: Cannot read property '12' of undefined [\#1673](https://github.com/unfoldingWord-dev/translationCore/issues/1673)
+- Scripture Pane Language Name doesn't match the actual translation [\#1672](https://github.com/unfoldingWord-dev/translationCore/issues/1672)
+- Target translation is not displayed in scripture pane or in Select area [\#1668](https://github.com/unfoldingWord-dev/translationCore/issues/1668)
+- Uncaught TypeError: Cannot read property 'includes' of undefined [\#1667](https://github.com/unfoldingWord-dev/translationCore/issues/1667)
+- Multiple problems with links in tHelps [\#1665](https://github.com/unfoldingWord-dev/translationCore/issues/1665)
+- Uncaught TypeError: Cannot read property 'finished\_chunks' of null [\#1650](https://github.com/unfoldingWord-dev/translationCore/issues/1650)
+- Wrong title/font in scripture pane [\#1646](https://github.com/unfoldingWord-dev/translationCore/issues/1646)
+- UI improvements on checking screen [\#1645](https://github.com/unfoldingWord-dev/translationCore/issues/1645)
+- tC does not recognize previously installed Git 2.9.2 [\#1631](https://github.com/unfoldingWord-dev/translationCore/issues/1631)
+- Selection has been made in check, but edit glyph is displayed [\#1629](https://github.com/unfoldingWord-dev/translationCore/issues/1629)
+- Uncaught TypeError: Cannot convert undefined or null to object [\#1623](https://github.com/unfoldingWord-dev/translationCore/issues/1623)
+- Text edits do not appear in the Select pane. [\#1618](https://github.com/unfoldingWord-dev/translationCore/issues/1618)
+- Import using URL still uses the old progress wheel [\#1613](https://github.com/unfoldingWord-dev/translationCore/issues/1613)
+- App malfunctions while performing/skipping checks [\#1611](https://github.com/unfoldingWord-dev/translationCore/issues/1611)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1610](https://github.com/unfoldingWord-dev/translationCore/issues/1610)
+- App hangs when reloading a project [\#1604](https://github.com/unfoldingWord-dev/translationCore/issues/1604)
+- Uncaught TypeError: Cannot read property 'includes' of undefined [\#1603](https://github.com/unfoldingWord-dev/translationCore/issues/1603)
+- Headers have disappeared on enlarged scripture pane between 0.6.22 and 0.6.23 [\#1597](https://github.com/unfoldingWord-dev/translationCore/issues/1597)
+- Save and Continue moves to next check, but text in Select area remains on same verse [\#1594](https://github.com/unfoldingWord-dev/translationCore/issues/1594)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1585](https://github.com/unfoldingWord-dev/translationCore/issues/1585)
+- Received the "Some selections are no longer valid and are removed." message [\#1583](https://github.com/unfoldingWord-dev/translationCore/issues/1583)
+- Multiple problems when uploading [\#1582](https://github.com/unfoldingWord-dev/translationCore/issues/1582)
+- Problems in tS after uploading from tC [\#1581](https://github.com/unfoldingWord-dev/translationCore/issues/1581)
+- Fail to push [\#1580](https://github.com/unfoldingWord-dev/translationCore/issues/1580)
+- Verse text appears blank in projects that have merge conflicts [\#1573](https://github.com/unfoldingWord-dev/translationCore/issues/1573)
+- Uncaught TypeError: Cannot read property 'package\_version' of undefined [\#1571](https://github.com/unfoldingWord-dev/translationCore/issues/1571)
+- Windows 10 machine locks up and project is rendered unusable [\#1568](https://github.com/unfoldingWord-dev/translationCore/issues/1568)
+- Uncaught SyntaxError: C:\Users\tlpri\translationCore\rmy-x-vg\_mrk\_text\_reg\manifest.json: Unexpected token \< in JSON at position 3 [\#1564](https://github.com/unfoldingWord-dev/translationCore/issues/1564)
+- Picture links in tHelps do not work [\#1552](https://github.com/unfoldingWord-dev/translationCore/issues/1552)
+- Gracefully handle incomplete projects [\#1536](https://github.com/unfoldingWord-dev/translationCore/issues/1536)
+- Clear the URL field when opening the Import Online Projects page [\#1529](https://github.com/unfoldingWord-dev/translationCore/issues/1529)
+- Checking work is lost after switching tools [\#1508](https://github.com/unfoldingWord-dev/translationCore/issues/1508)
+- Work area on project screen is blank [\#1496](https://github.com/unfoldingWord-dev/translationCore/issues/1496)
+- Clicking on multiple links in tHelps opens multiple windows [\#1456](https://github.com/unfoldingWord-dev/translationCore/issues/1456)
+- Clicking on a new group in the Words menu scrolls the selected group off the of screen [\#1448](https://github.com/unfoldingWord-dev/translationCore/issues/1448)
+- Project downloaded from door43 but the loading process did not continue [\#1432](https://github.com/unfoldingWord-dev/translationCore/issues/1432)
+- Project appears but check menu is blank [\#1383](https://github.com/unfoldingWord-dev/translationCore/issues/1383)
+- Re-importing a project from door43 causes problems [\#1382](https://github.com/unfoldingWord-dev/translationCore/issues/1382)
+- tN check does not show highlighted text in source [\#1377](https://github.com/unfoldingWord-dev/translationCore/issues/1377)
+- Problems with message displayed when opening a project [\#1369](https://github.com/unfoldingWord-dev/translationCore/issues/1369)
+- Loading a tW projects causes a blank screen with no error messages [\#1349](https://github.com/unfoldingWord-dev/translationCore/issues/1349)
+- tC does not know how to deal with chunks that contain conflicts [\#1348](https://github.com/unfoldingWord-dev/translationCore/issues/1348)
+- If a project is mostly empty, the main check screen is empty [\#1343](https://github.com/unfoldingWord-dev/translationCore/issues/1343)
+- When reopening a project, the check list should automatically scroll to the current check [\#1325](https://github.com/unfoldingWord-dev/translationCore/issues/1325)
+- Multiple panel sizing issues when app window is reduced in width or height [\#1311](https://github.com/unfoldingWord-dev/translationCore/issues/1311)
+- App hangs after loading a project [\#1307](https://github.com/unfoldingWord-dev/translationCore/issues/1307)
+- Remove Help menu or change it to have meaningful options [\#1275](https://github.com/unfoldingWord-dev/translationCore/issues/1275)
+- Modify View menu to only include desired and supported options [\#1274](https://github.com/unfoldingWord-dev/translationCore/issues/1274)
+- Modify Edit menu to only include desired and supported options [\#1273](https://github.com/unfoldingWord-dev/translationCore/issues/1273)
+- The reason is not being saved with the edit [\#1193](https://github.com/unfoldingWord-dev/translationCore/issues/1193)
+
+**Closed issues:**
+
+- Set up a Windows development environment [\#1845](https://github.com/unfoldingWord-dev/translationCore/issues/1845)
+- Test story 2 [\#1807](https://github.com/unfoldingWord-dev/translationCore/issues/1807)
+- Test Story [\#1802](https://github.com/unfoldingWord-dev/translationCore/issues/1802)
+- Get Coveralls working [\#1758](https://github.com/unfoldingWord-dev/translationCore/issues/1758)
+- test issues [\#1740](https://github.com/unfoldingWord-dev/translationCore/issues/1740)
+- Completely Remove Module API from codebase [\#1733](https://github.com/unfoldingWord-dev/translationCore/issues/1733)
+- Update all Resources to latest stable release from API [\#1719](https://github.com/unfoldingWord-dev/translationCore/issues/1719)
+- Integrate Coveralls with Repo [\#1695](https://github.com/unfoldingWord-dev/translationCore/issues/1695)
+- Dynamic Instructions for "Select" Card [\#1688](https://github.com/unfoldingWord-dev/translationCore/issues/1688)
+- tA ver 6 [\#1686](https://github.com/unfoldingWord-dev/translationCore/issues/1686)
+- test issue [\#1684](https://github.com/unfoldingWord-dev/translationCore/issues/1684)
+- Need visual indicators in the checking area when edits and comments have been performed on the check [\#1679](https://github.com/unfoldingWord-dev/translationCore/issues/1679)
+- Projects with extra manifest files won't import or load [\#1660](https://github.com/unfoldingWord-dev/translationCore/issues/1660)
+- Takes more than 3 minutes to open a Matthew tW project [\#1655](https://github.com/unfoldingWord-dev/translationCore/issues/1655)
+- Change the link for attribution in the Terms and Conditions to https://git.door43.org/ [\#1652](https://github.com/unfoldingWord-dev/translationCore/issues/1652)
+- Inconsistencies in time required to load projects [\#1647](https://github.com/unfoldingWord-dev/translationCore/issues/1647)
+- Do not close the project when exporting [\#1628](https://github.com/unfoldingWord-dev/translationCore/issues/1628)
+- Should be able to upload and export from the checking page [\#1627](https://github.com/unfoldingWord-dev/translationCore/issues/1627)
+- Keep the height of the check pane consistent [\#1626](https://github.com/unfoldingWord-dev/translationCore/issues/1626)
+- rename apps folder to .apps [\#1614](https://github.com/unfoldingWord-dev/translationCore/issues/1614)
+- Warn user when trying to load project with missing verses [\#1588](https://github.com/unfoldingWord-dev/translationCore/issues/1588)
+- Prohibit loading of project with no manifest [\#1587](https://github.com/unfoldingWord-dev/translationCore/issues/1587)
+- Prohibit loading projects with merge conflicts [\#1586](https://github.com/unfoldingWord-dev/translationCore/issues/1586)
+- Password handling [\#1576](https://github.com/unfoldingWord-dev/translationCore/issues/1576)
+- Cursor should change to a hand when hover over the \(i\) on the User screen [\#1574](https://github.com/unfoldingWord-dev/translationCore/issues/1574)
+- Modify the My Projects screen so that the buttons don't stack [\#1549](https://github.com/unfoldingWord-dev/translationCore/issues/1549)
+- Usability and styling enhancements to the User modal [\#1548](https://github.com/unfoldingWord-dev/translationCore/issues/1548)
+- Remove the "ToolsTester" tool option available in developer mode [\#1540](https://github.com/unfoldingWord-dev/translationCore/issues/1540)
+- Improper error message when attempting to upload while logged in as a local user [\#1516](https://github.com/unfoldingWord-dev/translationCore/issues/1516)
+- Prevent text highlighting in the Select pane [\#1515](https://github.com/unfoldingWord-dev/translationCore/issues/1515)
+- App hangs with project loading message displayed [\#1511](https://github.com/unfoldingWord-dev/translationCore/issues/1511)
+- typing error on Terms and Conditions Page [\#1500](https://github.com/unfoldingWord-dev/translationCore/issues/1500)
+- Revamp Fetch Data [\#1499](https://github.com/unfoldingWord-dev/translationCore/issues/1499)
+- Cannot Edit Verse On Missing Chunks [\#1465](https://github.com/unfoldingWord-dev/translationCore/issues/1465)
+- Break down Bibles into Book/Chapter/Verse [\#1464](https://github.com/unfoldingWord-dev/translationCore/issues/1464)
+- Should the user need to respond to the Skip dialog if the check has been bookmarked? [\#1449](https://github.com/unfoldingWord-dev/translationCore/issues/1449)
+- Performance issues [\#1442](https://github.com/unfoldingWord-dev/translationCore/issues/1442)
+- Do we really want to capture every highlight and un-highlight the user performs. \(And the associated user experience issues\) [\#1434](https://github.com/unfoldingWord-dev/translationCore/issues/1434)
+- Reset tHelps to the top when a new topic is displayed [\#1423](https://github.com/unfoldingWord-dev/translationCore/issues/1423)
+- Windows installation [\#1402](https://github.com/unfoldingWord-dev/translationCore/issues/1402)
+- Update all colors/buttons to conform to global style settings [\#1374](https://github.com/unfoldingWord-dev/translationCore/issues/1374)
+- Make creating a desktop icon the default when installing tC. [\#1366](https://github.com/unfoldingWord-dev/translationCore/issues/1366)
+- Performing an uninstall should "sign out" current user [\#1365](https://github.com/unfoldingWord-dev/translationCore/issues/1365)
+- The menu \(list of checks\) needs to scroll as the user moves forward/backward through the checks [\#1347](https://github.com/unfoldingWord-dev/translationCore/issues/1347)
+- The "X" for close dialog is almost invisible on the expanded scripture pane [\#1341](https://github.com/unfoldingWord-dev/translationCore/issues/1341)
+- Language names longer than 2 lines appear poorly on expanded scripture pane [\#1340](https://github.com/unfoldingWord-dev/translationCore/issues/1340)
+- tHelps external link bringing up wrong dialog [\#1335](https://github.com/unfoldingWord-dev/translationCore/issues/1335)
+- Do we need to add verbiage on the sign in page that references door43? [\#1328](https://github.com/unfoldingWord-dev/translationCore/issues/1328)
+- Do we want to have the Online/Offline switch available in beta? [\#1326](https://github.com/unfoldingWord-dev/translationCore/issues/1326)
+- tA ver 6 [\#1300](https://github.com/unfoldingWord-dev/translationCore/issues/1300)
+- Figure out how to deal with both unfinished and empty chunks [\#1292](https://github.com/unfoldingWord-dev/translationCore/issues/1292)
+- Change "Save and Continue" to "Save and Next" [\#1281](https://github.com/unfoldingWord-dev/translationCore/issues/1281)
+- It would be good to also show the project's target language name in the tC menu bar [\#1280](https://github.com/unfoldingWord-dev/translationCore/issues/1280)
+- Forms appear to be modals but are not [\#1272](https://github.com/unfoldingWord-dev/translationCore/issues/1272)
+- Project tab does not follow tC style guide [\#1271](https://github.com/unfoldingWord-dev/translationCore/issues/1271)
+- Should it be Sign In & Sign Out or Log In and Log Out? [\#1268](https://github.com/unfoldingWord-dev/translationCore/issues/1268)
+- Progress scrolls right off the bottom of the menu [\#1261](https://github.com/unfoldingWord-dev/translationCore/issues/1261)
+- Import local tS files [\#1231](https://github.com/unfoldingWord-dev/translationCore/issues/1231)
+- Should have a tooltip on the bookmark icon [\#1218](https://github.com/unfoldingWord-dev/translationCore/issues/1218)
+- Decide on and implement a standard for Close button and/or "X" on dialogs/modals [\#1213](https://github.com/unfoldingWord-dev/translationCore/issues/1213)
+- The "X" for close dialog is almost invisible on the Add Resources dialog [\#1211](https://github.com/unfoldingWord-dev/translationCore/issues/1211)
+- Disable the "Load" button on the tool when it is currently being used in the active project [\#1208](https://github.com/unfoldingWord-dev/translationCore/issues/1208)
+- When the user returns to a previously completed check, there should be a visible indication that it has been edited and/or commented. [\#1194](https://github.com/unfoldingWord-dev/translationCore/issues/1194)
+- Inconsistencies in when changes are commited [\#1181](https://github.com/unfoldingWord-dev/translationCore/issues/1181)
+- There should be some verbiage and a progress bar during the load of a project/tool combo [\#1176](https://github.com/unfoldingWord-dev/translationCore/issues/1176)
+- Problems created by force closing the app [\#1175](https://github.com/unfoldingWord-dev/translationCore/issues/1175)
+- It is not intuitive how to unselect something in the Select box [\#1170](https://github.com/unfoldingWord-dev/translationCore/issues/1170)
+- Screen real estate problem on open project work screen on my Lenovo laptop \(11e, 11.5 inch screen\) [\#1168](https://github.com/unfoldingWord-dev/translationCore/issues/1168)
+- Show the hand icon when hovering over the bookmark button  [\#1100](https://github.com/unfoldingWord-dev/translationCore/issues/1100)
+- 2. Project: Export to CSV [\#973](https://github.com/unfoldingWord-dev/translationCore/issues/973)
+- Standardize verbiage used to "import" and "export" projects [\#894](https://github.com/unfoldingWord-dev/translationCore/issues/894)
+- Split tN into Primary & Secondary [\#857](https://github.com/unfoldingWord-dev/translationCore/issues/857)
+- Standardize on capitalization rules [\#845](https://github.com/unfoldingWord-dev/translationCore/issues/845)
+- There should be informative text on all dialogs that indicate that something is happening [\#840](https://github.com/unfoldingWord-dev/translationCore/issues/840)
+- Export [\#833](https://github.com/unfoldingWord-dev/translationCore/issues/833)
+- Difficult to determine which Load Project button to click [\#784](https://github.com/unfoldingWord-dev/translationCore/issues/784)
+- "Login failed. Unknown error" message returned [\#778](https://github.com/unfoldingWord-dev/translationCore/issues/778)
+- No email address found message displayed for door43 user [\#776](https://github.com/unfoldingWord-dev/translationCore/issues/776)
+- Authorization to open the app should occur during the install process \(Mac\) [\#775](https://github.com/unfoldingWord-dev/translationCore/issues/775)
+- Send different categories of feedback to different places [\#766](https://github.com/unfoldingWord-dev/translationCore/issues/766)
+- enhancement for loading projects [\#652](https://github.com/unfoldingWord-dev/translationCore/issues/652)
+- Change wording of "A Fatal Error Has Occured" [\#645](https://github.com/unfoldingWord-dev/translationCore/issues/645)
+
+**Merged pull requests:**
+
+- tH [\#1844](https://github.com/unfoldingWord-dev/translationCore/pull/1844) ([mannycolon](https://github.com/mannycolon))
+- translationHelps bug [\#1843](https://github.com/unfoldingWord-dev/translationCore/pull/1843) ([mannycolon](https://github.com/mannycolon))
+- renamed submodule [\#1824](https://github.com/unfoldingWord-dev/translationCore/pull/1824) ([mannycolon](https://github.com/mannycolon))
+- renamed TranslationHelps to translationHelps [\#1820](https://github.com/unfoldingWord-dev/translationCore/pull/1820) ([mannycolon](https://github.com/mannycolon))
+- Refactor Reducers [\#1801](https://github.com/unfoldingWord-dev/translationCore/pull/1801) ([RoyalSix](https://github.com/RoyalSix))
+- Refactor/klappy/containers/\#1774 [\#1798](https://github.com/unfoldingWord-dev/translationCore/pull/1798) ([klappy](https://github.com/klappy))
+- Removed unnecessary action constants  [\#1797](https://github.com/unfoldingWord-dev/translationCore/pull/1797) ([mannycolon](https://github.com/mannycolon))
+- Change Folder Name From ULB  [\#1795](https://github.com/unfoldingWord-dev/translationCore/pull/1795) ([RoyalSix](https://github.com/RoyalSix))
+- Components core cleanup \#1774 [\#1794](https://github.com/unfoldingWord-dev/translationCore/pull/1794) ([klappy](https://github.com/klappy))
+- deleted unnecessary actions [\#1793](https://github.com/unfoldingWord-dev/translationCore/pull/1793) ([mannycolon](https://github.com/mannycolon))
+- updated contributing.md and ToolsTester [\#1792](https://github.com/unfoldingWord-dev/translationCore/pull/1792) ([mannycolon](https://github.com/mannycolon))
+- Root Folder Restructure \#1774 [\#1791](https://github.com/unfoldingWord-dev/translationCore/pull/1791) ([klappy](https://github.com/klappy))
+- Module API Removal [\#1789](https://github.com/unfoldingWord-dev/translationCore/pull/1789) ([mannycolon](https://github.com/mannycolon))
+- redux tests [\#1757](https://github.com/unfoldingWord-dev/translationCore/pull/1757) ([mannycolon](https://github.com/mannycolon))
+- Default CSV Export Location [\#1735](https://github.com/unfoldingWord-dev/translationCore/pull/1735) ([RoyalSix](https://github.com/RoyalSix))
+- Changed CoreActionConsts.js to ActionTypes.js  [\#1732](https://github.com/unfoldingWord-dev/translationCore/pull/1732) ([mannycolon](https://github.com/mannycolon))
+- CSV Fixes [\#1708](https://github.com/unfoldingWord-dev/translationCore/pull/1708) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.7.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.7.0) (2017-05-31)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26.8...v0.7.0)
+
+## [v0.6.26.8](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26.8) (2017-05-31)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26.7...v0.6.26.8)
+
+**Merged pull requests:**
+
+- Menu Always Scrolls To Current Check [\#1692](https://github.com/unfoldingWord-dev/translationCore/pull/1692) ([RoyalSix](https://github.com/RoyalSix))
+- fix for allowing both types of url on importing [\#1683](https://github.com/unfoldingWord-dev/translationCore/pull/1683) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Fixed Target translation not displayed in scripture pane or in Select area [\#1671](https://github.com/unfoldingWord-dev/translationCore/pull/1671) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.26.7](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26.7) (2017-05-30)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26.6...v0.6.26.7)
+
+**Merged pull requests:**
+
+- Overhaul export function [\#1676](https://github.com/unfoldingWord-dev/translationCore/pull/1676) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- fixed bug with action that makes sure check data is reflected correctly in the menu [\#1670](https://github.com/unfoldingWord-dev/translationCore/pull/1670) ([mannycolon](https://github.com/mannycolon))
+- fixed reference to door43 in Terms [\#1669](https://github.com/unfoldingWord-dev/translationCore/pull/1669) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Disable select buttons for current project and tool [\#1664](https://github.com/unfoldingWord-dev/translationCore/pull/1664) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Fixed bug where target language was being replaced by a different projects target language when switching projects [\#1663](https://github.com/unfoldingWord-dev/translationCore/pull/1663) ([mannycolon](https://github.com/mannycolon))
+- Add error handling for projects with no valid manifest [\#1662](https://github.com/unfoldingWord-dev/translationCore/pull/1662) ([cdwhitfield73](https://github.com/cdwhitfield73))
+
+## [v0.6.26.6](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26.6) (2017-05-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26.5...v0.6.26.6)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property 'finished\_chunks' of null [\#1649](https://github.com/unfoldingWord-dev/translationCore/issues/1649)
+- Uncaught Error: ENOTDIR: not a directory, scandir '/Users/cckozie/translationCore/es-419\_eph\_text\_ulb/2manifest.json' [\#1641](https://github.com/unfoldingWord-dev/translationCore/issues/1641)
+- Uncaught Error: ENOTDIR: not a directory, scandir '/Users/cckozie/translationCore/es-419\_eph\_text\_ulb/2manifest.json' [\#1640](https://github.com/unfoldingWord-dev/translationCore/issues/1640)
+- "From https://git.door43.org/toddlprice/rmy-x-vg\_mrk\_text\_reg\n \* branch            master     -\> FETCH\_HEAD\nerror: Your local changes to the following files would be overwritten by merge:\n\tmanifest.json\nPlease commit your changes or stash them before [\#1562](https://github.com/unfoldingWord-dev/translationCore/issues/1562)
+- "Cloning into '/Users/cckozie/translationCore/fr\_bible\_tw'...\nerror: RPC failed; curl 56 SSLRead\(\) return error -9806\nfatal: The remote end hung up unexpectedly\nfatal: early EOF\nfatal: index-pack failed\n" [\#1558](https://github.com/unfoldingWord-dev/translationCore/issues/1558)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1546](https://github.com/unfoldingWord-dev/translationCore/issues/1546)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1544](https://github.com/unfoldingWord-dev/translationCore/issues/1544)
+- Uncaught TypeError: Cannot set property 'comments' of undefined [\#1531](https://github.com/unfoldingWord-dev/translationCore/issues/1531)
+- "Cloning into '/Users/cckozie/translationCore/en-x-demo\_3jn\_text\_ulb'...\nfatal: repository 'https://git.door43.org/qa91/en-x-demo\_3jn\_text\_ulb.git/' not found\n" [\#1526](https://github.com/unfoldingWord-dev/translationCore/issues/1526)
+- "Cloning into '/Users/cckozie/translationCore/com'...\nfatal: unable to access 'http://google.com.git/': Could not resolve host: google.com.git\n" [\#1488](https://github.com/unfoldingWord-dev/translationCore/issues/1488)
+- Uncaught Error: ENAMETOOLONG: name too long, open '/Users/cckozie/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCore/translationCo [\#1486](https://github.com/unfoldingWord-dev/translationCore/issues/1486)
+- Uncaught TypeError: Cannot read property 'indexOf' of undefined [\#1483](https://github.com/unfoldingWord-dev/translationCore/issues/1483)
+- Uncaught TypeError: Cannot read property 'toggleSettings' of undefined [\#1453](https://github.com/unfoldingWord-dev/translationCore/issues/1453)
+- Uncaught TypeError: Cannot read property 'replaceChild' of null [\#1446](https://github.com/unfoldingWord-dev/translationCore/issues/1446)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#1428](https://github.com/unfoldingWord-dev/translationCore/issues/1428)
+- Uncaught TypeError: Cannot read property 'includes' of undefined [\#1411](https://github.com/unfoldingWord-dev/translationCore/issues/1411)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#1381](https://github.com/unfoldingWord-dev/translationCore/issues/1381)
+- Uncaught TypeError: Cannot read property 'killLoading' of undefined [\#1334](https://github.com/unfoldingWord-dev/translationCore/issues/1334)
+- Uncaught TypeError: Cannot read property 'find' of undefined [\#1329](https://github.com/unfoldingWord-dev/translationCore/issues/1329)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1323](https://github.com/unfoldingWord-dev/translationCore/issues/1323)
+- Uncaught SyntaxError: Invalid regular expression: /\(/: Unterminated group [\#1321](https://github.com/unfoldingWord-dev/translationCore/issues/1321)
+- Uncaught TypeError: Path must be a string. Received 27 [\#1320](https://github.com/unfoldingWord-dev/translationCore/issues/1320)
+- Uncaught TypeError: recentProjectsActions.startLoadingNewProject is not a function [\#1318](https://github.com/unfoldingWord-dev/translationCore/issues/1318)
+- Uncaught TypeError: callback is not a function [\#1317](https://github.com/unfoldingWord-dev/translationCore/issues/1317)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#1289](https://github.com/unfoldingWord-dev/translationCore/issues/1289)
+- {"errno":-4058,"code":"ENOENT","syscall":"open","path":"C:\\Users\\MarkStedman\\translationCore\\ilo\_psa\_text\_ulb\_L2\\manifest.json"} [\#1286](https://github.com/unfoldingWord-dev/translationCore/issues/1286)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1254](https://github.com/unfoldingWord-dev/translationCore/issues/1254)
+- Uncaught ReferenceError: store is not defined [\#1242](https://github.com/unfoldingWord-dev/translationCore/issues/1242)
+- Uncaught TypeError: Cannot read property 'file' of undefined [\#1241](https://github.com/unfoldingWord-dev/translationCore/issues/1241)
+- Uncaught TypeError: Cannot read property 'killLoading' of undefined [\#1239](https://github.com/unfoldingWord-dev/translationCore/issues/1239)
+- Uncaught TypeError: \_CoreActions2.default.updateSettings is not a function [\#1230](https://github.com/unfoldingWord-dev/translationCore/issues/1230)
+- "Invalid Token" [\#1229](https://github.com/unfoldingWord-dev/translationCore/issues/1229)
+- Uncaught SyntaxError: Invalid regular expression: missing / [\#1205](https://github.com/unfoldingWord-dev/translationCore/issues/1205)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1189](https://github.com/unfoldingWord-dev/translationCore/issues/1189)
+- Uncaught TypeError: Cannot read property 'toggleSettings' of undefined [\#1173](https://github.com/unfoldingWord-dev/translationCore/issues/1173)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1171](https://github.com/unfoldingWord-dev/translationCore/issues/1171)
+- "Cloning into '/Users/benjore/translationCore/usfm'...\nfatal: repository 'https://git.door43.org/Danjuma\_Alfred\_H/sw\_tit\_text\_ulb.usfm.git/' not found\n" [\#1154](https://github.com/unfoldingWord-dev/translationCore/issues/1154)
+- "Cloning into '/Users/benjore/translationCore/usfm'...\nfatal: repository 'https://git.door43.org/tinocobrazil/pt-br\_BLV\_L3V1\_2017.04/src/master/pt-br\_57-tit\_BLV\_L3V1.usfm.git/' not found\n" [\#1153](https://github.com/unfoldingWord-dev/translationCore/issues/1153)
+- Uncaught TypeError: Cannot read property 'toggleMenu' of undefined [\#1085](https://github.com/unfoldingWord-dev/translationCore/issues/1085)
+- Uncaught TypeError: Cannot set property 'finished\_chunks' of undefined [\#1084](https://github.com/unfoldingWord-dev/translationCore/issues/1084)
+- Uncaught TypeError: Cannot read property 'checkStatus' of undefined [\#1057](https://github.com/unfoldingWord-dev/translationCore/issues/1057)
+- Uncaught Error: Cannot find module '../../../../../static/ulgb/Mark.json' [\#1000](https://github.com/unfoldingWord-dev/translationCore/issues/1000)
+- Uncaught TypeError: Cannot read property '1' of null [\#997](https://github.com/unfoldingWord-dev/translationCore/issues/997)
+- Uncaught TypeError: Cannot read property 'push' of null [\#996](https://github.com/unfoldingWord-dev/translationCore/issues/996)
+- Uncaught TypeError: Cannot read property 'arrayOfChecks' of undefined [\#995](https://github.com/unfoldingWord-dev/translationCore/issues/995)
+- Uncaught TypeError: callback is not a function [\#991](https://github.com/unfoldingWord-dev/translationCore/issues/991)
+- Uncaught TypeError: \_this2.props.onSwitchToLoginPage is not a function [\#927](https://github.com/unfoldingWord-dev/translationCore/issues/927)
+
+**Merged pull requests:**
+
+- Fix for bug when extra manifest files [\#1661](https://github.com/unfoldingWord-dev/translationCore/pull/1661) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Update global colors and buttons [\#1659](https://github.com/unfoldingWord-dev/translationCore/pull/1659) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- QA issues for translation Helps [\#1658](https://github.com/unfoldingWord-dev/translationCore/pull/1658) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Cw misc cleanup [\#1653](https://github.com/unfoldingWord-dev/translationCore/pull/1653) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Loader image now shows in builds [\#1651](https://github.com/unfoldingWord-dev/translationCore/pull/1651) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.26.5](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26.5) (2017-05-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26.4...v0.6.26.5)
+
+**Merged pull requests:**
+
+- Add new In-Progress dialog to import and refresh [\#1644](https://github.com/unfoldingWord-dev/translationCore/pull/1644) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Implement flex layouts [\#1643](https://github.com/unfoldingWord-dev/translationCore/pull/1643) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- fixed error path of logo image in the loader modal \(builds\) [\#1639](https://github.com/unfoldingWord-dev/translationCore/pull/1639) ([mannycolon](https://github.com/mannycolon))
+- Fixed verse edit bug which wouldn't render verse edits to on the Select pane. [\#1638](https://github.com/unfoldingWord-dev/translationCore/pull/1638) ([mannycolon](https://github.com/mannycolon))
+- Add data migration [\#1636](https://github.com/unfoldingWord-dev/translationCore/pull/1636) ([ihoegen](https://github.com/ihoegen))
+- Fixed bug with lost menu Progress  [\#1635](https://github.com/unfoldingWord-dev/translationCore/pull/1635) ([mannycolon](https://github.com/mannycolon))
+- Use appropriate git based on arch [\#1634](https://github.com/unfoldingWord-dev/translationCore/pull/1634) ([ihoegen](https://github.com/ihoegen))
+- QA issues for 1548 [\#1632](https://github.com/unfoldingWord-dev/translationCore/pull/1632) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [v0.6.26.4](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26.4) (2017-05-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26+3...v0.6.26.4)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot convert undefined or null to object [\#1622](https://github.com/unfoldingWord-dev/translationCore/issues/1622)
+- Uncaught TypeError: Cannot convert undefined or null to object [\#1621](https://github.com/unfoldingWord-dev/translationCore/issues/1621)
+- Cannot load project after deleting the /Users/\[username\]/translationCore folder [\#1620](https://github.com/unfoldingWord-dev/translationCore/issues/1620)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1609](https://github.com/unfoldingWord-dev/translationCore/issues/1609)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1608](https://github.com/unfoldingWord-dev/translationCore/issues/1608)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1607](https://github.com/unfoldingWord-dev/translationCore/issues/1607)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1606](https://github.com/unfoldingWord-dev/translationCore/issues/1606)
+- Bug Report: [\#1605](https://github.com/unfoldingWord-dev/translationCore/issues/1605)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1596](https://github.com/unfoldingWord-dev/translationCore/issues/1596)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1592](https://github.com/unfoldingWord-dev/translationCore/issues/1592)
+- Uncaught TypeError: Cannot read property 'replace' of undefined [\#1591](https://github.com/unfoldingWord-dev/translationCore/issues/1591)
+- Uncaught TypeError: Cannot read property '9' of undefined [\#1589](https://github.com/unfoldingWord-dev/translationCore/issues/1589)
+- Fail to push [\#1575](https://github.com/unfoldingWord-dev/translationCore/issues/1575)
+- Fail to push [\#1563](https://github.com/unfoldingWord-dev/translationCore/issues/1563)
+- Unable to connect to server message on Import Online Projects screen [\#1556](https://github.com/unfoldingWord-dev/translationCore/issues/1556)
+- Uncaught TypeError: Cannot convert undefined or null to object [\#1539](https://github.com/unfoldingWord-dev/translationCore/issues/1539)
+- can't upload to door43 while logged in [\#1537](https://github.com/unfoldingWord-dev/translationCore/issues/1537)
+- Uncaught TypeError: Cannot read property '3' of undefined [\#1528](https://github.com/unfoldingWord-dev/translationCore/issues/1528)
+- Clicking on the \(i\) on the login page does not do anything [\#1521](https://github.com/unfoldingWord-dev/translationCore/issues/1521)
+- Unable to select text [\#1509](https://github.com/unfoldingWord-dev/translationCore/issues/1509)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#1505](https://github.com/unfoldingWord-dev/translationCore/issues/1505)
+- Not able to open project after no user logged in error, and then logging in [\#1504](https://github.com/unfoldingWord-dev/translationCore/issues/1504)
+- User looses ability to import door43 projects after restarting tC [\#1497](https://github.com/unfoldingWord-dev/translationCore/issues/1497)
+- Open projects should be closed when the user logs out [\#1495](https://github.com/unfoldingWord-dev/translationCore/issues/1495)
+- Imported projects don't show up on the My Projects screen [\#1472](https://github.com/unfoldingWord-dev/translationCore/issues/1472)
+- App gets into weird state after opening an imported project [\#1469](https://github.com/unfoldingWord-dev/translationCore/issues/1469)
+- There is no indication that anything is happening after the Import & Select button is clicked on a project on the Import Online Project screen [\#1463](https://github.com/unfoldingWord-dev/translationCore/issues/1463)
+- App hangs when attempting to download a project using a URL and there is no Internet connection [\#1460](https://github.com/unfoldingWord-dev/translationCore/issues/1460)
+- Problems created if tS is installed on a Windows machine that has tC installed [\#1458](https://github.com/unfoldingWord-dev/translationCore/issues/1458)
+- The definition for the tN's aren't showing up [\#1452](https://github.com/unfoldingWord-dev/translationCore/issues/1452)
+- Receive Login Failed message even though I have a good Internet connection and am using a valid username and password [\#1429](https://github.com/unfoldingWord-dev/translationCore/issues/1429)
+- Windows install hangs while loading [\#1413](https://github.com/unfoldingWord-dev/translationCore/issues/1413)
+- Clicking Select on a project in the "My Projects" page doesn't do anything [\#1399](https://github.com/unfoldingWord-dev/translationCore/issues/1399)
+- App hangs when user tries to load a project from the door43 list and there is no Internet connection [\#1386](https://github.com/unfoldingWord-dev/translationCore/issues/1386)
+- Error handling needs work when user enters a URL for importing a project [\#1384](https://github.com/unfoldingWord-dev/translationCore/issues/1384)
+- Need better error message if Internet connection is lost during project import [\#1373](https://github.com/unfoldingWord-dev/translationCore/issues/1373)
+- Unable to use tC without good internet [\#1370](https://github.com/unfoldingWord-dev/translationCore/issues/1370)
+- Error message after clicking on a door43 project to import [\#1368](https://github.com/unfoldingWord-dev/translationCore/issues/1368)
+- Git is not installed with tC, and the instructions on the warning are unclear [\#1364](https://github.com/unfoldingWord-dev/translationCore/issues/1364)
+- Disappearing Checks  [\#1363](https://github.com/unfoldingWord-dev/translationCore/issues/1363)
+- Cannot load non-Ephesians/Titus project in developer mode [\#1337](https://github.com/unfoldingWord-dev/translationCore/issues/1337)
+- Add ability to scroll vertically in the select panel [\#1332](https://github.com/unfoldingWord-dev/translationCore/issues/1332)
+- App misbehaves after clicking Select on a project [\#1331](https://github.com/unfoldingWord-dev/translationCore/issues/1331)
+- The projects modal needs usability work [\#1310](https://github.com/unfoldingWord-dev/translationCore/issues/1310)
+- Bible references are displayed backwards in RTL languages [\#1308](https://github.com/unfoldingWord-dev/translationCore/issues/1308)
+- Feedback does not get sent [\#1306](https://github.com/unfoldingWord-dev/translationCore/issues/1306)
+- There is no user feedback when downloading a project using the URL [\#1291](https://github.com/unfoldingWord-dev/translationCore/issues/1291)
+- It is not at all obvious how to get to the screen that allows the user to browse door43 projects and enter a project URL [\#1290](https://github.com/unfoldingWord-dev/translationCore/issues/1290)
+- The displayed list of projects on door43 is not complete for user [\#1288](https://github.com/unfoldingWord-dev/translationCore/issues/1288)
+- The Help sidebar is too long for laptop screens [\#1277](https://github.com/unfoldingWord-dev/translationCore/issues/1277)
+- Verbiage changes on Account Information panel [\#1269](https://github.com/unfoldingWord-dev/translationCore/issues/1269)
+- Wrong door43 project list is displayed after changing users [\#1258](https://github.com/unfoldingWord-dev/translationCore/issues/1258)
+- Improper error message when listing door43 projects if no Internet connection is available [\#1257](https://github.com/unfoldingWord-dev/translationCore/issues/1257)
+- Change the name of the "Application" tab [\#1250](https://github.com/unfoldingWord-dev/translationCore/issues/1250)
+- Create user account does not work [\#1247](https://github.com/unfoldingWord-dev/translationCore/issues/1247)
+- Unfriendly error message returned when attempting to login with no Internet connection [\#1246](https://github.com/unfoldingWord-dev/translationCore/issues/1246)
+- Remove the Online Tools dialog [\#1233](https://github.com/unfoldingWord-dev/translationCore/issues/1233)
+- Global Settings page needs work [\#1225](https://github.com/unfoldingWord-dev/translationCore/issues/1225)
+- Project sync does not work [\#1223](https://github.com/unfoldingWord-dev/translationCore/issues/1223)
+- Highlighting bug [\#1209](https://github.com/unfoldingWord-dev/translationCore/issues/1209)
+- tHelps not rendering properly [\#1207](https://github.com/unfoldingWord-dev/translationCore/issues/1207)
+- There is no user warning when an edit reason has been checked but no editing has occured [\#1191](https://github.com/unfoldingWord-dev/translationCore/issues/1191)
+- `onTouchTap` issue on latest build [\#1165](https://github.com/unfoldingWord-dev/translationCore/issues/1165)
+- Fix Update Version Script [\#1158](https://github.com/unfoldingWord-dev/translationCore/issues/1158)
+- Fix build issues that block testing [\#1155](https://github.com/unfoldingWord-dev/translationCore/issues/1155)
+- tC fails silently when loading projects without finished chunks [\#1138](https://github.com/unfoldingWord-dev/translationCore/issues/1138)
+- tN Not Loading Projects Other Than Tit/Eph [\#1135](https://github.com/unfoldingWord-dev/translationCore/issues/1135)
+- Importing Door43 Project Doesn't work [\#1133](https://github.com/unfoldingWord-dev/translationCore/issues/1133)
+- Clicking continue doesn't advance past a group and advance to the next group [\#1123](https://github.com/unfoldingWord-dev/translationCore/issues/1123)
+- "Save and Continue" clicked, worked the first time, didn't work the next time. [\#1122](https://github.com/unfoldingWord-dev/translationCore/issues/1122)
+- tN does not load default check when switching tool [\#1121](https://github.com/unfoldingWord-dev/translationCore/issues/1121)
+- VerseEdit not logging what verse was before the edit [\#1120](https://github.com/unfoldingWord-dev/translationCore/issues/1120)
+- Duplicate check of the same word and verse [\#1117](https://github.com/unfoldingWord-dev/translationCore/issues/1117)
+- Selections load for wrong check with same reference [\#1115](https://github.com/unfoldingWord-dev/translationCore/issues/1115)
+- Fix Konami Code [\#1114](https://github.com/unfoldingWord-dev/translationCore/issues/1114)
+- tHelps doesn't show when first opened [\#1110](https://github.com/unfoldingWord-dev/translationCore/issues/1110)
+- Multiple instance of a check not displaying properly in Scripture Pane [\#1109](https://github.com/unfoldingWord-dev/translationCore/issues/1109)
+- After an edit is saved, when navigated away and returned to that check, the edit is not persisting [\#1106](https://github.com/unfoldingWord-dev/translationCore/issues/1106)
+- When in edit mode, after editing verse, the changes are saved when checkbox is selected rather than when "Save Changes" is selected [\#1105](https://github.com/unfoldingWord-dev/translationCore/issues/1105)
+- VerseCheck: Target Language modal not displaying Right-to-Left correctly [\#1097](https://github.com/unfoldingWord-dev/translationCore/issues/1097)
+- Unable To Change Tools [\#1072](https://github.com/unfoldingWord-dev/translationCore/issues/1072)
+- When clicking on a header in the side menu, the bookmark selects [\#1069](https://github.com/unfoldingWord-dev/translationCore/issues/1069)
+- Scripture Pane Language selection not always showing properly [\#1066](https://github.com/unfoldingWord-dev/translationCore/issues/1066)
+- Scripture Pane not displaying correctly when name of translation is 2 lines long [\#928](https://github.com/unfoldingWord-dev/translationCore/issues/928)
+
+**Closed issues:**
+
+- Alert modal button should have the text "OK" not "Ok" [\#1513](https://github.com/unfoldingWord-dev/translationCore/issues/1513)
+- Prohibit user from re-upload a project that would overwrite the existing one [\#1503](https://github.com/unfoldingWord-dev/translationCore/issues/1503)
+- Main Modal Navigation [\#1502](https://github.com/unfoldingWord-dev/translationCore/issues/1502)
+- "Login in" -\> "Log in" [\#1501](https://github.com/unfoldingWord-dev/translationCore/issues/1501)
+- Prohibit user from re-importing a project over an existing one [\#1498](https://github.com/unfoldingWord-dev/translationCore/issues/1498)
+- update popup when login fails to new style alert dialog [\#1484](https://github.com/unfoldingWord-dev/translationCore/issues/1484)
+- Update global style of buttons and use global style in projects list [\#1479](https://github.com/unfoldingWord-dev/translationCore/issues/1479)
+- Main modal screen size [\#1473](https://github.com/unfoldingWord-dev/translationCore/issues/1473)
+- Add a pixel to the thickness of the separator lines on the tHelps modal [\#1470](https://github.com/unfoldingWord-dev/translationCore/issues/1470)
+- Avatar [\#1466](https://github.com/unfoldingWord-dev/translationCore/issues/1466)
+- Wrong error message displayed when attempting to import project from door43 and there is no Internet connection [\#1461](https://github.com/unfoldingWord-dev/translationCore/issues/1461)
+- Add tC version and build number to the splash screen [\#1454](https://github.com/unfoldingWord-dev/translationCore/issues/1454)
+- Add the Refresh button back to the page that lists my door43 projects [\#1427](https://github.com/unfoldingWord-dev/translationCore/issues/1427)
+- Replace the green and yellow colors used in the edit and comment sections [\#1424](https://github.com/unfoldingWord-dev/translationCore/issues/1424)
+- Add a vertical scrollbar to the tHelps modal [\#1422](https://github.com/unfoldingWord-dev/translationCore/issues/1422)
+- Add a vertical scroll bar to the tHelps modal [\#1421](https://github.com/unfoldingWord-dev/translationCore/issues/1421)
+- Make modals conform to Style Guide [\#1408](https://github.com/unfoldingWord-dev/translationCore/issues/1408)
+- Create Local User [\#1407](https://github.com/unfoldingWord-dev/translationCore/issues/1407)
+- Refactor the User and Project tabs [\#1406](https://github.com/unfoldingWord-dev/translationCore/issues/1406)
+- Highlight when navigating [\#1405](https://github.com/unfoldingWord-dev/translationCore/issues/1405)
+- Windows installation screen indicates copyright 2013-2017 [\#1397](https://github.com/unfoldingWord-dev/translationCore/issues/1397)
+- Windows installation screen indicates tC version 0.0.0 [\#1396](https://github.com/unfoldingWord-dev/translationCore/issues/1396)
+- Inconsistent verbiage on Import Online Project form [\#1394](https://github.com/unfoldingWord-dev/translationCore/issues/1394)
+- Create Build [\#1389](https://github.com/unfoldingWord-dev/translationCore/issues/1389)
+- Clean up user experience upon opening app [\#1345](https://github.com/unfoldingWord-dev/translationCore/issues/1345)
+- Disable Selection in Edit Mode & Comment Mode [\#1336](https://github.com/unfoldingWord-dev/translationCore/issues/1336)
+- Display full resource name in the Add Resource dropdown list [\#1327](https://github.com/unfoldingWord-dev/translationCore/issues/1327)
+- Change the verbiage on the warning that a reason code needs to be entered [\#1298](https://github.com/unfoldingWord-dev/translationCore/issues/1298)
+- Set focus to the text edit box when the user clicks "Edit" [\#1297](https://github.com/unfoldingWord-dev/translationCore/issues/1297)
+- Move the vertical line in the check info card to line up with Scripture Pane [\#1296](https://github.com/unfoldingWord-dev/translationCore/issues/1296)
+- Hide the File, Edit, View, Window, and Help menus on the menu bar [\#1283](https://github.com/unfoldingWord-dev/translationCore/issues/1283)
+- Different icons used to expand References and Helps pane [\#1278](https://github.com/unfoldingWord-dev/translationCore/issues/1278)
+- Account tab does not follow tC style guide [\#1270](https://github.com/unfoldingWord-dev/translationCore/issues/1270)
+- Disable "Import Local Project" [\#1266](https://github.com/unfoldingWord-dev/translationCore/issues/1266)
+- Make sign in required to use tC  [\#1265](https://github.com/unfoldingWord-dev/translationCore/issues/1265)
+- Suggested change on login error dialog [\#1245](https://github.com/unfoldingWord-dev/translationCore/issues/1245)
+- Fix download from Door43 [\#1232](https://github.com/unfoldingWord-dev/translationCore/issues/1232)
+- In Tools, change the "iW" icon to "tW" [\#1226](https://github.com/unfoldingWord-dev/translationCore/issues/1226)
+- Change the default category for Feedback and Comments to "General Feedback" [\#1224](https://github.com/unfoldingWord-dev/translationCore/issues/1224)
+- Make the dialog boxes consistent & conform to the Style Guide [\#1222](https://github.com/unfoldingWord-dev/translationCore/issues/1222)
+- Change verbiage on tools' definitions. [\#1216](https://github.com/unfoldingWord-dev/translationCore/issues/1216)
+- The Load button on the Add Resources dialog does not conform the the style guide [\#1212](https://github.com/unfoldingWord-dev/translationCore/issues/1212)
+- Fix the wording on the Add Resources dialog [\#1210](https://github.com/unfoldingWord-dev/translationCore/issues/1210)
+- Buttons on the Skip dialog do not comply with the style guide [\#1206](https://github.com/unfoldingWord-dev/translationCore/issues/1206)
+- The Save Changes button should be disabled until something has been entered/changed [\#1190](https://github.com/unfoldingWord-dev/translationCore/issues/1190)
+- Is there a reason we call it "Open" project and "Load" tool? [\#1187](https://github.com/unfoldingWord-dev/translationCore/issues/1187)
+- The style guide standards for buttons are not followed on the project check screen [\#1184](https://github.com/unfoldingWord-dev/translationCore/issues/1184)
+- Comment button remains outlined after deleting a comment [\#1180](https://github.com/unfoldingWord-dev/translationCore/issues/1180)
+- The coloring on the project list screen is confusing [\#1179](https://github.com/unfoldingWord-dev/translationCore/issues/1179)
+- We should provide some indication to the user that the app is loading \(Windows\) [\#1178](https://github.com/unfoldingWord-dev/translationCore/issues/1178)
+- The Skip or Close modal doesn't work. [\#1177](https://github.com/unfoldingWord-dev/translationCore/issues/1177)
+- The tC installation on Windows needs work [\#1174](https://github.com/unfoldingWord-dev/translationCore/issues/1174)
+- create Home Container to house all home screen implementation [\#1160](https://github.com/unfoldingWord-dev/translationCore/issues/1160)
+- Connect home screen implementation with app.js \(core\) [\#1159](https://github.com/unfoldingWord-dev/translationCore/issues/1159)
+- change actions files to ES6 syntax [\#1152](https://github.com/unfoldingWord-dev/translationCore/issues/1152)
+- Modify functionality of "Add Resources" modal [\#1149](https://github.com/unfoldingWord-dev/translationCore/issues/1149)
+- Build the Skeleton [\#1145](https://github.com/unfoldingWord-dev/translationCore/issues/1145)
+- Cannot switch from tN to tW without hanging the app [\#1144](https://github.com/unfoldingWord-dev/translationCore/issues/1144)
+- Create Build [\#1141](https://github.com/unfoldingWord-dev/translationCore/issues/1141)
+- fix bugs in containers and change them ES6 syntax [\#1139](https://github.com/unfoldingWord-dev/translationCore/issues/1139)
+- Change titles of Tools and use consistently in App [\#1137](https://github.com/unfoldingWord-dev/translationCore/issues/1137)
+- Fix bug where editing a verse without making any change would delete the entire verse. [\#1125](https://github.com/unfoldingWord-dev/translationCore/issues/1125)
+- Change Tools' Names [\#1113](https://github.com/unfoldingWord-dev/translationCore/issues/1113)
+- Name of Target Language [\#1112](https://github.com/unfoldingWord-dev/translationCore/issues/1112)
+- tHelps formatting [\#1111](https://github.com/unfoldingWord-dev/translationCore/issues/1111)
+- In edit mode, require a checkbox to be selected before "Save Changes" can be clicked [\#1108](https://github.com/unfoldingWord-dev/translationCore/issues/1108)
+- Show Target Language in Proper Direction in Expanded Scripture Pane [\#1101](https://github.com/unfoldingWord-dev/translationCore/issues/1101)
+- Get tN tool working [\#1071](https://github.com/unfoldingWord-dev/translationCore/issues/1071)
+- Make Green Checks persist [\#1032](https://github.com/unfoldingWord-dev/translationCore/issues/1032)
+- Progress Circle in Menu [\#1031](https://github.com/unfoldingWord-dev/translationCore/issues/1031)
+- implement data persistence for module settings reducer [\#1027](https://github.com/unfoldingWord-dev/translationCore/issues/1027)
+- Fixed scripture pane props so the modal pane opens [\#1026](https://github.com/unfoldingWord-dev/translationCore/issues/1026)
+- License Page [\#967](https://github.com/unfoldingWord-dev/translationCore/issues/967)
+- "Welcome to translationCore" Screen [\#963](https://github.com/unfoldingWord-dev/translationCore/issues/963)
+- Warning when trying to "Save and Continue" without selecting translation [\#908](https://github.com/unfoldingWord-dev/translationCore/issues/908)
+- Change wording for check info card [\#905](https://github.com/unfoldingWord-dev/translationCore/issues/905)
+- New tN \(Primary\) Tool [\#714](https://github.com/unfoldingWord-dev/translationCore/issues/714)
+- New tW \(Primary\) Tool [\#713](https://github.com/unfoldingWord-dev/translationCore/issues/713)
+
+**Merged pull requests:**
+
+- Change references from apps to .apps [\#1625](https://github.com/unfoldingWord-dev/translationCore/pull/1625) ([ihoegen](https://github.com/ihoegen))
+- Remove tool tester from dev mode [\#1624](https://github.com/unfoldingWord-dev/translationCore/pull/1624) ([ihoegen](https://github.com/ihoegen))
+- Js csv2 [\#1619](https://github.com/unfoldingWord-dev/translationCore/pull/1619) ([RoyalSix](https://github.com/RoyalSix))
+- No longer use password for Git pushes, use tokens instead [\#1617](https://github.com/unfoldingWord-dev/translationCore/pull/1617) ([ihoegen](https://github.com/ihoegen))
+- Find and alert for missing verses [\#1615](https://github.com/unfoldingWord-dev/translationCore/pull/1615) ([ihoegen](https://github.com/ihoegen))
+- more error handling [\#1612](https://github.com/unfoldingWord-dev/translationCore/pull/1612) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Revamped fetch datas & loading process [\#1602](https://github.com/unfoldingWord-dev/translationCore/pull/1602) ([mannycolon](https://github.com/mannycolon))
+- Add merge conflict checking for project chunks [\#1599](https://github.com/unfoldingWord-dev/translationCore/pull/1599) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.6.26+3](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26+3) (2017-05-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26+2...v0.6.26+3)
+
+## [v0.6.26+2](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26+2) (2017-05-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.26...v0.6.26+2)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property 'length' of null [\#1547](https://github.com/unfoldingWord-dev/translationCore/issues/1547)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1542](https://github.com/unfoldingWord-dev/translationCore/issues/1542)
+- Uncaught TypeError: Cannot read property '14' of undefined [\#1530](https://github.com/unfoldingWord-dev/translationCore/issues/1530)
+- "Cloning into '/Users/cckozie/translationCore/en-x-demo1\_tit\_text\_udb'...\nfatal: repository 'https://git.door43.org/qa98/en-x-demo1\_tit\_text\_udb.git/' not found\n" [\#1525](https://github.com/unfoldingWord-dev/translationCore/issues/1525)
+- "Cloning into '/Users/cckozie/translationCore/en-x-demo1\_tit\_text\_ulb'...\nfatal: repository 'https://git.door43.org/qa98/en-x-demo1\_tit\_text\_ulb.git/' not found\n" [\#1524](https://github.com/unfoldingWord-dev/translationCore/issues/1524)
+- "Cloning into '/Users/cckozie/translationCore/en-x-demo1\_tit\_text\_'...\nfatal: repository 'https://git.door43.org/qa98/en-x-demo1\_tit\_text\_.git/' not found\n" [\#1523](https://github.com/unfoldingWord-dev/translationCore/issues/1523)
+- Uncaught TypeError: Cannot set property 'comments' of undefined [\#1494](https://github.com/unfoldingWord-dev/translationCore/issues/1494)
+- Uncaught TypeError: Cannot read property 'package\_version' of undefined [\#1493](https://github.com/unfoldingWord-dev/translationCore/issues/1493)
+- Uncaught TypeError: Cannot read property '13' of undefined [\#1468](https://github.com/unfoldingWord-dev/translationCore/issues/1468)
+
+**Merged pull requests:**
+
+- Added Scroll To Previous & Next [\#1601](https://github.com/unfoldingWord-dev/translationCore/pull/1601) ([RoyalSix](https://github.com/RoyalSix))
+- Filter D43 Project Import List to current user [\#1600](https://github.com/unfoldingWord-dev/translationCore/pull/1600) ([klappy](https://github.com/klappy))
+- Feature/lw 1548 [\#1595](https://github.com/unfoldingWord-dev/translationCore/pull/1595) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Error handling and progress indicator for uploading [\#1593](https://github.com/unfoldingWord-dev/translationCore/pull/1593) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Edit recent projects style, also move the file [\#1584](https://github.com/unfoldingWord-dev/translationCore/pull/1584) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.6.26](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.26) (2017-05-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.25...v0.6.26)
+
+## [v0.6.25](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.25) (2017-05-16)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.24...v0.6.25)
+
+**Merged pull requests:**
+
+- Addressing missed concerns with sync function [\#1570](https://github.com/unfoldingWord-dev/translationCore/pull/1570) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fixed gitSync [\#1567](https://github.com/unfoldingWord-dev/translationCore/pull/1567) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fix Check Items Being Offscreen [\#1561](https://github.com/unfoldingWord-dev/translationCore/pull/1561) ([RoyalSix](https://github.com/RoyalSix))
+- Update git installer [\#1560](https://github.com/unfoldingWord-dev/translationCore/pull/1560) ([ihoegen](https://github.com/ihoegen))
+- Used Gogs API listRepos instead of searching [\#1559](https://github.com/unfoldingWord-dev/translationCore/pull/1559) ([klappy](https://github.com/klappy))
+- Information popup for D43 \(i\) [\#1557](https://github.com/unfoldingWord-dev/translationCore/pull/1557) ([klappy](https://github.com/klappy))
+- Fix Verbage and Error Handling For CSV [\#1555](https://github.com/unfoldingWord-dev/translationCore/pull/1555) ([RoyalSix](https://github.com/RoyalSix))
+- Force users to click to close alerts [\#1551](https://github.com/unfoldingWord-dev/translationCore/pull/1551) ([ihoegen](https://github.com/ihoegen))
+- Refresh user projects when switching tabs [\#1550](https://github.com/unfoldingWord-dev/translationCore/pull/1550) ([ihoegen](https://github.com/ihoegen))
+- Addressed QA issues related to project upload/sync to door43. [\#1541](https://github.com/unfoldingWord-dev/translationCore/pull/1541) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.24](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.24) (2017-05-12)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.23...v0.6.24)
+
+**Closed issues:**
+
+- Cannot move projects between machines by zipping and copying them [\#1535](https://github.com/unfoldingWord-dev/translationCore/issues/1535)
+
+**Merged pull requests:**
+
+- Change styling of secondary tabs in modal [\#1543](https://github.com/unfoldingWord-dev/translationCore/pull/1543) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- minor fix for bug [\#1538](https://github.com/unfoldingWord-dev/translationCore/pull/1538) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Addressed issues with Main Modal Navigation  and Main modal screen size [\#1534](https://github.com/unfoldingWord-dev/translationCore/pull/1534) ([mannycolon](https://github.com/mannycolon))
+- fixed minor bug [\#1527](https://github.com/unfoldingWord-dev/translationCore/pull/1527) ([mannycolon](https://github.com/mannycolon))
+- Require signin [\#1518](https://github.com/unfoldingWord-dev/translationCore/pull/1518) ([ihoegen](https://github.com/ihoegen))
+- Local user QA fail issues [\#1517](https://github.com/unfoldingWord-dev/translationCore/pull/1517) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.23](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.23) (2017-05-11)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.22...v0.6.23)
+
+**Fixed bugs:**
+
+- Online projects are displayed when logged in as local user [\#1507](https://github.com/unfoldingWord-dev/translationCore/issues/1507)
+- Some projects never finish loading [\#1477](https://github.com/unfoldingWord-dev/translationCore/issues/1477)
+- Cannot recover from a failed import from door43 [\#1476](https://github.com/unfoldingWord-dev/translationCore/issues/1476)
+- Uncaught TypeError: Cannot read property 'package\_version' of undefined [\#1462](https://github.com/unfoldingWord-dev/translationCore/issues/1462)
+- Error message dialogs should not be opened in their own window [\#1459](https://github.com/unfoldingWord-dev/translationCore/issues/1459)
+- Loading modal does not go away even after project/tool is loaded [\#1433](https://github.com/unfoldingWord-dev/translationCore/issues/1433)
+- Import from door43 hangs if the project is already open [\#1430](https://github.com/unfoldingWord-dev/translationCore/issues/1430)
+
+**Closed issues:**
+
+- Change the text in the alert displayed when attempting to export csv from a project with no checkdata [\#1514](https://github.com/unfoldingWord-dev/translationCore/issues/1514)
+- There should be a warning message when the user selects to import a project from door43 that already exists on the computer [\#1478](https://github.com/unfoldingWord-dev/translationCore/issues/1478)
+- Unable to re-import \(& update\) projects from Door43 [\#1450](https://github.com/unfoldingWord-dev/translationCore/issues/1450)
+- The edit flag remains on even after the edit was "deleted" [\#1431](https://github.com/unfoldingWord-dev/translationCore/issues/1431)
+- Use "Sign In" consistently rather than "login" [\#1426](https://github.com/unfoldingWord-dev/translationCore/issues/1426)
+- Need better screen utilization on projects tab [\#1403](https://github.com/unfoldingWord-dev/translationCore/issues/1403)
+- Remove or update the online status indicator in the menu bar [\#1252](https://github.com/unfoldingWord-dev/translationCore/issues/1252)
+
+**Merged pull requests:**
+
+- Second attempt overhaul of importing [\#1512](https://github.com/unfoldingWord-dev/translationCore/pull/1512) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Fixed spelling in Login page  [\#1506](https://github.com/unfoldingWord-dev/translationCore/pull/1506) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.22](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.22) (2017-05-09)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.21...v0.6.22)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property 'package\_version' of undefined [\#1487](https://github.com/unfoldingWord-dev/translationCore/issues/1487)
+- "fatal: repository 'google.com.git' does not exist\n" [\#1475](https://github.com/unfoldingWord-dev/translationCore/issues/1475)
+- "Cloning into 'C:\\Users\\tsqa1\\translationCore\\qa99'...\nfatal: repository 'https://git.door43.org/qa99.git/' not found\n" [\#1474](https://github.com/unfoldingWord-dev/translationCore/issues/1474)
+- "Warning: Failed prop type: Invalid prop `bsStyle` of value `prime` supplied to `Button`, expected one of \[\"success\",\"warning\",\"danger\",\"info\",\"default\",\"primary\",\"link\",\"white\",\"blue\",\"small-blue\"\].\n    in Button \(created by ActionsA [\#1419](https://github.com/unfoldingWord-dev/translationCore/issues/1419)
+- "Warning: Failed prop type: Invalid prop `bsStyle` of value `second` supplied to `Button`, expected one of \[\"success\",\"warning\",\"danger\",\"info\",\"default\",\"primary\",\"link\",\"white\",\"blue\",\"small-blue\"\].\n    in Button \(created by Actions [\#1418](https://github.com/unfoldingWord-dev/translationCore/issues/1418)
+- Uncaught TypeError: Cannot read property '3' of undefined [\#1410](https://github.com/unfoldingWord-dev/translationCore/issues/1410)
+- "Cloning into 'C:\\Users\\tsqa1\\translationCore\\en-x-demo2\_php\_text\_reg'...\nfatal: unable to access 'https://git.door43.org/qa99/en-x-demo2\_php\_text\_reg.git/': Couldn't resolve host 'git.door43.org'\n" [\#1398](https://github.com/unfoldingWord-dev/translationCore/issues/1398)
+- Uncaught TypeError: Cannot read property 'indexOf' of null [\#1380](https://github.com/unfoldingWord-dev/translationCore/issues/1380)
+
+**Merged pull requests:**
+
+- Local user implementation \#1407 [\#1491](https://github.com/unfoldingWord-dev/translationCore/pull/1491) ([mannycolon](https://github.com/mannycolon))
+- Convert signin alerts from snackbar to modals [\#1490](https://github.com/unfoldingWord-dev/translationCore/pull/1490) ([ihoegen](https://github.com/ihoegen))
+- issue 1484, update login failed dialog [\#1485](https://github.com/unfoldingWord-dev/translationCore/pull/1485) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Pulling the avatar from the correct location now [\#1482](https://github.com/unfoldingWord-dev/translationCore/pull/1482) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Send modal opening to tools [\#1481](https://github.com/unfoldingWord-dev/translationCore/pull/1481) ([ihoegen](https://github.com/ihoegen))
+- Added Export To CSV Feature [\#1471](https://github.com/unfoldingWord-dev/translationCore/pull/1471) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.6.21](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.21) (2017-05-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.20...v0.6.21)
+
+**Merged pull requests:**
+
+- issue 1479, update button styling [\#1480](https://github.com/unfoldingWord-dev/translationCore/pull/1480) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Add version to welcome and splash [\#1467](https://github.com/unfoldingWord-dev/translationCore/pull/1467) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Fixed project upload/sync and added successful upload dialog [\#1451](https://github.com/unfoldingWord-dev/translationCore/pull/1451) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.20](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.20) (2017-05-04)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.19...v0.6.20)
+
+**Fixed bugs:**
+
+- The check info card no longer has the "More" link [\#1441](https://github.com/unfoldingWord-dev/translationCore/issues/1441)
+
+**Merged pull requests:**
+
+- add more error handling to internet functions [\#1447](https://github.com/unfoldingWord-dev/translationCore/pull/1447) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Remove uneeded call that causes errors [\#1445](https://github.com/unfoldingWord-dev/translationCore/pull/1445) ([ihoegen](https://github.com/ihoegen))
+- removed console log and added better error handling to verifyGroupDataMatchesWithFs action [\#1444](https://github.com/unfoldingWord-dev/translationCore/pull/1444) ([mannycolon](https://github.com/mannycolon))
+- minor fix for scroll bars [\#1443](https://github.com/unfoldingWord-dev/translationCore/pull/1443) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Bash logic is hard [\#1440](https://github.com/unfoldingWord-dev/translationCore/pull/1440) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Changed 2013 to 2016 [\#1439](https://github.com/unfoldingWord-dev/translationCore/pull/1439) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- reduced min size limit for tC window [\#1438](https://github.com/unfoldingWord-dev/translationCore/pull/1438) ([mannycolon](https://github.com/mannycolon))
+- Fix Importing Projects [\#1437](https://github.com/unfoldingWord-dev/translationCore/pull/1437) ([RoyalSix](https://github.com/RoyalSix))
+- Complete overhaul of main modal [\#1436](https://github.com/unfoldingWord-dev/translationCore/pull/1436) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- created alert dialog and replaced all alerts with new alertdialog act… [\#1435](https://github.com/unfoldingWord-dev/translationCore/pull/1435) ([mannycolon](https://github.com/mannycolon))
+- Added welcome splash and re-work the structure and order of rendering containers [\#1420](https://github.com/unfoldingWord-dev/translationCore/pull/1420) ([mannycolon](https://github.com/mannycolon))
+- Dont manipulate the data if it does not exist [\#1417](https://github.com/unfoldingWord-dev/translationCore/pull/1417) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Give error when trying to import project from door43 with no internet access [\#1416](https://github.com/unfoldingWord-dev/translationCore/pull/1416) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Lw error messages [\#1344](https://github.com/unfoldingWord-dev/translationCore/pull/1344) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [v0.6.19](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.19) (2017-05-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.18...v0.6.19)
+
+**Fixed bugs:**
+
+- Uncaught TypeError: Cannot read property '6' of undefined [\#1409](https://github.com/unfoldingWord-dev/translationCore/issues/1409)
+- Need error handling for submitting feedback when there is no Internet connection [\#1393](https://github.com/unfoldingWord-dev/translationCore/issues/1393)
+- The door43 project list is not reset when the user clicks refresh and there is no Internet connection [\#1385](https://github.com/unfoldingWord-dev/translationCore/issues/1385)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1379](https://github.com/unfoldingWord-dev/translationCore/issues/1379)
+- Uncaught TypeError: path must be a string or Buffer [\#1376](https://github.com/unfoldingWord-dev/translationCore/issues/1376)
+- my recent projects not scrolling down to allow access for more projects [\#1362](https://github.com/unfoldingWord-dev/translationCore/issues/1362)
+- Uncaught TypeError: Cannot read property '9' of undefined [\#1356](https://github.com/unfoldingWord-dev/translationCore/issues/1356)
+- Uncaught TypeError: Cannot read property '19' of undefined [\#1355](https://github.com/unfoldingWord-dev/translationCore/issues/1355)
+- Uncaught TypeError: Cannot read property '48' of undefined [\#1354](https://github.com/unfoldingWord-dev/translationCore/issues/1354)
+- Uncaught TypeError: Cannot read property '3' of undefined [\#1353](https://github.com/unfoldingWord-dev/translationCore/issues/1353)
+- Uncaught TypeError: Cannot read property '22' of undefined [\#1352](https://github.com/unfoldingWord-dev/translationCore/issues/1352)
+- Uncaught TypeError: Cannot read property '27' of undefined [\#1351](https://github.com/unfoldingWord-dev/translationCore/issues/1351)
+- Uncaught TypeError: Cannot read property '25' of undefined [\#1350](https://github.com/unfoldingWord-dev/translationCore/issues/1350)
+- Projects do not show immediately after import from door43 [\#1342](https://github.com/unfoldingWord-dev/translationCore/issues/1342)
+- Uncaught TypeError: Cannot read property '14' of undefined [\#1339](https://github.com/unfoldingWord-dev/translationCore/issues/1339)
+- Uncaught TypeError: Cannot read property 'replaceChild' of null [\#1330](https://github.com/unfoldingWord-dev/translationCore/issues/1330)
+- Uncaught TypeError: Cannot read property 'length' of null [\#1324](https://github.com/unfoldingWord-dev/translationCore/issues/1324)
+- Uncaught SyntaxError: Invalid regular expression: /\(/: Unterminated group [\#1322](https://github.com/unfoldingWord-dev/translationCore/issues/1322)
+- Uncaught ReferenceError: manifest is not defined [\#1319](https://github.com/unfoldingWord-dev/translationCore/issues/1319)
+- Uncaught TypeError: callback is not a function [\#1316](https://github.com/unfoldingWord-dev/translationCore/issues/1316)
+- Uncaught ReferenceError: manifest is not defined [\#1315](https://github.com/unfoldingWord-dev/translationCore/issues/1315)
+- "Warning: Each child in an array or iterator should have a unique \"key\" prop. Check the render method of `ThirdParty`. See https://fb.me/react-warning-keys for more information.\n    in div \(created by ThirdParty\)\n    in ThirdParty \(created by Licenses [\#1313](https://github.com/unfoldingWord-dev/translationCore/issues/1313)
+- Uncaught TypeError: Cannot read property 'killLoading' of undefined [\#1305](https://github.com/unfoldingWord-dev/translationCore/issues/1305)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#1285](https://github.com/unfoldingWord-dev/translationCore/issues/1285)
+- Uncaught TypeError: Cannot read property 'killLoading' of undefined [\#1284](https://github.com/unfoldingWord-dev/translationCore/issues/1284)
+- Uncaught TypeError: Cannot read property 'find' of undefined [\#1262](https://github.com/unfoldingWord-dev/translationCore/issues/1262)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1253](https://github.com/unfoldingWord-dev/translationCore/issues/1253)
+- Uncaught ReferenceError: manifest is not defined [\#1244](https://github.com/unfoldingWord-dev/translationCore/issues/1244)
+- Uncaught TypeError: \_CoreActions2.default.updateSettings is not a function [\#1237](https://github.com/unfoldingWord-dev/translationCore/issues/1237)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#1234](https://github.com/unfoldingWord-dev/translationCore/issues/1234)
+- Uncaught SyntaxError: Invalid regular expression: missing / [\#1227](https://github.com/unfoldingWord-dev/translationCore/issues/1227)
+- Uncaught TypeError: recentProjectsActions.startLoadingNewProject is not a function [\#1221](https://github.com/unfoldingWord-dev/translationCore/issues/1221)
+- "Warning: setState\(...\): Cannot update during an existing state transition \(such as within `render` or another component's constructor\). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be  [\#1220](https://github.com/unfoldingWord-dev/translationCore/issues/1220)
+- Uncaught ReferenceError: manifest is not defined [\#1214](https://github.com/unfoldingWord-dev/translationCore/issues/1214)
+- Uncaught TypeError: \_CoreActions2.default.updateSettings is not a function [\#1198](https://github.com/unfoldingWord-dev/translationCore/issues/1198)
+- Uncaught TypeError: Cannot read property 'replaceChild' of null [\#1197](https://github.com/unfoldingWord-dev/translationCore/issues/1197)
+- Uncaught TypeError: Cannot read property 'killLoading' of undefined [\#1172](https://github.com/unfoldingWord-dev/translationCore/issues/1172)
+- Uncaught TypeError: Cannot read property 'replaceChild' of null [\#1161](https://github.com/unfoldingWord-dev/translationCore/issues/1161)
+- Uncaught TypeError: \_CoreActions2.default.updateSettings is not a function [\#1157](https://github.com/unfoldingWord-dev/translationCore/issues/1157)
+- Uncaught TypeError: CoreActions.updateSettings is not a function [\#1075](https://github.com/unfoldingWord-dev/translationCore/issues/1075)
+
+**Closed issues:**
+
+- Buttons wrap on "home" screen with window maximized [\#1404](https://github.com/unfoldingWord-dev/translationCore/issues/1404)
+
+**Merged pull requests:**
+
+- Master protect [\#1415](https://github.com/unfoldingWord-dev/translationCore/pull/1415) ([ihoegen](https://github.com/ihoegen))
+- Git Installer Error [\#1414](https://github.com/unfoldingWord-dev/translationCore/pull/1414) ([ihoegen](https://github.com/ihoegen))
+- Change Gogs Login Requirements [\#1412](https://github.com/unfoldingWord-dev/translationCore/pull/1412) ([RoyalSix](https://github.com/RoyalSix))
+- Circumvent review [\#1400](https://github.com/unfoldingWord-dev/translationCore/pull/1400) ([ihoegen](https://github.com/ihoegen))
+- recovered progress and checkmarks for menu on both tN & tW [\#1387](https://github.com/unfoldingWord-dev/translationCore/pull/1387) ([mannycolon](https://github.com/mannycolon))
+- Update repos when switching tabs [\#1378](https://github.com/unfoldingWord-dev/translationCore/pull/1378) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.6.18](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.18) (2017-05-02)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.17...v0.6.18)
+
+**Fixed bugs:**
+
+- Bug Report: [\#1392](https://github.com/unfoldingWord-dev/translationCore/issues/1392)
+- Bug Report: [\#1390](https://github.com/unfoldingWord-dev/translationCore/issues/1390)
+- Uncaught TypeError: Cannot read property '\_currentElement' of null [\#1372](https://github.com/unfoldingWord-dev/translationCore/issues/1372)
+- Uncaught TypeError: Cannot read property '\_currentElement' of null [\#1371](https://github.com/unfoldingWord-dev/translationCore/issues/1371)
+- "Error: spawn git ENOENT\n    at exports.\_errnoException \(util.js:1022:11\)\n    at Process.ChildProcess.\_handle.onexit \(internal/child\_process.js:193:32\)\n    at onErrorNT \(internal/child\_process.js:359:16\)\n    at \_combinedTickCallback \(internal/process/ [\#1367](https://github.com/unfoldingWord-dev/translationCore/issues/1367)
+- Uncaught TypeError: Cannot read property '\_currentElement' of null [\#1338](https://github.com/unfoldingWord-dev/translationCore/issues/1338)
+
+**Closed issues:**
+
+- Bring welcome screen to tC / merge home screen implementation code ONLY to tC codebase [\#1295](https://github.com/unfoldingWord-dev/translationCore/issues/1295)
+
+**Merged pull requests:**
+
+- Add /SILENT flag to installation for git [\#1388](https://github.com/unfoldingWord-dev/translationCore/pull/1388) ([ihoegen](https://github.com/ihoegen))
+- removed console log [\#1375](https://github.com/unfoldingWord-dev/translationCore/pull/1375) ([mannycolon](https://github.com/mannycolon))
+- Main modal reformat and color scheme [\#1361](https://github.com/unfoldingWord-dev/translationCore/pull/1361) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Fixed online import & added loading circle for user experience   [\#1360](https://github.com/unfoldingWord-dev/translationCore/pull/1360) ([mannycolon](https://github.com/mannycolon))
+- Force users to sign in [\#1358](https://github.com/unfoldingWord-dev/translationCore/pull/1358) ([ihoegen](https://github.com/ihoegen))
+- improved Loader modal to show progress and a spinning logo [\#1293](https://github.com/unfoldingWord-dev/translationCore/pull/1293) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.17](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.17) (2017-04-28)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.15...v0.6.17)
+
+**Merged pull requests:**
+
+- Add splash screen [\#1314](https://github.com/unfoldingWord-dev/translationCore/pull/1314) ([cdwhitfield73](https://github.com/cdwhitfield73))
+
+## [v0.6.15](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.15) (2017-04-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/untagged-a4394e921490b62e58e2...v0.6.15)
+
+**Merged pull requests:**
+
+- issue 1266, remove local import tab [\#1309](https://github.com/unfoldingWord-dev/translationCore/pull/1309) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- issue 1269, remove email section [\#1304](https://github.com/unfoldingWord-dev/translationCore/pull/1304) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- New Windows Installer [\#1303](https://github.com/unfoldingWord-dev/translationCore/pull/1303) ([ihoegen](https://github.com/ihoegen))
+- Account creation issue fixed [\#1301](https://github.com/unfoldingWord-dev/translationCore/pull/1301) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- License Page [\#1215](https://github.com/unfoldingWord-dev/translationCore/pull/1215) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [untagged-a4394e921490b62e58e2](https://github.com/unfoldingWord-dev/translationCore/tree/untagged-a4394e921490b62e58e2) (2017-04-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/untagged-6b65d2e493899c71f667...untagged-a4394e921490b62e58e2)
+
+**Fixed bugs:**
+
+- Signing out does not appear to do anything [\#1267](https://github.com/unfoldingWord-dev/translationCore/issues/1267)
+- Once tC has been opened on a Mac, clicking on it in the Launchpad should open it without the security message [\#1243](https://github.com/unfoldingWord-dev/translationCore/issues/1243)
+- There are multiple dialogs for selecting a project [\#1235](https://github.com/unfoldingWord-dev/translationCore/issues/1235)
+
+**Closed issues:**
+
+- Decide if we want to reimplement import from usfm for 0.9 [\#1251](https://github.com/unfoldingWord-dev/translationCore/issues/1251)
+- Is "Sync" the correct term for uploading to door43? [\#1204](https://github.com/unfoldingWord-dev/translationCore/issues/1204)
+- Make the UDB available in the scripture pane [\#947](https://github.com/unfoldingWord-dev/translationCore/issues/947)
+
+**Merged pull requests:**
+
+- Several fixes for styling and wording [\#1287](https://github.com/unfoldingWord-dev/translationCore/pull/1287) ([cdwhitfield73](https://github.com/cdwhitfield73))
+
+## [untagged-6b65d2e493899c71f667](https://github.com/unfoldingWord-dev/translationCore/tree/untagged-6b65d2e493899c71f667) (2017-04-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/untagged-ad440346fbe846295e0b...untagged-6b65d2e493899c71f667)
+
+## [untagged-ad440346fbe846295e0b](https://github.com/unfoldingWord-dev/translationCore/tree/untagged-ad440346fbe846295e0b) (2017-04-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.14...untagged-ad440346fbe846295e0b)
+
+## [v0.6.14](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.14) (2017-04-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.13...v0.6.14)
+
+**Fixed bugs:**
+
+- How to get out of full screen mode? [\#1236](https://github.com/unfoldingWord-dev/translationCore/issues/1236)
+- {"errno":-4058,"code":"ENOENT","syscall":"open","path":"C:\\Users\\perry\\translationCore\\04\\manifest.json"} [\#1203](https://github.com/unfoldingWord-dev/translationCore/issues/1203)
+- Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node. [\#1202](https://github.com/unfoldingWord-dev/translationCore/issues/1202)
+- Uncaught TypeError: Cannot read property 'tcInitialized' of null [\#1201](https://github.com/unfoldingWord-dev/translationCore/issues/1201)
+- Uncaught TypeError: Path must be a string. Received undefined [\#1200](https://github.com/unfoldingWord-dev/translationCore/issues/1200)
+- Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node. [\#1199](https://github.com/unfoldingWord-dev/translationCore/issues/1199)
+- "Warning: Unknown prop `onTouchTap` on \<div\> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop\n    in div \(created by Overlay\)\n    in Overlay \(created by DialogInline\)\n    in div \(created by DialogInline\)\n    in [\#1164](https://github.com/unfoldingWord-dev/translationCore/issues/1164)
+- "Warning: performUpdateIfNecessary: Unexpected batch number \(current 323, pending 317\)" [\#1162](https://github.com/unfoldingWord-dev/translationCore/issues/1162)
+- Uncaught ReferenceError: manifest is not defined [\#1127](https://github.com/unfoldingWord-dev/translationCore/issues/1127)
+
+**Closed issues:**
+
+- Need a better first screen after installation [\#1263](https://github.com/unfoldingWord-dev/translationCore/issues/1263)
+- Is it intentional for bookmarking a check to reset its progress [\#1188](https://github.com/unfoldingWord-dev/translationCore/issues/1188)
+- Work area is empty after loading a project and tool [\#1156](https://github.com/unfoldingWord-dev/translationCore/issues/1156)
+- Clicking V icon \(Next check\) moves the check down in the left panel \(list of checks\) but not always in the user input area. [\#850](https://github.com/unfoldingWord-dev/translationCore/issues/850)
+- Problems with message box indicating whether the current check was marked as checked or unchecked, flagged or unflagged [\#849](https://github.com/unfoldingWord-dev/translationCore/issues/849)
+- Do we want to allow the user to mark the check as Correct in context even when he has proposed a change? [\#847](https://github.com/unfoldingWord-dev/translationCore/issues/847)
+- Personal preference on style [\#846](https://github.com/unfoldingWord-dev/translationCore/issues/846)
+- Modify the verbiage in the hint for proposed changes [\#843](https://github.com/unfoldingWord-dev/translationCore/issues/843)
+- Mixed acronyms used for words check [\#841](https://github.com/unfoldingWord-dev/translationCore/issues/841)
+- Standardize verbiage describing what the tool does. [\#839](https://github.com/unfoldingWord-dev/translationCore/issues/839)
+- The workflow when starting from scratch is not intuitive [\#838](https://github.com/unfoldingWord-dev/translationCore/issues/838)
+- Unclear what to do after dragging a file to import local file text box [\#837](https://github.com/unfoldingWord-dev/translationCore/issues/837)
+- There should be a title and progress bar on the opening project dialog [\#790](https://github.com/unfoldingWord-dev/translationCore/issues/790)
+- There should be a local folder which is the default for saving projects [\#788](https://github.com/unfoldingWord-dev/translationCore/issues/788)
+- Opening a locally imported project only has overwrite and cancel options. [\#787](https://github.com/unfoldingWord-dev/translationCore/issues/787)
+- App crashes when creating a new account [\#781](https://github.com/unfoldingWord-dev/translationCore/issues/781)
+- App crashes when attempting to create user account that already exists [\#779](https://github.com/unfoldingWord-dev/translationCore/issues/779)
+
+**Merged pull requests:**
+
+- Feature/cw issue963 [\#1255](https://github.com/unfoldingWord-dev/translationCore/pull/1255) ([cdwhitfield73](https://github.com/cdwhitfield73))
+
+## [v0.6.13](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.13) (2017-04-25)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.12...v0.6.13)
+
+**Merged pull requests:**
+
+- Connect home screen implementation with app.js  [\#1169](https://github.com/unfoldingWord-dev/translationCore/pull/1169) ([mannycolon](https://github.com/mannycolon))
+- Update Version Script rewrite [\#1166](https://github.com/unfoldingWord-dev/translationCore/pull/1166) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.6.12](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.12) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.11...v0.6.12)
+
+**Merged pull requests:**
+
+- Restructure app.js and fixed onTouchTapEvent bug [\#1167](https://github.com/unfoldingWord-dev/translationCore/pull/1167) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.6.11](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.11) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.8...v0.6.11)
+
+## [v0.6.8](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.8) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.6...v0.6.8)
+
+## [v0.6.6](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.6) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.5...v0.6.6)
+
+## [v0.6.5](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.5) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.4...v0.6.5)
+
+## [v0.6.4](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.4) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.3...v0.6.4)
+
+## [v0.6.3](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.3) (2017-04-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.2...v0.6.3)
+
+## [v0.6.2](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.2) (2017-04-23)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.1...v0.6.2)
+
+## [v0.6.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.1) (2017-04-22)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.6.0...v0.6.1)
+
+**Fixed bugs:**
+
+- tW Not Loading Projects Other Than Tit/Eph [\#1136](https://github.com/unfoldingWord-dev/translationCore/issues/1136)
+- Uncaught TypeError: Cannot set property 'finished\_chunks' of undefined [\#1130](https://github.com/unfoldingWord-dev/translationCore/issues/1130)
+- Uncaught TypeError: Cannot read property 'toggleMenu' of undefined [\#1129](https://github.com/unfoldingWord-dev/translationCore/issues/1129)
+- Uncaught TypeError: Cannot set property 'finished\_chunks' of undefined [\#1126](https://github.com/unfoldingWord-dev/translationCore/issues/1126)
+- Browse Door43 projects broken [\#1118](https://github.com/unfoldingWord-dev/translationCore/issues/1118)
+- Switching Projects Is Not Working [\#1098](https://github.com/unfoldingWord-dev/translationCore/issues/1098)
+- VerseEdit: Add support for RTL [\#1094](https://github.com/unfoldingWord-dev/translationCore/issues/1094)
+- ScripturePane: When Quote in beginning of Verse Does not highlight [\#1091](https://github.com/unfoldingWord-dev/translationCore/issues/1091)
+- Uncaught Invariant Violation: Element type is invalid: expected a string \(for built-in components\) or a class/function \(for composite components\) but got: undefined. You likely forgot to export your component from the file it's defined in. Check the rende [\#1086](https://github.com/unfoldingWord-dev/translationCore/issues/1086)
+- Edit Verse text does not modify the app state [\#1082](https://github.com/unfoldingWord-dev/translationCore/issues/1082)
+- Handle occurrence shifts when Edit Selection Text [\#1081](https://github.com/unfoldingWord-dev/translationCore/issues/1081)
+- Uncaught TypeError: Cannot read property '1' of null [\#1076](https://github.com/unfoldingWord-dev/translationCore/issues/1076)
+- Uncaught Invariant Violation: Element type is invalid: expected a string \(for built-in components\) or a class/function \(for composite components\) but got: undefined. You likely forgot to export your component from the file it's defined in. Check the rende [\#1058](https://github.com/unfoldingWord-dev/translationCore/issues/1058)
+- Uncaught TypeError: callback is not a function [\#1056](https://github.com/unfoldingWord-dev/translationCore/issues/1056)
+- Fix Bookmark/checkmark behavior [\#1050](https://github.com/unfoldingWord-dev/translationCore/issues/1050)
+- Fix Non-USFM Project Loading [\#1048](https://github.com/unfoldingWord-dev/translationCore/issues/1048)
+- "Warning: React.createElement: type is invalid -- expected a string \(for built-in components\) or a class/function \(for composite components\) but got: undefined. You likely forgot to export your component from the file it's defined in. Check the render met [\#1040](https://github.com/unfoldingWord-dev/translationCore/issues/1040)
+- Uncaught Invariant Violation: Element type is invalid: expected a string \(for built-in components\) or a class/function \(for composite components\) but got: undefined. You likely forgot to export your component from the file it's defined in. Check the rende [\#1039](https://github.com/unfoldingWord-dev/translationCore/issues/1039)
+- tHelps & Menu don't reopen [\#1036](https://github.com/unfoldingWord-dev/translationCore/issues/1036)
+- Menu dropdown arrow not rendering correctly [\#1030](https://github.com/unfoldingWord-dev/translationCore/issues/1030)
+- Uncaught TypeError: Cannot read property 'getNativeNode' of null [\#999](https://github.com/unfoldingWord-dev/translationCore/issues/999)
+- Uncaught Invariant Violation: Element type is invalid: expected a string \(for built-in components\) or a class/function \(for composite components\) but got: null. Check the render method of `ToolsContainer`. [\#998](https://github.com/unfoldingWord-dev/translationCore/issues/998)
+- Uncaught TypeError: Cannot read property 'getNativeNode' of null [\#994](https://github.com/unfoldingWord-dev/translationCore/issues/994)
+- {} [\#993](https://github.com/unfoldingWord-dev/translationCore/issues/993)
+- Uncaught TypeError: callback is not a function [\#990](https://github.com/unfoldingWord-dev/translationCore/issues/990)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$yf4euqrabzluldx1wsxde7b9' of null [\#932](https://github.com/unfoldingWord-dev/translationCore/issues/932)
+
+**Closed issues:**
+
+- fix develop bugs related to new blank projects  and windows related issues [\#1099](https://github.com/unfoldingWord-dev/translationCore/issues/1099)
+- Refactor Fetch Data process in translationNotes [\#1089](https://github.com/unfoldingWord-dev/translationCore/issues/1089)
+- Remove all API calls from tN [\#1088](https://github.com/unfoldingWord-dev/translationCore/issues/1088)
+- fixed bugs with develop after multiple PRs were merged without merging with develop in advance [\#1077](https://github.com/unfoldingWord-dev/translationCore/issues/1077)
+- Case sensitive sorting of tW search [\#1074](https://github.com/unfoldingWord-dev/translationCore/issues/1074)
+- Side Menu Modifications [\#1068](https://github.com/unfoldingWord-dev/translationCore/issues/1068)
+- Greek Pop-over refinements [\#1067](https://github.com/unfoldingWord-dev/translationCore/issues/1067)
+- Target Language in ScripturePane modal not displaying Right-to-Left correctly [\#1065](https://github.com/unfoldingWord-dev/translationCore/issues/1065)
+- Data storage/loading filtered by contextId [\#1053](https://github.com/unfoldingWord-dev/translationCore/issues/1053)
+- Data not storing/loading in Windows [\#1052](https://github.com/unfoldingWord-dev/translationCore/issues/1052)
+- Saving Verse Edit changes to Target source file [\#1043](https://github.com/unfoldingWord-dev/translationCore/issues/1043)
+- Fix Automated Build Process [\#1042](https://github.com/unfoldingWord-dev/translationCore/issues/1042)
+- Implement new top menu [\#1038](https://github.com/unfoldingWord-dev/translationCore/issues/1038)
+- Change the pop-over type for displaying Greek information [\#1037](https://github.com/unfoldingWord-dev/translationCore/issues/1037)
+- Font sizes in Helps [\#1035](https://github.com/unfoldingWord-dev/translationCore/issues/1035)
+- Order checks alphabetically by slug/groupID [\#1033](https://github.com/unfoldingWord-dev/translationCore/issues/1033)
+- Debug Save & Continue [\#1029](https://github.com/unfoldingWord-dev/translationCore/issues/1029)
+- Default Check when loading [\#1028](https://github.com/unfoldingWord-dev/translationCore/issues/1028)
+- Implement file system loading for Group Index & Group Data [\#1018](https://github.com/unfoldingWord-dev/translationCore/issues/1018)
+- Review Mode Modal [\#977](https://github.com/unfoldingWord-dev/translationCore/issues/977)
+- Change Labels for Scripture Pane Content Manager [\#895](https://github.com/unfoldingWord-dev/translationCore/issues/895)
+- tW Update false negatives/positives [\#865](https://github.com/unfoldingWord-dev/translationCore/issues/865)
+- In VerseCheck: Modal Pop-out for Target Translation [\#863](https://github.com/unfoldingWord-dev/translationCore/issues/863)
+- Bookmark [\#862](https://github.com/unfoldingWord-dev/translationCore/issues/862)
+
+**Merged pull requests:**
+
+- Fixed issues switching between tools [\#1151](https://github.com/unfoldingWord-dev/translationCore/pull/1151) ([klappy](https://github.com/klappy))
+- Utilize verify chunks more often [\#1150](https://github.com/unfoldingWord-dev/translationCore/pull/1150) ([ihoegen](https://github.com/ihoegen))
+- Update title of tools in status bar [\#1148](https://github.com/unfoldingWord-dev/translationCore/pull/1148) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- changed actions files to ES6 syntax [\#1147](https://github.com/unfoldingWord-dev/translationCore/pull/1147) ([mannycolon](https://github.com/mannycolon))
+- fixed multiple bugs in containers and change them to es6 syntax [\#1140](https://github.com/unfoldingWord-dev/translationCore/pull/1140) ([mannycolon](https://github.com/mannycolon))
+- Fix Import Door43 Projects [\#1134](https://github.com/unfoldingWord-dev/translationCore/pull/1134) ([RoyalSix](https://github.com/RoyalSix))
+- Initial commit of fixing state [\#1132](https://github.com/unfoldingWord-dev/translationCore/pull/1132) ([klappy](https://github.com/klappy))
+-  Renamed importantWords back to translationWords [\#1131](https://github.com/unfoldingWord-dev/translationCore/pull/1131) ([mannycolon](https://github.com/mannycolon))
+- Fix konami code [\#1128](https://github.com/unfoldingWord-dev/translationCore/pull/1128) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Added ability to edit target language bible in resources reducer [\#1124](https://github.com/unfoldingWord-dev/translationCore/pull/1124) ([mannycolon](https://github.com/mannycolon))
+- Menu Dupes now visible, Objects compared with isEqual [\#1119](https://github.com/unfoldingWord-dev/translationCore/pull/1119) ([klappy](https://github.com/klappy))
+- Filter loading checkDataObjects by groupId, quote and occurrence [\#1116](https://github.com/unfoldingWord-dev/translationCore/pull/1116) ([klappy](https://github.com/klappy))
+- Added data persistence to menu glyph icons [\#1103](https://github.com/unfoldingWord-dev/translationCore/pull/1103) ([mannycolon](https://github.com/mannycolon))
+- Changing Projects Bug Fixed [\#1102](https://github.com/unfoldingWord-dev/translationCore/pull/1102) ([RoyalSix](https://github.com/RoyalSix))
+- Invalidate Selections if occurrences don't match current count. [\#1096](https://github.com/unfoldingWord-dev/translationCore/pull/1096) ([klappy](https://github.com/klappy))
+- npm peer dependencies [\#1095](https://github.com/unfoldingWord-dev/translationCore/pull/1095) ([mannycolon](https://github.com/mannycolon))
+- New Statusbar [\#1093](https://github.com/unfoldingWord-dev/translationCore/pull/1093) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fix saving in windows. [\#1092](https://github.com/unfoldingWord-dev/translationCore/pull/1092) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Styling for Greek popover [\#1090](https://github.com/unfoldingWord-dev/translationCore/pull/1090) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- last fix [\#1087](https://github.com/unfoldingWord-dev/translationCore/pull/1087) ([mannycolon](https://github.com/mannycolon))
+- fixed develop again [\#1083](https://github.com/unfoldingWord-dev/translationCore/pull/1083) ([mannycolon](https://github.com/mannycolon))
+- Feature/klappy 1053 [\#1080](https://github.com/unfoldingWord-dev/translationCore/pull/1080) ([klappy](https://github.com/klappy))
+- issue 1068, styling changes to sidebar collapse button [\#1079](https://github.com/unfoldingWord-dev/translationCore/pull/1079) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- fixed develop [\#1078](https://github.com/unfoldingWord-dev/translationCore/pull/1078) ([mannycolon](https://github.com/mannycolon))
+- Fix Changing Tools [\#1073](https://github.com/unfoldingWord-dev/translationCore/pull/1073) ([RoyalSix](https://github.com/RoyalSix))
+- Added Persistence To Groups Data [\#1063](https://github.com/unfoldingWord-dev/translationCore/pull/1063) ([RoyalSix](https://github.com/RoyalSix))
+- Verse Edit [\#1062](https://github.com/unfoldingWord-dev/translationCore/pull/1062) ([ihoegen](https://github.com/ihoegen))
+- Implemented contextId resume and moved default logic [\#1061](https://github.com/unfoldingWord-dev/translationCore/pull/1061) ([klappy](https://github.com/klappy))
+- issue 1036, fix menu opening and closing [\#1060](https://github.com/unfoldingWord-dev/translationCore/pull/1060) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Update gitignore file [\#1059](https://github.com/unfoldingWord-dev/translationCore/pull/1059) ([cdwhitfield73](https://github.com/cdwhitfield73))
+- Made the greek pop-over disappear when clicking away [\#1055](https://github.com/unfoldingWord-dev/translationCore/pull/1055) ([mannycolon](https://github.com/mannycolon))
+- Prevent bookmarks from toggling when they aren't supposed to [\#1054](https://github.com/unfoldingWord-dev/translationCore/pull/1054) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fix tests [\#1049](https://github.com/unfoldingWord-dev/translationCore/pull/1049) ([ihoegen](https://github.com/ihoegen))
+- Feature/klappy navigation debug [\#1047](https://github.com/unfoldingWord-dev/translationCore/pull/1047) ([klappy](https://github.com/klappy))
+- Implement data persistence for module settings reducer [\#1046](https://github.com/unfoldingWord-dev/translationCore/pull/1046) ([mannycolon](https://github.com/mannycolon))
+- Alphabetize the menu by slug [\#1045](https://github.com/unfoldingWord-dev/translationCore/pull/1045) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Reminders Implementation in the Menu [\#1044](https://github.com/unfoldingWord-dev/translationCore/pull/1044) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [v0.6.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.6.0) (2017-04-05)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.5.1...v0.6.0)
+
+**Implemented enhancements:**
+
+- New notification system Implementation  [\#815](https://github.com/unfoldingWord-dev/translationCore/issues/815)
+- Handling Diverged Git History [\#728](https://github.com/unfoldingWord-dev/translationCore/issues/728)
+- Refine Drag text selection method  [\#724](https://github.com/unfoldingWord-dev/translationCore/issues/724)
+- Future proof check data storage [\#723](https://github.com/unfoldingWord-dev/translationCore/issues/723)
+- Training Team Retrospective [\#683](https://github.com/unfoldingWord-dev/translationCore/issues/683)
+- For tN tool, change the options in the checkboxes [\#669](https://github.com/unfoldingWord-dev/translationCore/issues/669)
+- Include the UDB in the scripture pane. [\#667](https://github.com/unfoldingWord-dev/translationCore/issues/667)
+- Autoselect Flag when Propose Changes is marked [\#663](https://github.com/unfoldingWord-dev/translationCore/issues/663)
+- Scripture Pane Verse Navigation [\#654](https://github.com/unfoldingWord-dev/translationCore/issues/654)
+
+**Fixed bugs:**
+
+- Uncaught ReferenceError: callback is not defined [\#869](https://github.com/unfoldingWord-dev/translationCore/issues/869)
+- Uncaught TypeError: callback is not a function [\#854](https://github.com/unfoldingWord-dev/translationCore/issues/854)
+- Uncaught SyntaxError: Invalid regular expression: missing / [\#852](https://github.com/unfoldingWord-dev/translationCore/issues/852)
+- Uncaught ReferenceError: string is not defined [\#851](https://github.com/unfoldingWord-dev/translationCore/issues/851)
+- Uncaught TypeError: Cannot read property '1' of null [\#848](https://github.com/unfoldingWord-dev/translationCore/issues/848)
+- Uncaught TypeError: Cannot read property '0' of undefined [\#834](https://github.com/unfoldingWord-dev/translationCore/issues/834)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$9zns1v5zrcb84jsd1twd4jwcdi' of null [\#831](https://github.com/unfoldingWord-dev/translationCore/issues/831)
+- Uncaught TypeError: Cannot read property 'heading' of undefined [\#829](https://github.com/unfoldingWord-dev/translationCore/issues/829)
+- Uncaught ReferenceError: heading is not defined [\#828](https://github.com/unfoldingWord-dev/translationCore/issues/828)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#827](https://github.com/unfoldingWord-dev/translationCore/issues/827)
+- Uncaught SyntaxError: /Users/mannycolon/tcprojects/translationCore/src/js/reducers/notificationsReducer.js: Unexpected token \(11:15\) [\#826](https://github.com/unfoldingWord-dev/translationCore/issues/826)
+- Uncaught SyntaxError: /Users/mannycolon/tcprojects/translationCore/src/js/containers/NotificationContainer.js: Unexpected token \(2:19\) [\#825](https://github.com/unfoldingWord-dev/translationCore/issues/825)
+- Uncaught ReferenceError: connect is not defined [\#824](https://github.com/unfoldingWord-dev/translationCore/issues/824)
+- Uncaught TypeError: /Users/mannycolon/tcprojects/translationCore/src/js/components/core/notifications/Snackbar.js: Duplicate declaration "Snackbar" [\#823](https://github.com/unfoldingWord-dev/translationCore/issues/823)
+- Uncaught TypeError: Cannot read property '\_currentElement' of null [\#822](https://github.com/unfoldingWord-dev/translationCore/issues/822)
+- Uncaught Invariant Violation: MuiThemeProvider.render\(\): A valid React element \(or null\) must be returned. You may have returned undefined, an array or some other invalid object. [\#821](https://github.com/unfoldingWord-dev/translationCore/issues/821)
+- Uncaught Error: Invariant Violation: Dispatch.dispatch\(...\): Cannot dispatch in the middle of a dispatch. [\#820](https://github.com/unfoldingWord-dev/translationCore/issues/820)
+- Uncaught SyntaxError: /Users/mannycolon/tcprojects/translationCore/src/js/NotificationApi/ToastComponent.js: Unexpected token \(49:21\) [\#819](https://github.com/unfoldingWord-dev/translationCore/issues/819)
+- Uncaught TypeError: Cannot read property 'getNativeNode' of null [\#818](https://github.com/unfoldingWord-dev/translationCore/issues/818)
+- Uncaught ReferenceError: Snackbar is not defined [\#817](https://github.com/unfoldingWord-dev/translationCore/issues/817)
+- Uncaught TypeError: Cannot read property 'direction' of undefined [\#812](https://github.com/unfoldingWord-dev/translationCore/issues/812)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$4asctzureuye64xsrrot9vbo6r' of null [\#810](https://github.com/unfoldingWord-dev/translationCore/issues/810)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$qfm2y1g06aywcj00m5aru23xr' of null [\#809](https://github.com/unfoldingWord-dev/translationCore/issues/809)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$y5nmzyf073iljatnjkgiizfr' of null [\#808](https://github.com/unfoldingWord-dev/translationCore/issues/808)
+- Uncaught TypeError: Cannot read property 'getNativeNode' of null [\#807](https://github.com/unfoldingWord-dev/translationCore/issues/807)
+- Uncaught TypeError: Cannot read property 'name' of undefined [\#806](https://github.com/unfoldingWord-dev/translationCore/issues/806)
+- Uncaught TypeError: Cannot read property '\_\_reactInternalInstance$tsw4bb5bpcnx4tcpjmemz33di' of null [\#805](https://github.com/unfoldingWord-dev/translationCore/issues/805)
+- Uncaught TypeError: Cannot read property '\_currentElement' of null [\#804](https://github.com/unfoldingWord-dev/translationCore/issues/804)
+- Uncaught TypeError: CoreActions.updateSettings is not a function [\#803](https://github.com/unfoldingWord-dev/translationCore/issues/803)
+- Uncaught TypeError: Cannot read property '4' of undefined [\#802](https://github.com/unfoldingWord-dev/translationCore/issues/802)
+- Uncaught TypeError: Cannot read property '15' of undefined [\#801](https://github.com/unfoldingWord-dev/translationCore/issues/801)
+- Uncaught TypeError: callback is not a function [\#800](https://github.com/unfoldingWord-dev/translationCore/issues/800)
+- Uncaught TypeError: Cannot read property 'heading' of undefined [\#799](https://github.com/unfoldingWord-dev/translationCore/issues/799)
+- Uncaught TypeError: Cannot read property 'length' of undefined [\#798](https://github.com/unfoldingWord-dev/translationCore/issues/798)
+- Uncaught Error: Invariant Violation: Dispatch.dispatch\(...\): Cannot dispatch in the middle of a dispatch. [\#796](https://github.com/unfoldingWord-dev/translationCore/issues/796)
+- Uncaught TypeError: Cannot read property 'getNativeNode' of null [\#795](https://github.com/unfoldingWord-dev/translationCore/issues/795)
+- Uncaught TypeError: Cannot read property 'heading' of undefined [\#794](https://github.com/unfoldingWord-dev/translationCore/issues/794)
+- Uncaught TypeError: Cannot create property 'language\_id' on number '3' [\#793](https://github.com/unfoldingWord-dev/translationCore/issues/793)
+- Uncaught SyntaxError: Invalid regular expression: missing / [\#789](https://github.com/unfoldingWord-dev/translationCore/issues/789)
+- Uncaught TypeError: Cannot create property 'language\_id' on number '3' [\#777](https://github.com/unfoldingWord-dev/translationCore/issues/777)
+- {"test":"Github integration testing"} [\#773](https://github.com/unfoldingWord-dev/translationCore/issues/773)
+- tC Turning User Wi-Fi Off on Hibernate [\#770](https://github.com/unfoldingWord-dev/translationCore/issues/770)
+- Git Installation not working on Windows 10 [\#749](https://github.com/unfoldingWord-dev/translationCore/issues/749)
+- Handling Diverged Git History [\#728](https://github.com/unfoldingWord-dev/translationCore/issues/728)
+- "No link specified" error when loading online project [\#721](https://github.com/unfoldingWord-dev/translationCore/issues/721)
+- Punctuation included in the highlight [\#711](https://github.com/unfoldingWord-dev/translationCore/issues/711)
+- Drag to highlight not working all the time [\#706](https://github.com/unfoldingWord-dev/translationCore/issues/706)
+- Training Team Retrospective [\#683](https://github.com/unfoldingWord-dev/translationCore/issues/683)
+- Import Fails Silently [\#682](https://github.com/unfoldingWord-dev/translationCore/issues/682)
+- Allow Import of URL that doesn't end in '.git' [\#681](https://github.com/unfoldingWord-dev/translationCore/issues/681)
+- Highlight Selection methods not compatible [\#672](https://github.com/unfoldingWord-dev/translationCore/issues/672)
+- My list of online projects is not complete [\#651](https://github.com/unfoldingWord-dev/translationCore/issues/651)
+- Progress bar/tC logo animation doesn't always work [\#46](https://github.com/unfoldingWord-dev/translationCore/issues/46)
+
+**Closed issues:**
+
+- Fix Menu To Allow Multiple Checks [\#1024](https://github.com/unfoldingWord-dev/translationCore/issues/1024)
+- add checkDataLoadActions to changeContextId actions [\#1021](https://github.com/unfoldingWord-dev/translationCore/issues/1021)
+- Implement data persistence for Group Index & Group Data [\#1011](https://github.com/unfoldingWord-dev/translationCore/issues/1011)
+- Generate Group Data and Group Index [\#1009](https://github.com/unfoldingWord-dev/translationCore/issues/1009)
+- Refactor Tool Fetch Datas Using Promises [\#1005](https://github.com/unfoldingWord-dev/translationCore/issues/1005)
+- Loading Data from Data Persistence  [\#985](https://github.com/unfoldingWord-dev/translationCore/issues/985)
+- Nest Reducer Props [\#984](https://github.com/unfoldingWord-dev/translationCore/issues/984)
+- Fetch Data - New Data Structure [\#983](https://github.com/unfoldingWord-dev/translationCore/issues/983)
+- Integrate Reducers and Actions with VerseCheck [\#982](https://github.com/unfoldingWord-dev/translationCore/issues/982)
+- Implement Navigation - Refactor Menu [\#981](https://github.com/unfoldingWord-dev/translationCore/issues/981)
+- Implement Reducer/Actions for Group Index. [\#952](https://github.com/unfoldingWord-dev/translationCore/issues/952)
+- Implement ContextId Actions/Reducers [\#951](https://github.com/unfoldingWord-dev/translationCore/issues/951)
+- Implement Group Data reducer/actions [\#950](https://github.com/unfoldingWord-dev/translationCore/issues/950)
+- implement Index file that addresses order and labels  [\#949](https://github.com/unfoldingWord-dev/translationCore/issues/949)
+- Add Data Loading to Containers [\#948](https://github.com/unfoldingWord-dev/translationCore/issues/948)
+- refactor all redux files to ES6 syntax [\#945](https://github.com/unfoldingWord-dev/translationCore/issues/945)
+- create commentsReducer and commentsActions  [\#944](https://github.com/unfoldingWord-dev/translationCore/issues/944)
+- Replace put data in common with specific actions [\#943](https://github.com/unfoldingWord-dev/translationCore/issues/943)
+- Refactor All 'getDataFromCommon' calls [\#941](https://github.com/unfoldingWord-dev/translationCore/issues/941)
+- Abstract/Fix common.tc generation [\#940](https://github.com/unfoldingWord-dev/translationCore/issues/940)
+- Remove Non-Redux Functions To Helper Methods [\#939](https://github.com/unfoldingWord-dev/translationCore/issues/939)
+- Abstract Common Methods In New Loading Actions [\#938](https://github.com/unfoldingWord-dev/translationCore/issues/938)
+- Convert All Loading Functions to Actions [\#937](https://github.com/unfoldingWord-dev/translationCore/issues/937)
+- create a function helper that generates a namespace based on the new data structure [\#936](https://github.com/unfoldingWord-dev/translationCore/issues/936)
+- create  helper function that  generates a timestamp  [\#935](https://github.com/unfoldingWord-dev/translationCore/issues/935)
+- Optimize Screen Height for iW/tW. [\#929](https://github.com/unfoldingWord-dev/translationCore/issues/929)
+- restructure redux data persistence implementation [\#923](https://github.com/unfoldingWord-dev/translationCore/issues/923)
+- Refactor Loading Process [\#921](https://github.com/unfoldingWord-dev/translationCore/issues/921)
+- integrate verseCheck with tN [\#919](https://github.com/unfoldingWord-dev/translationCore/issues/919)
+- Refactor AccessProject, UploadMethods and CheckDataGrabber using redux  [\#918](https://github.com/unfoldingWord-dev/translationCore/issues/918)
+- Data Persistence modeled after New Data Structure [\#912](https://github.com/unfoldingWord-dev/translationCore/issues/912)
+- Reducers modeled after New Data Structure [\#911](https://github.com/unfoldingWord-dev/translationCore/issues/911)
+- In Edit Mode, Target language shouldn't update until "Save Changes" is clicked [\#909](https://github.com/unfoldingWord-dev/translationCore/issues/909)
+- Limit \# of highlights to 4 [\#907](https://github.com/unfoldingWord-dev/translationCore/issues/907)
+- Verse check integration [\#906](https://github.com/unfoldingWord-dev/translationCore/issues/906)
+- Resources Implementation w/ Redux [\#904](https://github.com/unfoldingWord-dev/translationCore/issues/904)
+- Refactor CheckStoreActions functions out of app.js [\#903](https://github.com/unfoldingWord-dev/translationCore/issues/903)
+- Remove commentBoxStore and proposedChangesStore [\#901](https://github.com/unfoldingWord-dev/translationCore/issues/901)
+- Change the way we require modules in order to import them using ES6 convention [\#900](https://github.com/unfoldingWord-dev/translationCore/issues/900)
+- REFACTOR: api.saveModule and api.getModule w/ redux [\#898](https://github.com/unfoldingWord-dev/translationCore/issues/898)
+- Implement redux data persistence [\#892](https://github.com/unfoldingWord-dev/translationCore/issues/892)
+- REFACTOR: ModuleWrapperContainer so that it doesn't rely on props from App.js [\#889](https://github.com/unfoldingWord-dev/translationCore/issues/889)
+- REFACTOR: SideBarContainer so that it doesn't rely on  App.js props [\#888](https://github.com/unfoldingWord-dev/translationCore/issues/888)
+- Methods To Refactor [\#887](https://github.com/unfoldingWord-dev/translationCore/issues/887)
+- VerseCheck: Implement Actions [\#885](https://github.com/unfoldingWord-dev/translationCore/issues/885)
+- Implement redux for the PopoverApi. [\#884](https://github.com/unfoldingWord-dev/translationCore/issues/884)
+- VerseCheck: Implement UI Design [\#882](https://github.com/unfoldingWord-dev/translationCore/issues/882)
+- VerseCheck: Rough component layout [\#881](https://github.com/unfoldingWord-dev/translationCore/issues/881)
+- VerseCheck: Create Repo and Setup Tool [\#880](https://github.com/unfoldingWord-dev/translationCore/issues/880)
+-  Change reducers from using lodash.merge to Object Spread Operator. [\#877](https://github.com/unfoldingWord-dev/translationCore/issues/877)
+- Make Object Spread Operator usable in tC codebase [\#876](https://github.com/unfoldingWord-dev/translationCore/issues/876)
+- Update ULB, tN, tW [\#875](https://github.com/unfoldingWord-dev/translationCore/issues/875)
+- Implement Redux [\#874](https://github.com/unfoldingWord-dev/translationCore/issues/874)
+- Remove bold font from selected text [\#873](https://github.com/unfoldingWord-dev/translationCore/issues/873)
+- Hide Developer mode [\#872](https://github.com/unfoldingWord-dev/translationCore/issues/872)
+- re-arrange the layout so that it fits new design [\#871](https://github.com/unfoldingWord-dev/translationCore/issues/871)
+- Comment Mode [\#861](https://github.com/unfoldingWord-dev/translationCore/issues/861)
+- Edit Mode [\#860](https://github.com/unfoldingWord-dev/translationCore/issues/860)
+- Select Mode [\#859](https://github.com/unfoldingWord-dev/translationCore/issues/859)
+- Check info Card [\#858](https://github.com/unfoldingWord-dev/translationCore/issues/858)
+- Make tN text selection component the same as tW [\#856](https://github.com/unfoldingWord-dev/translationCore/issues/856)
+- Split tN into Primary/Secondary [\#855](https://github.com/unfoldingWord-dev/translationCore/issues/855)
+- Fix Drag to select ending outside of text [\#816](https://github.com/unfoldingWord-dev/translationCore/issues/816)
+- Implement new Scripture Pane [\#814](https://github.com/unfoldingWord-dev/translationCore/issues/814)
+- Use manifest.json instead of tc-manifest.json [\#813](https://github.com/unfoldingWord-dev/translationCore/issues/813)
+- Version \# in GitHub match app [\#811](https://github.com/unfoldingWord-dev/translationCore/issues/811)
+- tC is turning off my wifi [\#792](https://github.com/unfoldingWord-dev/translationCore/issues/792)
+- Opening project runs forever on usfm file [\#791](https://github.com/unfoldingWord-dev/translationCore/issues/791)
+- Unhelpful message when attempting to login when in offline mode [\#783](https://github.com/unfoldingWord-dev/translationCore/issues/783)
+- Block all projects except Ephesians & Titus [\#769](https://github.com/unfoldingWord-dev/translationCore/issues/769)
+- Integrate Rollbar with GitHub [\#765](https://github.com/unfoldingWord-dev/translationCore/issues/765)
+- Implement new "Read" Panel in "Scrunch mode" [\#763](https://github.com/unfoldingWord-dev/translationCore/issues/763)
+- Collapsible tHelps Panel [\#762](https://github.com/unfoldingWord-dev/translationCore/issues/762)
+- Collapsible Side Menu [\#761](https://github.com/unfoldingWord-dev/translationCore/issues/761)
+- Automatically update main repo when PR merged in tools repo [\#759](https://github.com/unfoldingWord-dev/translationCore/issues/759)
+- Slow CI Build [\#755](https://github.com/unfoldingWord-dev/translationCore/issues/755)
+- Abstract function for sending selection [\#743](https://github.com/unfoldingWord-dev/translationCore/issues/743)
+- Address Selection Bugs [\#742](https://github.com/unfoldingWord-dev/translationCore/issues/742)
+- Abstract logic for figuring out overlapping selections [\#741](https://github.com/unfoldingWord-dev/translationCore/issues/741)
+- Abstract highlight rendering separate from selection [\#740](https://github.com/unfoldingWord-dev/translationCore/issues/740)
+- Abstracted function for removing selection [\#739](https://github.com/unfoldingWord-dev/translationCore/issues/739)
+- Abstracted function for storing/appending selection [\#738](https://github.com/unfoldingWord-dev/translationCore/issues/738)
+- New Data Structure [\#734](https://github.com/unfoldingWord-dev/translationCore/issues/734)
+- Scripture Pane Modal Popup [\#732](https://github.com/unfoldingWord-dev/translationCore/issues/732)
+- Make feedback accessible from the menu [\#710](https://github.com/unfoldingWord-dev/translationCore/issues/710)
+- Make Reports sortable by category: user [\#674](https://github.com/unfoldingWord-dev/translationCore/issues/674)
+- "Deletion" checkbox in Propose Changes tab [\#660](https://github.com/unfoldingWord-dev/translationCore/issues/660)
+- Add list of accepted file formats/extensions [\#646](https://github.com/unfoldingWord-dev/translationCore/issues/646)
+- Error Reporting [\#609](https://github.com/unfoldingWord-dev/translationCore/issues/609)
+- Edit Project Details [\#579](https://github.com/unfoldingWord-dev/translationCore/issues/579)
+- Add the "Glossary" panel to the left side of the available tools screen [\#528](https://github.com/unfoldingWord-dev/translationCore/issues/528)
+- Data folder to change [\#468](https://github.com/unfoldingWord-dev/translationCore/issues/468)
+- Refactor Build Process [\#467](https://github.com/unfoldingWord-dev/translationCore/issues/467)
+- UX Issues [\#462](https://github.com/unfoldingWord-dev/translationCore/issues/462)
+- Modify the Report Filters for the checkBoxes on proposed changes [\#396](https://github.com/unfoldingWord-dev/translationCore/issues/396)
+- High Contrast for projectors [\#352](https://github.com/unfoldingWord-dev/translationCore/issues/352)
+- Implement alias/nickname creation in the login component [\#271](https://github.com/unfoldingWord-dev/translationCore/issues/271)
+- UX/UI Tweaks from Demos [\#72](https://github.com/unfoldingWord-dev/translationCore/issues/72)
+- Page Rendering and User Experience [\#63](https://github.com/unfoldingWord-dev/translationCore/issues/63)
+
+**Merged pull requests:**
+
+- Fixed Group Data Action Workflow [\#1025](https://github.com/unfoldingWord-dev/translationCore/pull/1025) ([RoyalSix](https://github.com/RoyalSix))
+- made changeContextId actions load files from system if they exist [\#1023](https://github.com/unfoldingWord-dev/translationCore/pull/1023) ([mannycolon](https://github.com/mannycolon))
+- Reintroduce context to the status bar [\#1022](https://github.com/unfoldingWord-dev/translationCore/pull/1022) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- removed savePath is undefined log from savemethods.js [\#1020](https://github.com/unfoldingWord-dev/translationCore/pull/1020) ([mannycolon](https://github.com/mannycolon))
+- Temporarily filter GroupsIndex to fix menu [\#1019](https://github.com/unfoldingWord-dev/translationCore/pull/1019) ([klappy](https://github.com/klappy))
+- fixed groupsDataReducer.js [\#1017](https://github.com/unfoldingWord-dev/translationCore/pull/1017) ([mannycolon](https://github.com/mannycolon))
+- fixed misspelled comments [\#1016](https://github.com/unfoldingWord-dev/translationCore/pull/1016) ([mannycolon](https://github.com/mannycolon))
+- Fixed usfm import and currentTool reducer [\#1015](https://github.com/unfoldingWord-dev/translationCore/pull/1015) ([klappy](https://github.com/klappy))
+- Implemented data persistence for Groups Index and Groups Data [\#1014](https://github.com/unfoldingWord-dev/translationCore/pull/1014) ([mannycolon](https://github.com/mannycolon))
+- added setProjectDetail action to toolsContainer.js [\#1013](https://github.com/unfoldingWord-dev/translationCore/pull/1013) ([mannycolon](https://github.com/mannycolon))
+- Refactor group menu [\#1010](https://github.com/unfoldingWord-dev/translationCore/pull/1010) ([klappy](https://github.com/klappy))
+- Add Group Data/Index Actions [\#1008](https://github.com/unfoldingWord-dev/translationCore/pull/1008) ([RoyalSix](https://github.com/RoyalSix))
+- Added SET\_PROJECT\_DETAIL action to project details actions [\#1007](https://github.com/unfoldingWord-dev/translationCore/pull/1007) ([mannycolon](https://github.com/mannycolon))
+- Created check data loading actions [\#1006](https://github.com/unfoldingWord-dev/translationCore/pull/1006) ([mannycolon](https://github.com/mannycolon))
+- Updates to get Reducer Props rendering properly [\#1004](https://github.com/unfoldingWord-dev/translationCore/pull/1004) ([klappy](https://github.com/klappy))
+- added fixes [\#1002](https://github.com/unfoldingWord-dev/translationCore/pull/1002) ([RoyalSix](https://github.com/RoyalSix))
+- Move Non-Redux Functions [\#1001](https://github.com/unfoldingWord-dev/translationCore/pull/1001) ([RoyalSix](https://github.com/RoyalSix))
+- Feature/mc modules settings reducer [\#992](https://github.com/unfoldingWord-dev/translationCore/pull/992) ([mannycolon](https://github.com/mannycolon))
+- Updating name of action to match what it does. [\#988](https://github.com/unfoldingWord-dev/translationCore/pull/988) ([klappy](https://github.com/klappy))
+- Nested props and actions [\#987](https://github.com/unfoldingWord-dev/translationCore/pull/987) ([mannycolon](https://github.com/mannycolon))
+- Feature/lw reminders persistance [\#979](https://github.com/unfoldingWord-dev/translationCore/pull/979) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Add saveMethods for the selectionsReducer [\#961](https://github.com/unfoldingWord-dev/translationCore/pull/961) ([ihoegen](https://github.com/ihoegen))
+- saveVerseEdit [\#960](https://github.com/unfoldingWord-dev/translationCore/pull/960) ([klappy](https://github.com/klappy))
+- Merge of the group index reducer into the the group data reducer [\#958](https://github.com/unfoldingWord-dev/translationCore/pull/958) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fix upload tests [\#957](https://github.com/unfoldingWord-dev/translationCore/pull/957) ([ihoegen](https://github.com/ihoegen))
+- Refactor of Load Methods [\#956](https://github.com/unfoldingWord-dev/translationCore/pull/956) ([RoyalSix](https://github.com/RoyalSix))
+- Feature/mc comments reducer [\#955](https://github.com/unfoldingWord-dev/translationCore/pull/955) ([mannycolon](https://github.com/mannycolon))
+- Implement group data, groupIndex & context Id reducers/actions and add data persistence [\#954](https://github.com/unfoldingWord-dev/translationCore/pull/954) ([mannycolon](https://github.com/mannycolon))
+- Implement ContextId Actions/Reducers \#951 [\#953](https://github.com/unfoldingWord-dev/translationCore/pull/953) ([klappy](https://github.com/klappy))
+- Created commentsReducer, verseEditReducer, modulesReducer and remindersReducer [\#946](https://github.com/unfoldingWord-dev/translationCore/pull/946) ([mannycolon](https://github.com/mannycolon))
+- Add timestamp generator helper [\#942](https://github.com/unfoldingWord-dev/translationCore/pull/942) ([ihoegen](https://github.com/ihoegen))
+- Add VerseCheck [\#931](https://github.com/unfoldingWord-dev/translationCore/pull/931) ([ihoegen](https://github.com/ihoegen))
+- Fix WiFi Disable On Hibernate Bug \(Mac Only\) [\#926](https://github.com/unfoldingWord-dev/translationCore/pull/926) ([RoyalSix](https://github.com/RoyalSix))
+- n [\#925](https://github.com/unfoldingWord-dev/translationCore/pull/925) ([mannycolon](https://github.com/mannycolon))
+- redux resources [\#924](https://github.com/unfoldingWord-dev/translationCore/pull/924) ([mannycolon](https://github.com/mannycolon))
+- restructure redux data persistence implementation [\#922](https://github.com/unfoldingWord-dev/translationCore/pull/922) ([mannycolon](https://github.com/mannycolon))
+- Removed trailing commas preventing app launch [\#920](https://github.com/unfoldingWord-dev/translationCore/pull/920) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Refactor Many Main Methods To Redux [\#917](https://github.com/unfoldingWord-dev/translationCore/pull/917) ([RoyalSix](https://github.com/RoyalSix))
+- Fix issue with test [\#916](https://github.com/unfoldingWord-dev/translationCore/pull/916) ([ihoegen](https://github.com/ihoegen))
+- Migrate to manifest.json instead of tc-manifest.json [\#915](https://github.com/unfoldingWord-dev/translationCore/pull/915) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- fixed commits bug introduced by luke's PR [\#902](https://github.com/unfoldingWord-dev/translationCore/pull/902) ([mannycolon](https://github.com/mannycolon))
+- refactor \*\*ModuleWrapperContainer\*\* and \*\*sideBarContainer\*\* [\#897](https://github.com/unfoldingWord-dev/translationCore/pull/897) ([mannycolon](https://github.com/mannycolon))
+- Preliminary version of data persistence Implementation w/  redux [\#896](https://github.com/unfoldingWord-dev/translationCore/pull/896) ([mannycolon](https://github.com/mannycolon))
+- 2. re-structure the way redux was implemented in tC. Now using storeConfiguration for easy data persistence implementation \(Second\) [\#893](https://github.com/unfoldingWord-dev/translationCore/pull/893) ([mannycolon](https://github.com/mannycolon))
+- 1. PopoverAPI w/ redux \(First\) [\#890](https://github.com/unfoldingWord-dev/translationCore/pull/890) ([mannycolon](https://github.com/mannycolon))
+- Enable or disable developer mode with the konami code [\#883](https://github.com/unfoldingWord-dev/translationCore/pull/883) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Allow ES6 Object Spread Operator in tC [\#878](https://github.com/unfoldingWord-dev/translationCore/pull/878) ([mannycolon](https://github.com/mannycolon))
+- layout re-arrangement for toggle-able menu and tHelps [\#870](https://github.com/unfoldingWord-dev/translationCore/pull/870) ([mannycolon](https://github.com/mannycolon))
+- Add missing package, better error tracking [\#868](https://github.com/unfoldingWord-dev/translationCore/pull/868) ([ihoegen](https://github.com/ihoegen))
+- DragDropActions.js bug fixed and renamed Snackbar component  [\#867](https://github.com/unfoldingWord-dev/translationCore/pull/867) ([mannycolon](https://github.com/mannycolon))
+- Non-Developer Mode Project Restrictions [\#866](https://github.com/unfoldingWord-dev/translationCore/pull/866) ([RoyalSix](https://github.com/RoyalSix))
+- Feature/mc 732 814 [\#853](https://github.com/unfoldingWord-dev/translationCore/pull/853) ([mannycolon](https://github.com/mannycolon))
+- Toggle the menu [\#836](https://github.com/unfoldingWord-dev/translationCore/pull/836) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Version Scripts [\#832](https://github.com/unfoldingWord-dev/translationCore/pull/832) ([ihoegen](https://github.com/ihoegen))
+- Added the UDB to the Scripture Pane [\#830](https://github.com/unfoldingWord-dev/translationCore/pull/830) ([RoyalSix](https://github.com/RoyalSix))
+- Prevent projects with an old manifest from failing silently [\#780](https://github.com/unfoldingWord-dev/translationCore/pull/780) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Refresh repo list [\#774](https://github.com/unfoldingWord-dev/translationCore/pull/774) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- No longer requiring .git url [\#772](https://github.com/unfoldingWord-dev/translationCore/pull/772) ([ihoegen](https://github.com/ihoegen))
+- Remove rollbar from development, only enabled on production [\#771](https://github.com/unfoldingWord-dev/translationCore/pull/771) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.5.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.5.1) (2017-02-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.4.1...v0.5.1)
+
+**Fixed bugs:**
+
+- Fix bug with checks that have the same chapt and verse [\#744](https://github.com/unfoldingWord-dev/translationCore/issues/744)
+- Import Projects copy to ~/translationCore  [\#725](https://github.com/unfoldingWord-dev/translationCore/issues/725)
+
+**Closed issues:**
+
+- Offline Mode + Internal tHelps links [\#750](https://github.com/unfoldingWord-dev/translationCore/issues/750)
+- Check Verse Display [\#731](https://github.com/unfoldingWord-dev/translationCore/issues/731)
+- Make all tHelps links work internally [\#709](https://github.com/unfoldingWord-dev/translationCore/issues/709)
+- Remove OBS & Bible References links from tHelps [\#708](https://github.com/unfoldingWord-dev/translationCore/issues/708)
+- Popup window for offline mode [\#703](https://github.com/unfoldingWord-dev/translationCore/issues/703)
+- Ability to toggle between online/offline mode [\#702](https://github.com/unfoldingWord-dev/translationCore/issues/702)
+- Disable electron's internet connection [\#701](https://github.com/unfoldingWord-dev/translationCore/issues/701)
+- Multiple checks in same verse, highlight respective occurrence [\#697](https://github.com/unfoldingWord-dev/translationCore/issues/697)
+- Migrate tN Essentials to New Google Sheet [\#695](https://github.com/unfoldingWord-dev/translationCore/issues/695)
+- Implement Rollbar for error reporting and user feedback [\#647](https://github.com/unfoldingWord-dev/translationCore/issues/647)
+- Offline Mode [\#628](https://github.com/unfoldingWord-dev/translationCore/issues/628)
+- Store Settings somewhere other than LocalStorage [\#626](https://github.com/unfoldingWord-dev/translationCore/issues/626)
+
+**Merged pull requests:**
+
+- tools commits [\#760](https://github.com/unfoldingWord-dev/translationCore/pull/760) ([mannycolon](https://github.com/mannycolon))
+- Added Dispatcher to Root.js, Removed Extra Code [\#758](https://github.com/unfoldingWord-dev/translationCore/pull/758) ([RoyalSix](https://github.com/RoyalSix))
+- Add templates [\#757](https://github.com/unfoldingWord-dev/translationCore/pull/757) ([ihoegen](https://github.com/ihoegen))
+- Fix Git Installer In Builds [\#756](https://github.com/unfoldingWord-dev/translationCore/pull/756) ([ihoegen](https://github.com/ihoegen))
+- Added a util that handles dispatching redux actions in non-react components [\#754](https://github.com/unfoldingWord-dev/translationCore/pull/754) ([mannycolon](https://github.com/mannycolon))
+- Give warning when attempting to access external resource in offline mode [\#753](https://github.com/unfoldingWord-dev/translationCore/pull/753) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Bring latest tHelps commit to develop [\#751](https://github.com/unfoldingWord-dev/translationCore/pull/751) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Normal projects are copied to working directory [\#747](https://github.com/unfoldingWord-dev/translationCore/pull/747) ([ihoegen](https://github.com/ihoegen))
+- Store Settings somewhere other than LocalStorage [\#746](https://github.com/unfoldingWord-dev/translationCore/pull/746) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.4.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.4.1) (2017-02-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.4.0...v0.4.1)
+
+**Merged pull requests:**
+
+- Multiple checks in same verse, highlight respective occurrence \#697 and Fix bug with checks that have the same chapt and verse \#744 [\#745](https://github.com/unfoldingWord-dev/translationCore/pull/745) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.4.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.4.0) (2017-02-17)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.3.0...v0.4.0)
+
+**Implemented enhancements:**
+
+- Blue boundary on bottom of checking pane [\#590](https://github.com/unfoldingWord-dev/translationCore/issues/590)
+
+**Fixed bugs:**
+
+- Footnotes should not be shown [\#712](https://github.com/unfoldingWord-dev/translationCore/issues/712)
+- Checks Showing up out of order [\#688](https://github.com/unfoldingWord-dev/translationCore/issues/688)
+- Target Language Doesn't Update when Loading New Project [\#680](https://github.com/unfoldingWord-dev/translationCore/issues/680)
+- Bundle "Git" with tC installer [\#679](https://github.com/unfoldingWord-dev/translationCore/issues/679)
+- Scripture Pane showing the wrong book [\#657](https://github.com/unfoldingWord-dev/translationCore/issues/657)
+- Selecting check box switches tab back to tW [\#656](https://github.com/unfoldingWord-dev/translationCore/issues/656)
+
+**Closed issues:**
+
+- Refine Drag to Select [\#735](https://github.com/unfoldingWord-dev/translationCore/issues/735)
+- Migrate tW False Positives Data to Google Sheets [\#700](https://github.com/unfoldingWord-dev/translationCore/issues/700)
+- Show all words in Menu from the tW article title [\#699](https://github.com/unfoldingWord-dev/translationCore/issues/699)
+- Export Data for tN - To determine essential checks [\#693](https://github.com/unfoldingWord-dev/translationCore/issues/693)
+- Export Data for tW - False Positive, False Negative Data Check [\#692](https://github.com/unfoldingWord-dev/translationCore/issues/692)
+- tHelps color scheme [\#690](https://github.com/unfoldingWord-dev/translationCore/issues/690)
+- Tools breakdown [\#677](https://github.com/unfoldingWord-dev/translationCore/issues/677)
+- Abort Loading Screen [\#655](https://github.com/unfoldingWord-dev/translationCore/issues/655)
+- Figures of Speech Check [\#643](https://github.com/unfoldingWord-dev/translationCore/issues/643)
+- Make tC More Responsive [\#511](https://github.com/unfoldingWord-dev/translationCore/issues/511)
+- Changes App [\#42](https://github.com/unfoldingWord-dev/translationCore/issues/42)
+
+**Merged pull requests:**
+
+- Offline Mode For TC [\#730](https://github.com/unfoldingWord-dev/translationCore/pull/730) ([RoyalSix](https://github.com/RoyalSix))
+- Setup app to use rollbar instead of HockeyApp [\#729](https://github.com/unfoldingWord-dev/translationCore/pull/729) ([ihoegen](https://github.com/ihoegen))
+- tools commits update [\#727](https://github.com/unfoldingWord-dev/translationCore/pull/727) ([mannycolon](https://github.com/mannycolon))
+- UI to toggle online/offline mode [\#719](https://github.com/unfoldingWord-dev/translationCore/pull/719) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Show all words in Menu from the tW article title \#699 [\#717](https://github.com/unfoldingWord-dev/translationCore/pull/717) ([mannycolon](https://github.com/mannycolon))
+- Sort the submenus [\#705](https://github.com/unfoldingWord-dev/translationCore/pull/705) ([ihoegen](https://github.com/ihoegen))
+- Add way to stop loading after delay [\#704](https://github.com/unfoldingWord-dev/translationCore/pull/704) ([ihoegen](https://github.com/ihoegen))
+- Make sure users have git installed [\#686](https://github.com/unfoldingWord-dev/translationCore/pull/686) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.3.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.3.0) (2017-02-13)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.2.0...v0.3.0)
+
+**Implemented enhancements:**
+
+- Delete Project\(s\) of Broken Imports [\#666](https://github.com/unfoldingWord-dev/translationCore/issues/666)
+- Adding Scripture Reference to Scripture Pane [\#659](https://github.com/unfoldingWord-dev/translationCore/issues/659)
+- Close Project/Home Open App Fresh State [\#624](https://github.com/unfoldingWord-dev/translationCore/issues/624)
+
+**Fixed bugs:**
+
+- Remove Other Words from the importantWords tool [\#696](https://github.com/unfoldingWord-dev/translationCore/issues/696)
+- Blank Helps section in tN [\#676](https://github.com/unfoldingWord-dev/translationCore/issues/676)
+- Gateway text has issues when Switching tools  [\#675](https://github.com/unfoldingWord-dev/translationCore/issues/675)
+- Click to Highlight not working in some verses [\#673](https://github.com/unfoldingWord-dev/translationCore/issues/673)
+- ULB, verses truncated when word occurs twice [\#665](https://github.com/unfoldingWord-dev/translationCore/issues/665)
+- Sign-In Option Buttons Disarranged After Signing Out [\#642](https://github.com/unfoldingWord-dev/translationCore/issues/642)
+- Progress on Menu Items not updating after doing a check [\#641](https://github.com/unfoldingWord-dev/translationCore/issues/641)
+- Fix reopening app [\#606](https://github.com/unfoldingWord-dev/translationCore/issues/606)
+- Imported Project from D43 Hangs [\#599](https://github.com/unfoldingWord-dev/translationCore/issues/599)
+- translationCore directory in user path not automatically created. [\#598](https://github.com/unfoldingWord-dev/translationCore/issues/598)
+- Fix: Correct and Flagged reset data [\#583](https://github.com/unfoldingWord-dev/translationCore/issues/583)
+- Highlight Selection Methods not functioning [\#492](https://github.com/unfoldingWord-dev/translationCore/issues/492)
+
+**Closed issues:**
+
+- Extract data for tN Essentials [\#694](https://github.com/unfoldingWord-dev/translationCore/issues/694)
+- Figure out issue with Windows 10 Installer [\#662](https://github.com/unfoldingWord-dev/translationCore/issues/662)
+- Offline Mode - Phase 2 [\#644](https://github.com/unfoldingWord-dev/translationCore/issues/644)
+- Redux Implementation of StatusBar [\#634](https://github.com/unfoldingWord-dev/translationCore/issues/634)
+- "Check Mark" should not auto select "Proposed Changes" tab [\#631](https://github.com/unfoldingWord-dev/translationCore/issues/631)
+- Center Icons on tabs under check [\#630](https://github.com/unfoldingWord-dev/translationCore/issues/630)
+- Burmese Target Rendering when using Click to Select [\#629](https://github.com/unfoldingWord-dev/translationCore/issues/629)
+- Relabel Old Testament Source as Hebrew not Greek [\#625](https://github.com/unfoldingWord-dev/translationCore/issues/625)
+- Click to Select/Drag to Select [\#622](https://github.com/unfoldingWord-dev/translationCore/issues/622)
+- implement redux w/ `importantWords Tool` and `sidebarContainer` to address slow app performance and buggy menu [\#618](https://github.com/unfoldingWord-dev/translationCore/issues/618)
+- Implement Redux for the Tools [\#608](https://github.com/unfoldingWord-dev/translationCore/issues/608)
+- Support for USFM language tags [\#605](https://github.com/unfoldingWord-dev/translationCore/issues/605)
+- Make bug reports less frequent [\#601](https://github.com/unfoldingWord-dev/translationCore/issues/601)
+- Rename "translationWords" to "Important Words" [\#596](https://github.com/unfoldingWord-dev/translationCore/issues/596)
+- Mac Build [\#595](https://github.com/unfoldingWord-dev/translationCore/issues/595)
+- Clean tA source for the tH pane [\#594](https://github.com/unfoldingWord-dev/translationCore/issues/594)
+- Link removed from below the check in the tN tab [\#593](https://github.com/unfoldingWord-dev/translationCore/issues/593)
+- tA Title removed from below the check in the tN tab [\#592](https://github.com/unfoldingWord-dev/translationCore/issues/592)
+- Only use KT folder of key terms and not all [\#591](https://github.com/unfoldingWord-dev/translationCore/issues/591)
+- Fill in white gap on right side [\#589](https://github.com/unfoldingWord-dev/translationCore/issues/589)
+- Paste Help tab text [\#588](https://github.com/unfoldingWord-dev/translationCore/issues/588)
+- Save on edit/action/blur [\#587](https://github.com/unfoldingWord-dev/translationCore/issues/587)
+- Default to first tab when Navigating to new check [\#586](https://github.com/unfoldingWord-dev/translationCore/issues/586)
+- Clicking Flag for Review, auto selects Propose Change Tab [\#585](https://github.com/unfoldingWord-dev/translationCore/issues/585)
+- Unselect Correct or Flag on check [\#584](https://github.com/unfoldingWord-dev/translationCore/issues/584)
+- Target check missing ending punctuation on target verses [\#582](https://github.com/unfoldingWord-dev/translationCore/issues/582)
+- Highlight Gateway "quote" in tN and tW in Scripture Pane [\#581](https://github.com/unfoldingWord-dev/translationCore/issues/581)
+- Top Menu Implementation [\#580](https://github.com/unfoldingWord-dev/translationCore/issues/580)
+- Debugging USFM Imports [\#578](https://github.com/unfoldingWord-dev/translationCore/issues/578)
+- Hide ToolsTester unless in Developer Mode [\#577](https://github.com/unfoldingWord-dev/translationCore/issues/577)
+- Type of Feedback Dropdown [\#576](https://github.com/unfoldingWord-dev/translationCore/issues/576)
+- Reports include Target Verse [\#575](https://github.com/unfoldingWord-dev/translationCore/issues/575)
+- Research To Get Translation Articles Source [\#573](https://github.com/unfoldingWord-dev/translationCore/issues/573)
+- Missing Target Verse renders oddly [\#565](https://github.com/unfoldingWord-dev/translationCore/issues/565)
+- One translationWords Tool [\#455](https://github.com/unfoldingWord-dev/translationCore/issues/455)
+- Automated Builds [\#420](https://github.com/unfoldingWord-dev/translationCore/issues/420)
+- How to delete projects? [\#361](https://github.com/unfoldingWord-dev/translationCore/issues/361)
+- Use full tW title [\#359](https://github.com/unfoldingWord-dev/translationCore/issues/359)
+- New UX/UI Implementation [\#277](https://github.com/unfoldingWord-dev/translationCore/issues/277)
+- Hide Developer Tools Menu item? [\#223](https://github.com/unfoldingWord-dev/translationCore/issues/223)
+- Prompt user to load project when report generation is attempted with no project loaded [\#167](https://github.com/unfoldingWord-dev/translationCore/issues/167)
+- User Workflow [\#108](https://github.com/unfoldingWord-dev/translationCore/issues/108)
+
+**Merged pull requests:**
+
+- updated scripturePane's commit [\#687](https://github.com/unfoldingWord-dev/translationCore/pull/687) ([mannycolon](https://github.com/mannycolon))
+- updated tools commits [\#685](https://github.com/unfoldingWord-dev/translationCore/pull/685) ([mannycolon](https://github.com/mannycolon))
+- Fix Issues w/ Highlighting Related to Redux [\#684](https://github.com/unfoldingWord-dev/translationCore/pull/684) ([RoyalSix](https://github.com/RoyalSix))
+- Fixed Styling On Menu Buttons After Making Report [\#678](https://github.com/unfoldingWord-dev/translationCore/pull/678) ([RoyalSix](https://github.com/RoyalSix))
+- updated commits to reflect changes in tools codebase  [\#671](https://github.com/unfoldingWord-dev/translationCore/pull/671) ([mannycolon](https://github.com/mannycolon))
+- Remove imported project dir on error [\#670](https://github.com/unfoldingWord-dev/translationCore/pull/670) ([ihoegen](https://github.com/ihoegen))
+- Removes Setup Icon for Windows [\#664](https://github.com/unfoldingWord-dev/translationCore/pull/664) ([ihoegen](https://github.com/ihoegen))
+- Close Project On Demand [\#661](https://github.com/unfoldingWord-dev/translationCore/pull/661) ([ihoegen](https://github.com/ihoegen))
+- Fixed Item Status Re-render [\#653](https://github.com/unfoldingWord-dev/translationCore/pull/653) ([RoyalSix](https://github.com/RoyalSix))
+- Adds Project Book To StatusBar [\#639](https://github.com/unfoldingWord-dev/translationCore/pull/639) ([RoyalSix](https://github.com/RoyalSix))
+- Updated commits for tools  [\#638](https://github.com/unfoldingWord-dev/translationCore/pull/638) ([mannycolon](https://github.com/mannycolon))
+- Implementation of Redux for New Menu Design [\#636](https://github.com/unfoldingWord-dev/translationCore/pull/636) ([RoyalSix](https://github.com/RoyalSix))
+- Clean App on Version Change [\#635](https://github.com/unfoldingWord-dev/translationCore/pull/635) ([ihoegen](https://github.com/ihoegen))
+- Filled in white gap on right side and made the width screen size more responsive [\#632](https://github.com/unfoldingWord-dev/translationCore/pull/632) ([mannycolon](https://github.com/mannycolon))
+- Fixes issue with Application Could Not be Started on windows 10 [\#623](https://github.com/unfoldingWord-dev/translationCore/pull/623) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.2.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.2.0) (2017-02-03)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.11...v0.2.0)
+
+**Fixed bugs:**
+
+- FIX BUG: sometimes comment box will not save data when navigating to another check [\#532](https://github.com/unfoldingWord-dev/translationCore/issues/532)
+- FIX BUG: Sometimes proposed changes will not save the data when navigating to another check [\#531](https://github.com/unfoldingWord-dev/translationCore/issues/531)
+- Reports will sometimes not generate [\#509](https://github.com/unfoldingWord-dev/translationCore/issues/509)
+-  In my recent projects page the Load Project button isn't working [\#334](https://github.com/unfoldingWord-dev/translationCore/issues/334)
+
+**Closed issues:**
+
+- Remove sidebar component [\#569](https://github.com/unfoldingWord-dev/translationCore/issues/569)
+- Bring Import Online Functionality To New Modal [\#567](https://github.com/unfoldingWord-dev/translationCore/issues/567)
+- Remove code for old Modals from actions, stores and app.js [\#566](https://github.com/unfoldingWord-dev/translationCore/issues/566)
+- Add Reports  To Modal w/ Redux Implementation [\#564](https://github.com/unfoldingWord-dev/translationCore/issues/564)
+- Implement a Feedback System [\#563](https://github.com/unfoldingWord-dev/translationCore/issues/563)
+- create a reports sub tab/section under the projects tab in the modal [\#562](https://github.com/unfoldingWord-dev/translationCore/issues/562)
+- Move The Tools Buttons In The Modal and Implement Redux at the same time [\#555](https://github.com/unfoldingWord-dev/translationCore/issues/555)
+- Menu Bug [\#541](https://github.com/unfoldingWord-dev/translationCore/issues/541)
+- Fix automatic builds [\#535](https://github.com/unfoldingWord-dev/translationCore/issues/535)
+- Add the necessary "sections" for each of the three tabs. [\#529](https://github.com/unfoldingWord-dev/translationCore/issues/529)
+- Restyle the `Tool Cards`to look like the mock ups [\#527](https://github.com/unfoldingWord-dev/translationCore/issues/527)
+- Let the user know that a project must be loaded before they load a tool [\#526](https://github.com/unfoldingWord-dev/translationCore/issues/526)
+- Import Online section of the Projects tab [\#525](https://github.com/unfoldingWord-dev/translationCore/issues/525)
+- Allow the local project dropzone to accept USFM [\#524](https://github.com/unfoldingWord-dev/translationCore/issues/524)
+- Move the `import project locally component` into the 'Import Local Project' sub tab in the centralized modal [\#523](https://github.com/unfoldingWord-dev/translationCore/issues/523)
+- Create a reducer and actions that will handle all project related components [\#522](https://github.com/unfoldingWord-dev/translationCore/issues/522)
+- Create the view design of the `my projects` section   \(holds list of projects \) [\#520](https://github.com/unfoldingWord-dev/translationCore/issues/520)
+- Move settings to a new section under the application tab [\#518](https://github.com/unfoldingWord-dev/translationCore/issues/518)
+- Redux implementation of the Login Components inside the Application Tab \(Centralized Modal\) [\#516](https://github.com/unfoldingWord-dev/translationCore/issues/516)
+- Create a modal that has tabs that work like the tabs on the mockups [\#515](https://github.com/unfoldingWord-dev/translationCore/issues/515)
+- Add version numbers everywhere they exist on mockups \(MODAL FOOTER\) [\#514](https://github.com/unfoldingWord-dev/translationCore/issues/514)
+- Style the login and sign up screens to match mockups [\#513](https://github.com/unfoldingWord-dev/translationCore/issues/513)
+- Improve the workflow for changing and commiting changes to submodules [\#512](https://github.com/unfoldingWord-dev/translationCore/issues/512)
+- Implement New Source for tW Articles [\#494](https://github.com/unfoldingWord-dev/translationCore/issues/494)
+- Public Beta List [\#444](https://github.com/unfoldingWord-dev/translationCore/issues/444)
+- rework how proposeChanges handles data fetching and saving in the store [\#363](https://github.com/unfoldingWord-dev/translationCore/issues/363)
+- rework how comment\_box handles data fetching [\#362](https://github.com/unfoldingWord-dev/translationCore/issues/362)
+- Can the menu icon be altered to allow for smaller window sizes? [\#360](https://github.com/unfoldingWord-dev/translationCore/issues/360)
+- translationNotes: Make the tN module fetch data parse the group metadata being saved in the CheckStore [\#262](https://github.com/unfoldingWord-dev/translationCore/issues/262)
+- Menu option to close the program [\#222](https://github.com/unfoldingWord-dev/translationCore/issues/222)
+
+**Merged pull requests:**
+
+- updated commits for tools again [\#621](https://github.com/unfoldingWord-dev/translationCore/pull/621) ([mannycolon](https://github.com/mannycolon))
+- updated scripturePane commit to latest version [\#620](https://github.com/unfoldingWord-dev/translationCore/pull/620) ([mannycolon](https://github.com/mannycolon))
+- Prepare for main master branch [\#619](https://github.com/unfoldingWord-dev/translationCore/pull/619) ([ihoegen](https://github.com/ihoegen))
+- Implementation of New Menu Design [\#617](https://github.com/unfoldingWord-dev/translationCore/pull/617) ([RoyalSix](https://github.com/RoyalSix))
+- Added ability to choose a category when submitting feedback [\#616](https://github.com/unfoldingWord-dev/translationCore/pull/616) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Make USFM Opening Better [\#615](https://github.com/unfoldingWord-dev/translationCore/pull/615) ([ihoegen](https://github.com/ihoegen))
+- SideBarContainer w/ Redux \(this should help fix the bugs introduced from my last PR\) [\#614](https://github.com/unfoldingWord-dev/translationCore/pull/614) ([mannycolon](https://github.com/mannycolon))
+- Fix Chunk Issue [\#613](https://github.com/unfoldingWord-dev/translationCore/pull/613) ([ihoegen](https://github.com/ihoegen))
+- Modify tests for mac build [\#612](https://github.com/unfoldingWord-dev/translationCore/pull/612) ([ihoegen](https://github.com/ihoegen))
+- Hide tools tester in dev mode [\#611](https://github.com/unfoldingWord-dev/translationCore/pull/611) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Added Redux implementation to send down to tools  [\#607](https://github.com/unfoldingWord-dev/translationCore/pull/607) ([mannycolon](https://github.com/mannycolon))
+- Cut down on errors reported [\#604](https://github.com/unfoldingWord-dev/translationCore/pull/604) ([ihoegen](https://github.com/ihoegen))
+- Configure travis for mac builds [\#603](https://github.com/unfoldingWord-dev/translationCore/pull/603) ([ihoegen](https://github.com/ihoegen))
+- Checking for Translation Core Folder on Mount [\#600](https://github.com/unfoldingWord-dev/translationCore/pull/600) ([RoyalSix](https://github.com/RoyalSix))
+- This PR introduces ES6 compiling to our codebase \(hurray!!\) [\#597](https://github.com/unfoldingWord-dev/translationCore/pull/597) ([mannycolon](https://github.com/mannycolon))
+- Block empty errors [\#574](https://github.com/unfoldingWord-dev/translationCore/pull/574) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.1.11](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.11) (2017-01-27)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.10...v0.1.11)
+
+**Merged pull requests:**
+
+- Move Import Online Functionality To Modal w/Redux [\#572](https://github.com/unfoldingWord-dev/translationCore/pull/572) ([RoyalSix](https://github.com/RoyalSix))
+- Massive code deletion: [\#571](https://github.com/unfoldingWord-dev/translationCore/pull/571) ([mannycolon](https://github.com/mannycolon))
+- Implement bug reporting API [\#570](https://github.com/unfoldingWord-dev/translationCore/pull/570) ([ihoegen](https://github.com/ihoegen))
+- Add Reports To Modal w/ Redux Implementation [\#568](https://github.com/unfoldingWord-dev/translationCore/pull/568) ([mannycolon](https://github.com/mannycolon))
+- Added Recent Project To Modal w/ Redux [\#561](https://github.com/unfoldingWord-dev/translationCore/pull/561) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.1.10](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.10) (2017-01-26)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.9...v0.1.10)
+
+**Fixed bugs:**
+
+- Not able to Sync project [\#493](https://github.com/unfoldingWord-dev/translationCore/issues/493)
+
+**Closed issues:**
+
+- Update Tools to Newest Version [\#506](https://github.com/unfoldingWord-dev/translationCore/issues/506)
+- Create build - Windows [\#504](https://github.com/unfoldingWord-dev/translationCore/issues/504)
+- make the tools layout scale with window size [\#500](https://github.com/unfoldingWord-dev/translationCore/issues/500)
+- Fix recent projects opening [\#489](https://github.com/unfoldingWord-dev/translationCore/issues/489)
+- Check if the required dependencies are downloaded for each tool [\#487](https://github.com/unfoldingWord-dev/translationCore/issues/487)
+- Fixed the menus bugs that wouldnt allow tools with a different data structure to render  [\#485](https://github.com/unfoldingWord-dev/translationCore/issues/485)
+- Gray Scripture X turns red on highlight [\#484](https://github.com/unfoldingWord-dev/translationCore/issues/484)
+- New ?/Help tab [\#483](https://github.com/unfoldingWord-dev/translationCore/issues/483)
+- New tW tab [\#482](https://github.com/unfoldingWord-dev/translationCore/issues/482)
+- tW Update fonts and colors [\#481](https://github.com/unfoldingWord-dev/translationCore/issues/481)
+- Find md/html source for tW articles [\#480](https://github.com/unfoldingWord-dev/translationCore/issues/480)
+- Blue border around check [\#479](https://github.com/unfoldingWord-dev/translationCore/issues/479)
+- Navigation and Check buttons group [\#477](https://github.com/unfoldingWord-dev/translationCore/issues/477)
+- Move tabs below check [\#476](https://github.com/unfoldingWord-dev/translationCore/issues/476)
+- Send Group name to menu headers [\#475](https://github.com/unfoldingWord-dev/translationCore/issues/475)
+- Create Accordion Menu [\#474](https://github.com/unfoldingWord-dev/translationCore/issues/474)
+- Remove \(or move\) the Submenu [\#473](https://github.com/unfoldingWord-dev/translationCore/issues/473)
+- Chevrons to be static [\#472](https://github.com/unfoldingWord-dev/translationCore/issues/472)
+- Refine Menu to look like mockups [\#471](https://github.com/unfoldingWord-dev/translationCore/issues/471)
+- Refine tN tool to look like mockups [\#470](https://github.com/unfoldingWord-dev/translationCore/issues/470)
+- Refine tW tool to look like mockups [\#469](https://github.com/unfoldingWord-dev/translationCore/issues/469)
+- Create or modifed the tabs react bootstrap component to implement new layout [\#463](https://github.com/unfoldingWord-dev/translationCore/issues/463)
+- Ensure Loading of projects works well [\#453](https://github.com/unfoldingWord-dev/translationCore/issues/453)
+- Git submodules for tools [\#452](https://github.com/unfoldingWord-dev/translationCore/issues/452)
+- Menu Refactor [\#442](https://github.com/unfoldingWord-dev/translationCore/issues/442)
+
+**Merged pull requests:**
+
+- updated tC menubar and moved the close window command to the file submenu [\#560](https://github.com/unfoldingWord-dev/translationCore/pull/560) ([mannycolon](https://github.com/mannycolon))
+- checking scripture pane new commit [\#559](https://github.com/unfoldingWord-dev/translationCore/pull/559) ([mannycolon](https://github.com/mannycolon))
+- Links and Resource Update [\#558](https://github.com/unfoldingWord-dev/translationCore/pull/558) ([ihoegen](https://github.com/ihoegen))
+- Moved tools to new centralized modal and implemented redux in its back end \(container\) [\#557](https://github.com/unfoldingWord-dev/translationCore/pull/557) ([mannycolon](https://github.com/mannycolon))
+- Add a brand new view for projects. [\#554](https://github.com/unfoldingWord-dev/translationCore/pull/554) ([ihoegen](https://github.com/ihoegen))
+- Modified the Tool cards to look like the new mockups [\#553](https://github.com/unfoldingWord-dev/translationCore/pull/553) ([mannycolon](https://github.com/mannycolon))
+- Added Load From USFM File [\#552](https://github.com/unfoldingWord-dev/translationCore/pull/552) ([RoyalSix](https://github.com/RoyalSix))
+- added latest commits to tools because bug fixes were recently added to  the tools [\#551](https://github.com/unfoldingWord-dev/translationCore/pull/551) ([mannycolon](https://github.com/mannycolon))
+- Move Settings to the Application Modal  [\#550](https://github.com/unfoldingWord-dev/translationCore/pull/550) ([ihoegen](https://github.com/ihoegen))
+- Fix the Modal Tabs [\#549](https://github.com/unfoldingWord-dev/translationCore/pull/549) ([RoyalSix](https://github.com/RoyalSix))
+- improved css styling for modal components [\#548](https://github.com/unfoldingWord-dev/translationCore/pull/548) ([mannycolon](https://github.com/mannycolon))
+- login redux implementation for the Application tab [\#547](https://github.com/unfoldingWord-dev/translationCore/pull/547) ([mannycolon](https://github.com/mannycolon))
+- Change design of login modal [\#546](https://github.com/unfoldingWord-dev/translationCore/pull/546) ([ihoegen](https://github.com/ihoegen))
+- Central Modal: Added Sub tabs \(sections\) and added App version on the footer [\#545](https://github.com/unfoldingWord-dev/translationCore/pull/545) ([mannycolon](https://github.com/mannycolon))
+- Updated tools commits to include new changes in reports  [\#544](https://github.com/unfoldingWord-dev/translationCore/pull/544) ([mannycolon](https://github.com/mannycolon))
+- New modal tabs [\#543](https://github.com/unfoldingWord-dev/translationCore/pull/543) ([mannycolon](https://github.com/mannycolon))
+- Make the load online pane look like the mockups [\#542](https://github.com/unfoldingWord-dev/translationCore/pull/542) ([ihoegen](https://github.com/ihoegen))
+- Fixed The Menu Using Old Props Bug [\#540](https://github.com/unfoldingWord-dev/translationCore/pull/540) ([RoyalSix](https://github.com/RoyalSix))
+- added new commits for tools and submodules. this should bring submodules to latest commit in all repos [\#539](https://github.com/unfoldingWord-dev/translationCore/pull/539) ([mannycolon](https://github.com/mannycolon))
+- Very Basic Modal System Using Redux [\#538](https://github.com/unfoldingWord-dev/translationCore/pull/538) ([RoyalSix](https://github.com/RoyalSix))
+- new icon [\#537](https://github.com/unfoldingWord-dev/translationCore/pull/537) ([mannycolon](https://github.com/mannycolon))
+- Fix Auto Builds [\#534](https://github.com/unfoldingWord-dev/translationCore/pull/534) ([ihoegen](https://github.com/ihoegen))
+- Added Padding on Arrows in Menu For Better Aligning [\#533](https://github.com/unfoldingWord-dev/translationCore/pull/533) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.1.9](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.9) (2017-01-20)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.8...v0.1.9)
+
+**Implemented enhancements:**
+
+- Add the ability to the source section \(tA, tW\) to pop out  [\#266](https://github.com/unfoldingWord-dev/translationCore/issues/266)
+- Implement sliding in/out source \(tA, tW\) section [\#265](https://github.com/unfoldingWord-dev/translationCore/issues/265)
+
+**Fixed bugs:**
+
+- Package manager uninstall and update tabs aren't working [\#249](https://github.com/unfoldingWord-dev/translationCore/issues/249)
+
+**Closed issues:**
+
+- Nested Accordion Menu [\#466](https://github.com/unfoldingWord-dev/translationCore/issues/466)
+- translationWords Tool Update UI [\#456](https://github.com/unfoldingWord-dev/translationCore/issues/456)
+- Right side Resource Pane [\#454](https://github.com/unfoldingWord-dev/translationCore/issues/454)
+- Git functions working well [\#451](https://github.com/unfoldingWord-dev/translationCore/issues/451)
+- Refactor all the Modals [\#446](https://github.com/unfoldingWord-dev/translationCore/issues/446)
+- refactor the scripture pane module [\#440](https://github.com/unfoldingWord-dev/translationCore/issues/440)
+- refactor translationNotes tool [\#439](https://github.com/unfoldingWord-dev/translationCore/issues/439)
+- refactor comment\_box module [\#437](https://github.com/unfoldingWord-dev/translationCore/issues/437)
+- Login Refactor [\#436](https://github.com/unfoldingWord-dev/translationCore/issues/436)
+- Make tests work locally [\#435](https://github.com/unfoldingWord-dev/translationCore/issues/435)
+- Refactor Package Manager [\#434](https://github.com/unfoldingWord-dev/translationCore/issues/434)
+- refactor proposed changes module [\#432](https://github.com/unfoldingWord-dev/translationCore/issues/432)
+- Refactor UploadModal.js  [\#428](https://github.com/unfoldingWord-dev/translationCore/issues/428)
+- Refactor translationWords tool [\#427](https://github.com/unfoldingWord-dev/translationCore/issues/427)
+- Login Modal.js Refactor [\#424](https://github.com/unfoldingWord-dev/translationCore/issues/424)
+- Notes Translation Check Component: Back End Implementation [\#419](https://github.com/unfoldingWord-dev/translationCore/issues/419)
+- Refactor for Testability [\#418](https://github.com/unfoldingWord-dev/translationCore/issues/418)
+- Notes Translation Check Component: Front End Implementation [\#415](https://github.com/unfoldingWord-dev/translationCore/issues/415)
+- translationCore v0.1.8 [\#410](https://github.com/unfoldingWord-dev/translationCore/issues/410)
+- UI Testing for translationCore: Main App [\#409](https://github.com/unfoldingWord-dev/translationCore/issues/409)
+- Encrypt The Authentication Token For Travis [\#408](https://github.com/unfoldingWord-dev/translationCore/issues/408)
+- Package Manager UI Testing  [\#404](https://github.com/unfoldingWord-dev/translationCore/issues/404)
+- Fix the extra spacing in the menu when the user scrolls [\#403](https://github.com/unfoldingWord-dev/translationCore/issues/403)
+- Add Buttons to the navigation menu [\#402](https://github.com/unfoldingWord-dev/translationCore/issues/402)
+- Selector Bar [\#401](https://github.com/unfoldingWord-dev/translationCore/issues/401)
+- Update package manager to handle specific versions [\#400](https://github.com/unfoldingWord-dev/translationCore/issues/400)
+- incorporate changes to "proposed changes module" with both translationNotes tool and translationWords tool [\#399](https://github.com/unfoldingWord-dev/translationCore/issues/399)
+- Access Project NHPT [\#395](https://github.com/unfoldingWord-dev/translationCore/issues/395)
+- Create Mac Build [\#394](https://github.com/unfoldingWord-dev/translationCore/issues/394)
+- Project Manifest Tests [\#392](https://github.com/unfoldingWord-dev/translationCore/issues/392)
+- CheckDataGrabber.js NHPT [\#390](https://github.com/unfoldingWord-dev/translationCore/issues/390)
+- Report Filters Testing [\#387](https://github.com/unfoldingWord-dev/translationCore/issues/387)
+- Research and implement a new way to use NPM and Babel in builds [\#385](https://github.com/unfoldingWord-dev/translationCore/issues/385)
+- CoreActions and Store NHPT [\#383](https://github.com/unfoldingWord-dev/translationCore/issues/383)
+- PackageManager.js NHPT  [\#382](https://github.com/unfoldingWord-dev/translationCore/issues/382)
+- LoadOnline.js NHPT [\#381](https://github.com/unfoldingWord-dev/translationCore/issues/381)
+- ModuleAPI.js NHPT [\#380](https://github.com/unfoldingWord-dev/translationCore/issues/380)
+- Upload.js NHPT [\#379](https://github.com/unfoldingWord-dev/translationCore/issues/379)
+- Auto Build [\#378](https://github.com/unfoldingWord-dev/translationCore/issues/378)
+- Creating New "Words Check" Tool [\#374](https://github.com/unfoldingWord-dev/translationCore/issues/374)
+- Words Translation Check Component: back end [\#373](https://github.com/unfoldingWord-dev/translationCore/issues/373)
+- Words Translation Check Component: front end [\#372](https://github.com/unfoldingWord-dev/translationCore/issues/372)
+- Create components for new Tools UI [\#371](https://github.com/unfoldingWord-dev/translationCore/issues/371)
+- Notes Translation Check Component [\#370](https://github.com/unfoldingWord-dev/translationCore/issues/370)
+- Words Translation Check Component [\#369](https://github.com/unfoldingWord-dev/translationCore/issues/369)
+- TranslationHelps Drawer Component [\#368](https://github.com/unfoldingWord-dev/translationCore/issues/368)
+- Scripture Pane Component [\#367](https://github.com/unfoldingWord-dev/translationCore/issues/367)
+- Proposed Changes Component [\#366](https://github.com/unfoldingWord-dev/translationCore/issues/366)
+- Comments Box Component [\#365](https://github.com/unfoldingWord-dev/translationCore/issues/365)
+- Test For Upload.js & AccessProject.js & CheckDataGrabber.js [\#350](https://github.com/unfoldingWord-dev/translationCore/issues/350)
+- Unit Tests for Core [\#326](https://github.com/unfoldingWord-dev/translationCore/issues/326)
+- Core API Integration/Unit Tests [\#312](https://github.com/unfoldingWord-dev/translationCore/issues/312)
+- Core UX/UI [\#311](https://github.com/unfoldingWord-dev/translationCore/issues/311)
+- New Menu/Submenu Implementation [\#302](https://github.com/unfoldingWord-dev/translationCore/issues/302)
+- translationNotes installation error in package manager [\#299](https://github.com/unfoldingWord-dev/translationCore/issues/299)
+- Rework the commentBox component to fit the new UX/UI  [\#298](https://github.com/unfoldingWord-dev/translationCore/issues/298)
+- rework commentBox back end and remove tools dependency \(make it more modular\) [\#286](https://github.com/unfoldingWord-dev/translationCore/issues/286)
+- Launching app for the first time causes problems because packages-compiled does not exist yet [\#281](https://github.com/unfoldingWord-dev/translationCore/issues/281)
+- Getting more done in GitHub with ZenHub [\#279](https://github.com/unfoldingWord-dev/translationCore/issues/279)
+- Unable to install multiple Tools at one time [\#269](https://github.com/unfoldingWord-dev/translationCore/issues/269)
+- Enhancement on Scriptural Context scrolling [\#192](https://github.com/unfoldingWord-dev/translationCore/issues/192)
+- Account For Aramaic Verses In OT [\#183](https://github.com/unfoldingWord-dev/translationCore/issues/183)
+- Long error messages make it impossible to click the refresh button in the error modal [\#181](https://github.com/unfoldingWord-dev/translationCore/issues/181)
+- Provide More error information to user if an error is encountered [\#170](https://github.com/unfoldingWord-dev/translationCore/issues/170)
+- Show recent projects on demand [\#131](https://github.com/unfoldingWord-dev/translationCore/issues/131)
+- Roadmap for Private Beta Release [\#90](https://github.com/unfoldingWord-dev/translationCore/issues/90)
+- Loading the entire check list slows down the main view [\#61](https://github.com/unfoldingWord-dev/translationCore/issues/61)
+- Old Testament Support [\#33](https://github.com/unfoldingWord-dev/translationCore/issues/33)
+- Offline Error Handling [\#25](https://github.com/unfoldingWord-dev/translationCore/issues/25)
+
+**Merged pull requests:**
+
+- fixed projectModal.js css [\#510](https://github.com/unfoldingWord-dev/translationCore/pull/510) ([mannycolon](https://github.com/mannycolon))
+- Js menu bootstrap [\#508](https://github.com/unfoldingWord-dev/translationCore/pull/508) ([RoyalSix](https://github.com/RoyalSix))
+- modified the styling for the scroll bars to make it more consistent w… [\#507](https://github.com/unfoldingWord-dev/translationCore/pull/507) ([mannycolon](https://github.com/mannycolon))
+- Update submodules [\#505](https://github.com/unfoldingWord-dev/translationCore/pull/505) ([ihoegen](https://github.com/ihoegen))
+- Check if dependencies are installed [\#503](https://github.com/unfoldingWord-dev/translationCore/pull/503) ([ihoegen](https://github.com/ihoegen))
+- added white logo and fix styling for logo pic [\#502](https://github.com/unfoldingWord-dev/translationCore/pull/502) ([mannycolon](https://github.com/mannycolon))
+- new app layout [\#501](https://github.com/unfoldingWord-dev/translationCore/pull/501) ([mannycolon](https://github.com/mannycolon))
+- new nav tabs css classes [\#499](https://github.com/unfoldingWord-dev/translationCore/pull/499) ([mannycolon](https://github.com/mannycolon))
+- Fix wrong path on reports [\#498](https://github.com/unfoldingWord-dev/translationCore/pull/498) ([ihoegen](https://github.com/ihoegen))
+- Fix issue with sidebar and change of height [\#497](https://github.com/unfoldingWord-dev/translationCore/pull/497) ([ihoegen](https://github.com/ihoegen))
+- update color scheme in core [\#496](https://github.com/unfoldingWord-dev/translationCore/pull/496) ([mannycolon](https://github.com/mannycolon))
+- Static Chevrons [\#495](https://github.com/unfoldingWord-dev/translationCore/pull/495) ([ihoegen](https://github.com/ihoegen))
+- Update the fonts [\#491](https://github.com/unfoldingWord-dev/translationCore/pull/491) ([ihoegen](https://github.com/ihoegen))
+- Js load fix [\#490](https://github.com/unfoldingWord-dev/translationCore/pull/490) ([RoyalSix](https://github.com/RoyalSix))
+- Fix binding issue [\#488](https://github.com/unfoldingWord-dev/translationCore/pull/488) ([ihoegen](https://github.com/ihoegen))
+- fixed bug that woulnt allow wordscheck tool to render [\#486](https://github.com/unfoldingWord-dev/translationCore/pull/486) ([mannycolon](https://github.com/mannycolon))
+- Add Recent Projects to the upload modal [\#465](https://github.com/unfoldingWord-dev/translationCore/pull/465) ([ihoegen](https://github.com/ihoegen))
+- Previous and next buttons removal [\#461](https://github.com/unfoldingWord-dev/translationCore/pull/461) ([mannycolon](https://github.com/mannycolon))
+- Add submodule support for the Application [\#460](https://github.com/unfoldingWord-dev/translationCore/pull/460) ([ihoegen](https://github.com/ihoegen))
+- Removed the current check word from the status bar [\#459](https://github.com/unfoldingWord-dev/translationCore/pull/459) ([mannycolon](https://github.com/mannycolon))
+- Added redux dependency [\#458](https://github.com/unfoldingWord-dev/translationCore/pull/458) ([mannycolon](https://github.com/mannycolon))
+- Testing for git, along with refined syncing [\#457](https://github.com/unfoldingWord-dev/translationCore/pull/457) ([ihoegen](https://github.com/ihoegen))
+- Modals Refactoring  [\#450](https://github.com/unfoldingWord-dev/translationCore/pull/450) ([ihoegen](https://github.com/ihoegen))
+- Js menu refactor [\#447](https://github.com/unfoldingWord-dev/translationCore/pull/447) ([RoyalSix](https://github.com/RoyalSix))
+- Load tools that either use a container or a view [\#445](https://github.com/unfoldingWord-dev/translationCore/pull/445) ([ihoegen](https://github.com/ihoegen))
+- Package manager refactor [\#433](https://github.com/unfoldingWord-dev/translationCore/pull/433) ([ihoegen](https://github.com/ihoegen))
+- Js redux [\#431](https://github.com/unfoldingWord-dev/translationCore/pull/431) ([RoyalSix](https://github.com/RoyalSix))
+- Login refactor [\#430](https://github.com/unfoldingWord-dev/translationCore/pull/430) ([RoyalSix](https://github.com/RoyalSix))
+- Refactor of Upload [\#429](https://github.com/unfoldingWord-dev/translationCore/pull/429) ([ihoegen](https://github.com/ihoegen))
+- Should fix issues with local tests failling [\#426](https://github.com/unfoldingWord-dev/translationCore/pull/426) ([ihoegen](https://github.com/ihoegen))
+- CheckData Grabber Tests [\#423](https://github.com/unfoldingWord-dev/translationCore/pull/423) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.1.8](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.8) (2016-12-15)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.7...v0.1.8)
+
+**Fixed bugs:**
+
+- Issues discovered in tC v0.1.5 [\#293](https://github.com/unfoldingWord-dev/translationCore/issues/293)
+
+**Closed issues:**
+
+- Tests for ImportUSFM and PackageManager [\#354](https://github.com/unfoldingWord-dev/translationCore/issues/354)
+- Integrate Travis CI with the Repo [\#347](https://github.com/unfoldingWord-dev/translationCore/issues/347)
+- Rewrite Upload.js to allow for easy testing of the crucial functions [\#344](https://github.com/unfoldingWord-dev/translationCore/issues/344)
+- Tools extraction of unnecessary menus components \(translationCoreApps repo\) [\#342](https://github.com/unfoldingWord-dev/translationCore/issues/342)
+- Write tests for the USFM-Parser Node Module [\#339](https://github.com/unfoldingWord-dev/translationCore/issues/339)
+- Create desktop shortcut on install [\#332](https://github.com/unfoldingWord-dev/translationCore/issues/332)
+- Creating a Build Sprint \#7 Review  [\#330](https://github.com/unfoldingWord-dev/translationCore/issues/330)
+- Selector Bar [\#328](https://github.com/unfoldingWord-dev/translationCore/issues/328)
+- Integration Tests for Core API [\#325](https://github.com/unfoldingWord-dev/translationCore/issues/325)
+- Submenu Status [\#319](https://github.com/unfoldingWord-dev/translationCore/issues/319)
+- Chevron Menu Structure [\#318](https://github.com/unfoldingWord-dev/translationCore/issues/318)
+- Progress for the Groups [\#317](https://github.com/unfoldingWord-dev/translationCore/issues/317)
+- Implement headings in the side bar container \(menu\) [\#306](https://github.com/unfoldingWord-dev/translationCore/issues/306)
+- Implement rendering checks in the submenu [\#305](https://github.com/unfoldingWord-dev/translationCore/issues/305)
+- Updating USFM Loading Process To New Flow [\#303](https://github.com/unfoldingWord-dev/translationCore/issues/303)
+
+**Merged pull requests:**
+
+- Fix depreceated mounting issue [\#414](https://github.com/unfoldingWord-dev/translationCore/pull/414) ([ihoegen](https://github.com/ihoegen))
+- UI Testing [\#413](https://github.com/unfoldingWord-dev/translationCore/pull/413) ([ihoegen](https://github.com/ihoegen))
+- refactor to account for ScripturePane new changes [\#411](https://github.com/unfoldingWord-dev/translationCore/pull/411) ([mannycolon](https://github.com/mannycolon))
+- Added Encryption For Authentication [\#407](https://github.com/unfoldingWord-dev/translationCore/pull/407) ([RoyalSix](https://github.com/RoyalSix))
+- new api method [\#406](https://github.com/unfoldingWord-dev/translationCore/pull/406) ([mannycolon](https://github.com/mannycolon))
+- added more error handling to menus [\#398](https://github.com/unfoldingWord-dev/translationCore/pull/398) ([mannycolon](https://github.com/mannycolon))
+- Added better error handling to submenu.js [\#393](https://github.com/unfoldingWord-dev/translationCore/pull/393) ([mannycolon](https://github.com/mannycolon))
+- Report Filters, Access Project, and Project Manifest Tests [\#391](https://github.com/unfoldingWord-dev/translationCore/pull/391) ([ihoegen](https://github.com/ihoegen))
+- Upload.js Tests [\#389](https://github.com/unfoldingWord-dev/translationCore/pull/389) ([RoyalSix](https://github.com/RoyalSix))
+- Fix package manager [\#386](https://github.com/unfoldingWord-dev/translationCore/pull/386) ([ihoegen](https://github.com/ihoegen))
+- Non-happy-path Testing [\#384](https://github.com/unfoldingWord-dev/translationCore/pull/384) ([ihoegen](https://github.com/ihoegen))
+- Automated Builds  [\#377](https://github.com/unfoldingWord-dev/translationCore/pull/377) ([ihoegen](https://github.com/ihoegen))
+- Access Project, CheckDataGrabber Tests [\#364](https://github.com/unfoldingWord-dev/translationCore/pull/364) ([RoyalSix](https://github.com/RoyalSix))
+
+## [v0.1.7](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.7) (2016-12-01)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.6...v0.1.7)
+
+**Closed issues:**
+
+- Build 0.1.6 [\#315](https://github.com/unfoldingWord-dev/translationCore/issues/315)
+- Help thomas set up translationCore  in his computer [\#313](https://github.com/unfoldingWord-dev/translationCore/issues/313)
+- Testing USFM files from India [\#296](https://github.com/unfoldingWord-dev/translationCore/issues/296)
+
+**Merged pull requests:**
+
+- Created a simple test for CoreStore and CoreActions [\#358](https://github.com/unfoldingWord-dev/translationCore/pull/358) ([ihoegen](https://github.com/ihoegen))
+- Menus goToNext and goToPrevious now work much more smoothly and items scroll to top on click [\#357](https://github.com/unfoldingWord-dev/translationCore/pull/357) ([mannycolon](https://github.com/mannycolon))
+- Fixes issues brought up by @len-wallstrom [\#356](https://github.com/unfoldingWord-dev/translationCore/pull/356) ([ihoegen](https://github.com/ihoegen))
+- Tests for ImportUSFM and PackageManager [\#355](https://github.com/unfoldingWord-dev/translationCore/pull/355) ([ihoegen](https://github.com/ihoegen))
+- Progress circles [\#351](https://github.com/unfoldingWord-dev/translationCore/pull/351) ([mannycolon](https://github.com/mannycolon))
+- Travis-CI Initialization [\#349](https://github.com/unfoldingWord-dev/translationCore/pull/349) ([ihoegen](https://github.com/ihoegen))
+- A couple of tests for loadonline [\#348](https://github.com/unfoldingWord-dev/translationCore/pull/348) ([ihoegen](https://github.com/ihoegen))
+- Move scripts to relevant folders [\#346](https://github.com/unfoldingWord-dev/translationCore/pull/346) ([ihoegen](https://github.com/ihoegen))
+- Rewrite Upload.js for Testing [\#345](https://github.com/unfoldingWord-dev/translationCore/pull/345) ([ihoegen](https://github.com/ihoegen))
+- menus bug fix [\#343](https://github.com/unfoldingWord-dev/translationCore/pull/343) ([mannycolon](https://github.com/mannycolon))
+- Remove dead code [\#341](https://github.com/unfoldingWord-dev/translationCore/pull/341) ([ihoegen](https://github.com/ihoegen))
+- scroll bars enhancement  [\#340](https://github.com/unfoldingWord-dev/translationCore/pull/340) ([mannycolon](https://github.com/mannycolon))
+- menu fix [\#338](https://github.com/unfoldingWord-dev/translationCore/pull/338) ([mannycolon](https://github.com/mannycolon))
+-  scroll bars stylings [\#337](https://github.com/unfoldingWord-dev/translationCore/pull/337) ([mannycolon](https://github.com/mannycolon))
+- Chevron Menu Structure [\#336](https://github.com/unfoldingWord-dev/translationCore/pull/336) ([mannycolon](https://github.com/mannycolon))
+- Integration Testing for API [\#335](https://github.com/unfoldingWord-dev/translationCore/pull/335) ([ihoegen](https://github.com/ihoegen))
+- Automated builds, includes desktop icons [\#333](https://github.com/unfoldingWord-dev/translationCore/pull/333) ([ihoegen](https://github.com/ihoegen))
+- Added check for blank filepath [\#331](https://github.com/unfoldingWord-dev/translationCore/pull/331) ([RoyalSix](https://github.com/RoyalSix))
+- USFM Fix [\#310](https://github.com/unfoldingWord-dev/translationCore/pull/310) ([RoyalSix](https://github.com/RoyalSix))
+- New Menu/Submenu Implementation [\#309](https://github.com/unfoldingWord-dev/translationCore/pull/309) ([mannycolon](https://github.com/mannycolon))
+
+## [v0.1.6](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.6) (2016-11-18)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.5...v0.1.6)
+
+**Fixed bugs:**
+
+- Fix fatal loading bug in translationWords [\#307](https://github.com/unfoldingWord-dev/translationCore/issues/307)
+- Error Modals not working in builds [\#210](https://github.com/unfoldingWord-dev/translationCore/issues/210)
+- Problem loading projects [\#209](https://github.com/unfoldingWord-dev/translationCore/issues/209)
+- Door43 Project not loading [\#202](https://github.com/unfoldingWord-dev/translationCore/issues/202)
+- Frozen Loading Screen [\#201](https://github.com/unfoldingWord-dev/translationCore/issues/201)
+- Error on loading project [\#190](https://github.com/unfoldingWord-dev/translationCore/issues/190)
+
+**Closed issues:**
+
+- Fix the Original Language In TPane [\#304](https://github.com/unfoldingWord-dev/translationCore/issues/304)
+- save all checkingRubric questions in a JSON file  [\#294](https://github.com/unfoldingWord-dev/translationCore/issues/294)
+-  checkingRubric tool: implement design of the rubric component to render QA questions [\#287](https://github.com/unfoldingWord-dev/translationCore/issues/287)
+- integrate tPane with checkingRubric [\#285](https://github.com/unfoldingWord-dev/translationCore/issues/285)
+- Design the view component for the checkingRubric [\#284](https://github.com/unfoldingWord-dev/translationCore/issues/284)
+- implement fetchData for checkingRubric [\#283](https://github.com/unfoldingWord-dev/translationCore/issues/283)
+- Save Gateway Text with Check [\#274](https://github.com/unfoldingWord-dev/translationCore/issues/274)
+- User Accounts - persistence [\#273](https://github.com/unfoldingWord-dev/translationCore/issues/273)
+- Bundle tNotes ULB [\#272](https://github.com/unfoldingWord-dev/translationCore/issues/272)
+- Bundle tWords ULB [\#270](https://github.com/unfoldingWord-dev/translationCore/issues/270)
+- Design documentation for developer mode [\#268](https://github.com/unfoldingWord-dev/translationCore/issues/268)
+- Bundle translationWords source files with tool  [\#263](https://github.com/unfoldingWord-dev/translationCore/issues/263)
+- Bundle Resources for Translation Academy tool [\#259](https://github.com/unfoldingWord-dev/translationCore/issues/259)
+- Create the top status bar component [\#258](https://github.com/unfoldingWord-dev/translationCore/issues/258)
+- Bring the online/offline status to the top status bar [\#257](https://github.com/unfoldingWord-dev/translationCore/issues/257)
+- Generate a "path" to the current check \(i.e the "Luke \> Translation Words \> Angel"\) [\#256](https://github.com/unfoldingWord-dev/translationCore/issues/256)
+- Create the status bar component at the top of the screen [\#255](https://github.com/unfoldingWord-dev/translationCore/issues/255)
+- Toggle the nav bars contents when the tC icon is clicked [\#251](https://github.com/unfoldingWord-dev/translationCore/issues/251)
+- Creating builds [\#240](https://github.com/unfoldingWord-dev/translationCore/issues/240)
+- Easily Accessible Import from Door43 [\#230](https://github.com/unfoldingWord-dev/translationCore/issues/230)
+- Pre-parse and bundle Resource Data in Checking Tools [\#224](https://github.com/unfoldingWord-dev/translationCore/issues/224)
+- Use new source for UGNT \(Greek Source\) [\#211](https://github.com/unfoldingWord-dev/translationCore/issues/211)
+- Import from online to use listing of repos [\#199](https://github.com/unfoldingWord-dev/translationCore/issues/199)
+- Use Verse Mapping to Align Hebrew With Other Languages [\#182](https://github.com/unfoldingWord-dev/translationCore/issues/182)
+- Report Usability: Recover the ability to print report pdf version  [\#177](https://github.com/unfoldingWord-dev/translationCore/issues/177)
+- Support Garhwali \(gbm\) USFM files [\#174](https://github.com/unfoldingWord-dev/translationCore/issues/174)
+- Report Usability [\#50](https://github.com/unfoldingWord-dev/translationCore/issues/50)
+- Plan for translationManager App [\#43](https://github.com/unfoldingWord-dev/translationCore/issues/43)
+
+**Merged pull requests:**
+
+- Upgrade to 0.1.6 [\#314](https://github.com/unfoldingWord-dev/translationCore/pull/314) ([ihoegen](https://github.com/ihoegen))
+- Fixed the alert object error message [\#295](https://github.com/unfoldingWord-dev/translationCore/pull/295) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- status bar fixes [\#292](https://github.com/unfoldingWord-dev/translationCore/pull/292) ([mannycolon](https://github.com/mannycolon))
+- User Login Persistence [\#290](https://github.com/unfoldingWord-dev/translationCore/pull/290) ([RoyalSix](https://github.com/RoyalSix))
+- Modification of build scripts [\#289](https://github.com/unfoldingWord-dev/translationCore/pull/289) ([ihoegen](https://github.com/ihoegen))
+- Clear Local Storage When App Is Caught In Restart Loop [\#282](https://github.com/unfoldingWord-dev/translationCore/pull/282) ([RoyalSix](https://github.com/RoyalSix))
+- Allow inclusion of submodules in packages [\#278](https://github.com/unfoldingWord-dev/translationCore/pull/278) ([ihoegen](https://github.com/ihoegen))
+- Added ability to load a tool from a local directory [\#261](https://github.com/unfoldingWord-dev/translationCore/pull/261) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [v0.1.5](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.5) (2016-11-04)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/0.1.4...v0.1.5)
+
+**Implemented enhancements:**
+
+- Presentation of the translation notes information [\#191](https://github.com/unfoldingWord-dev/translationCore/issues/191)
+- Change Check Category by Clicking logo/title [\#189](https://github.com/unfoldingWord-dev/translationCore/issues/189)
+- Wording on 'Load your first project' screen [\#187](https://github.com/unfoldingWord-dev/translationCore/issues/187)
+- Implement new buttons design based on mockups [\#157](https://github.com/unfoldingWord-dev/translationCore/issues/157)
+- Implement new translationCore app layout design [\#156](https://github.com/unfoldingWord-dev/translationCore/issues/156)
+- Implement new menuView layout design [\#155](https://github.com/unfoldingWord-dev/translationCore/issues/155)
+
+**Fixed bugs:**
+
+- Git Errors [\#235](https://github.com/unfoldingWord-dev/translationCore/issues/235)
+- Can't Copy & Paste [\#203](https://github.com/unfoldingWord-dev/translationCore/issues/203)
+- Confusing Loading of Project [\#188](https://github.com/unfoldingWord-dev/translationCore/issues/188)
+- reportview doesnt work when logged in [\#152](https://github.com/unfoldingWord-dev/translationCore/issues/152)
+
+**Closed issues:**
+
+- LTR Languages Rendering As RTL [\#234](https://github.com/unfoldingWord-dev/translationCore/issues/234)
+- Demo Stability  [\#233](https://github.com/unfoldingWord-dev/translationCore/issues/233)
+- Fix report opening on extracted modules [\#229](https://github.com/unfoldingWord-dev/translationCore/issues/229)
+- Rename apps to tools [\#208](https://github.com/unfoldingWord-dev/translationCore/issues/208)
+- Tutorial unclear [\#207](https://github.com/unfoldingWord-dev/translationCore/issues/207)
+- Screen Real Estate Optimization [\#200](https://github.com/unfoldingWord-dev/translationCore/issues/200)
+- Video Walkthrough by @ihoegen [\#196](https://github.com/unfoldingWord-dev/translationCore/issues/196)
+- Change "The meaning has been: Retained/Replaced" to "The figure has been:..." [\#194](https://github.com/unfoldingWord-dev/translationCore/issues/194)
+- Correction of ULB title  [\#193](https://github.com/unfoldingWord-dev/translationCore/issues/193)
+- Confusing first screen [\#186](https://github.com/unfoldingWord-dev/translationCore/issues/186)
+- Get Sample Hebrew Project To Test Hebrew In TPane [\#184](https://github.com/unfoldingWord-dev/translationCore/issues/184)
+- Parse Hebrew From Resource For tC format [\#178](https://github.com/unfoldingWord-dev/translationCore/issues/178)
+- Fix\Update Languages in reference Tri-pane. [\#175](https://github.com/unfoldingWord-dev/translationCore/issues/175)
+- Make reports an internal component and remove new window option [\#173](https://github.com/unfoldingWord-dev/translationCore/issues/173)
+- Integrate reportFilter.js functions with the report view UI [\#172](https://github.com/unfoldingWord-dev/translationCore/issues/172)
+- Take Apps Out Of Codebase [\#168](https://github.com/unfoldingWord-dev/translationCore/issues/168)
+- Update Modules [\#165](https://github.com/unfoldingWord-dev/translationCore/issues/165)
+- translationCore package manager UI [\#162](https://github.com/unfoldingWord-dev/translationCore/issues/162)
+- Compile modules [\#161](https://github.com/unfoldingWord-dev/translationCore/issues/161)
+- Download modules [\#160](https://github.com/unfoldingWord-dev/translationCore/issues/160)
+- translationCore package manager [\#159](https://github.com/unfoldingWord-dev/translationCore/issues/159)
+- Create central repo for module manifest tracking. [\#158](https://github.com/unfoldingWord-dev/translationCore/issues/158)
+- Prevent translationAcademy text from getting into the checkstore when using drag to select [\#151](https://github.com/unfoldingWord-dev/translationCore/issues/151)
+- Implement drag to select selection component in TranslationNotes [\#150](https://github.com/unfoldingWord-dev/translationCore/issues/150)
+- Bold selected words in drag to select [\#149](https://github.com/unfoldingWord-dev/translationCore/issues/149)
+- Create new build and get to stakeholders before sprint review [\#148](https://github.com/unfoldingWord-dev/translationCore/issues/148)
+- Implement report data filtering/parsing for reportview [\#147](https://github.com/unfoldingWord-dev/translationCore/issues/147)
+- Dynamic Compilation of Modules [\#144](https://github.com/unfoldingWord-dev/translationCore/issues/144)
+- Look into a developer only acccess option to hide the example check module rather than using a hotkey [\#134](https://github.com/unfoldingWord-dev/translationCore/issues/134)
+- Implement better optimized report view [\#123](https://github.com/unfoldingWord-dev/translationCore/issues/123)
+- Implement layout design for a better optimized report view [\#122](https://github.com/unfoldingWord-dev/translationCore/issues/122)
+- Nested Menu [\#109](https://github.com/unfoldingWord-dev/translationCore/issues/109)
+- Text Selection for Arabic [\#99](https://github.com/unfoldingWord-dev/translationCore/issues/99)
+- Add Refresh button when an error occurs [\#98](https://github.com/unfoldingWord-dev/translationCore/issues/98)
+- Close modal and pop toast when a project successfully loads [\#96](https://github.com/unfoldingWord-dev/translationCore/issues/96)
+- Collapsable Menu Categories [\#84](https://github.com/unfoldingWord-dev/translationCore/issues/84)
+- Loading in the entire book for the tpane slows down re-render [\#62](https://github.com/unfoldingWord-dev/translationCore/issues/62)
+- Extracting tC apps/modules to their own Repo [\#27](https://github.com/unfoldingWord-dev/translationCore/issues/27)
+
+**Merged pull requests:**
+
+- New mockups implementation in the side nav bar and top status bar [\#264](https://github.com/unfoldingWord-dev/translationCore/pull/264) ([mannycolon](https://github.com/mannycolon))
+- fixed a bug with the login section on tC tutorial [\#254](https://github.com/unfoldingWord-dev/translationCore/pull/254) ([mannycolon](https://github.com/mannycolon))
+- Parsed and added new source UGNT [\#253](https://github.com/unfoldingWord-dev/translationCore/pull/253) ([RoyalSix](https://github.com/RoyalSix))
+-  report cards pdf printing [\#245](https://github.com/unfoldingWord-dev/translationCore/pull/245) ([mannycolon](https://github.com/mannycolon))
+- added stack to git commits [\#239](https://github.com/unfoldingWord-dev/translationCore/pull/239) ([RoyalSix](https://github.com/RoyalSix))
+- fixed app description styling [\#238](https://github.com/unfoldingWord-dev/translationCore/pull/238) ([mannycolon](https://github.com/mannycolon))
+- Door 43 Projects on Load Menu [\#237](https://github.com/unfoldingWord-dev/translationCore/pull/237) ([ihoegen](https://github.com/ihoegen))
+- Refactored CheckdataGrabber [\#236](https://github.com/unfoldingWord-dev/translationCore/pull/236) ([RoyalSix](https://github.com/RoyalSix))
+- recovered the ability to copy and paste in tC [\#232](https://github.com/unfoldingWord-dev/translationCore/pull/232) ([mannycolon](https://github.com/mannycolon))
+- Made the error screen better by hiding technical details [\#231](https://github.com/unfoldingWord-dev/translationCore/pull/231) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Fix report opening [\#228](https://github.com/unfoldingWord-dev/translationCore/pull/228) ([ihoegen](https://github.com/ihoegen))
+- Garhwali Support [\#227](https://github.com/unfoldingWord-dev/translationCore/pull/227) ([ihoegen](https://github.com/ihoegen))
+- Refactored Anything That Has To Do With Loads [\#226](https://github.com/unfoldingWord-dev/translationCore/pull/226) ([RoyalSix](https://github.com/RoyalSix))
+- Changed the tutorial's order and fixed the load your project page [\#225](https://github.com/unfoldingWord-dev/translationCore/pull/225) ([mannycolon](https://github.com/mannycolon))
+- Made the tPane titles info to render dynamically  [\#221](https://github.com/unfoldingWord-dev/translationCore/pull/221) ([mannycolon](https://github.com/mannycolon))
+- translationCore text refactoring [\#220](https://github.com/unfoldingWord-dev/translationCore/pull/220) ([mannycolon](https://github.com/mannycolon))
+- added toast notification on load [\#219](https://github.com/unfoldingWord-dev/translationCore/pull/219) ([mannycolon](https://github.com/mannycolon))
+- Wording on 'Load your first project' screen [\#218](https://github.com/unfoldingWord-dev/translationCore/pull/218) ([mannycolon](https://github.com/mannycolon))
+- Change Check Category by Clicking the anywher inside the box [\#217](https://github.com/unfoldingWord-dev/translationCore/pull/217) ([mannycolon](https://github.com/mannycolon))
+- Got rid of that left arrow on the first slide of the tutorial [\#215](https://github.com/unfoldingWord-dev/translationCore/pull/215) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- fixed the parsing of the YAML in translationAcademy [\#214](https://github.com/unfoldingWord-dev/translationCore/pull/214) ([mannycolon](https://github.com/mannycolon))
+- Fixed the titles/labels in the tPane  [\#213](https://github.com/unfoldingWord-dev/translationCore/pull/213) ([mannycolon](https://github.com/mannycolon))
+- Js hebrew [\#212](https://github.com/unfoldingWord-dev/translationCore/pull/212) ([RoyalSix](https://github.com/RoyalSix))
+- report label change [\#185](https://github.com/unfoldingWord-dev/translationCore/pull/185) ([mannycolon](https://github.com/mannycolon))
+- Package Manager [\#179](https://github.com/unfoldingWord-dev/translationCore/pull/179) ([ihoegen](https://github.com/ihoegen))
+
+## [0.1.4](https://github.com/unfoldingWord-dev/translationCore/tree/0.1.4) (2016-10-06)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/0.1.3...0.1.4)
+
+**Closed issues:**
+
+- Create individual repos for packages [\#163](https://github.com/unfoldingWord-dev/translationCore/issues/163)
+
+**Merged pull requests:**
+
+- New sideNavbar and menuViews styling [\#180](https://github.com/unfoldingWord-dev/translationCore/pull/180) ([mannycolon](https://github.com/mannycolon))
+- Implemented new layout design for report view and added filters [\#176](https://github.com/unfoldingWord-dev/translationCore/pull/176) ([mannycolon](https://github.com/mannycolon))
+- Give user the option to refresh if an error occurs [\#169](https://github.com/unfoldingWord-dev/translationCore/pull/169) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Report Views Are Fully Optimized [\#166](https://github.com/unfoldingWord-dev/translationCore/pull/166) ([RoyalSix](https://github.com/RoyalSix))
+- Small bug fix [\#154](https://github.com/unfoldingWord-dev/translationCore/pull/154) ([EvanWiederspan](https://github.com/EvanWiederspan))
+- Drag to select option / api.settings [\#145](https://github.com/unfoldingWord-dev/translationCore/pull/145) ([EllDoubleYew](https://github.com/EllDoubleYew))
+
+## [0.1.3](https://github.com/unfoldingWord-dev/translationCore/tree/0.1.3) (2016-09-22)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/0.1.2...0.1.3)
+
+**Fixed bugs:**
+
+- Reopen a USFM Project [\#114](https://github.com/unfoldingWord-dev/translationCore/issues/114)
+- Save Username/Alias in metadata [\#106](https://github.com/unfoldingWord-dev/translationCore/issues/106)
+
+**Closed issues:**
+
+- As a developer I want to Rename the lexical check and phrase check modules name so that we have a more  persistent and cohesive way to identify them [\#142](https://github.com/unfoldingWord-dev/translationCore/issues/142)
+- Add new translationNotes and translationWords logo/icons [\#141](https://github.com/unfoldingWord-dev/translationCore/issues/141)
+- Implement settings in the api [\#139](https://github.com/unfoldingWord-dev/translationCore/issues/139)
+- Create a 0.1.2 Build [\#138](https://github.com/unfoldingWord-dev/translationCore/issues/138)
+- Refactor target verse selection area to support a drag-to-select-first implementation [\#128](https://github.com/unfoldingWord-dev/translationCore/issues/128)
+- When no project is open show a list of recently opened projects [\#121](https://github.com/unfoldingWord-dev/translationCore/issues/121)
+- When a project is open show a list of check apps [\#120](https://github.com/unfoldingWord-dev/translationCore/issues/120)
+- Implement design for a "Labeled well" system [\#119](https://github.com/unfoldingWord-dev/translationCore/issues/119)
+- Design layout for a "Labeled well" system [\#118](https://github.com/unfoldingWord-dev/translationCore/issues/118)
+- Change the way the store handles status to accommodate a new question for each check [\#117](https://github.com/unfoldingWord-dev/translationCore/issues/117)
+- Implement design for consistent status options in the component view [\#116](https://github.com/unfoldingWord-dev/translationCore/issues/116)
+- Design layout for consistent status options [\#115](https://github.com/unfoldingWord-dev/translationCore/issues/115)
+- Arabic RTL in tN [\#112](https://github.com/unfoldingWord-dev/translationCore/issues/112)
+- Implement drag to select in our target verse display. [\#111](https://github.com/unfoldingWord-dev/translationCore/issues/111)
+- Add setting for drag to select or click to select [\#110](https://github.com/unfoldingWord-dev/translationCore/issues/110)
+- Hide Example check  [\#107](https://github.com/unfoldingWord-dev/translationCore/issues/107)
+- Consistent Status Options [\#104](https://github.com/unfoldingWord-dev/translationCore/issues/104)
+- Ready for Testing Arabic Target Language. [\#100](https://github.com/unfoldingWord-dev/translationCore/issues/100)
+- Project Overview for Readme [\#94](https://github.com/unfoldingWord-dev/translationCore/issues/94)
+- Modify translationNotes parser so that it stores checks in the correct order. [\#91](https://github.com/unfoldingWord-dev/translationCore/issues/91)
+- Don't show the blank white screen [\#85](https://github.com/unfoldingWord-dev/translationCore/issues/85)
+- Headings to label component "wells" [\#83](https://github.com/unfoldingWord-dev/translationCore/issues/83)
+- Improve data parsing for confirmDisplay.js and translationAcademy  [\#82](https://github.com/unfoldingWord-dev/translationCore/issues/82)
+- Display Imported Projects [\#52](https://github.com/unfoldingWord-dev/translationCore/issues/52)
+- Create diagrams for tC architecture and the API abstraction [\#35](https://github.com/unfoldingWord-dev/translationCore/issues/35)
+- App: translationNotes [\#5](https://github.com/unfoldingWord-dev/translationCore/issues/5)
+
+**Merged pull requests:**
+
+- fixed reportview when logged in to door43 account [\#153](https://github.com/unfoldingWord-dev/translationCore/pull/153) ([mannycolon](https://github.com/mannycolon))
+- Added arabic directional support for translationNotes [\#146](https://github.com/unfoldingWord-dev/translationCore/pull/146) ([EllDoubleYew](https://github.com/EllDoubleYew))
+- Refactored/Renamed the lexical check and phrase check modules [\#143](https://github.com/unfoldingWord-dev/translationCore/pull/143) ([mannycolon](https://github.com/mannycolon))
+- Added New modules icons [\#140](https://github.com/unfoldingWord-dev/translationCore/pull/140) ([mannycolon](https://github.com/mannycolon))
+
+## [0.1.2](https://github.com/unfoldingWord-dev/translationCore/tree/0.1.2) (2016-09-19)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.1...0.1.2)
+
+**Implemented enhancements:**
+
+- Dynamic Compilation of Modules [\#39](https://github.com/unfoldingWord-dev/translationCore/issues/39)
+
+**Fixed bugs:**
+
+- ReportViews are not displaying comments for translationWords app and/ or translationNotes app [\#69](https://github.com/unfoldingWord-dev/translationCore/issues/69)
+
+**Closed issues:**
+
+- Cannot Change The Current Check [\#127](https://github.com/unfoldingWord-dev/translationCore/issues/127)
+- Move USFM Import working folder [\#101](https://github.com/unfoldingWord-dev/translationCore/issues/101)
+- Sync ConfirmDisplay.js with current Check in translationNotes [\#81](https://github.com/unfoldingWord-dev/translationCore/issues/81)
+- Make TragetVerseDisplay components change the background color of word/phrase selected to yellow so that the end user have that highlighting experience  [\#79](https://github.com/unfoldingWord-dev/translationCore/issues/79)
+- TranslationNotes: Refine UI/UX [\#78](https://github.com/unfoldingWord-dev/translationCore/issues/78)
+- TranslationNotes: Ensure all data saves and reloads properly [\#77](https://github.com/unfoldingWord-dev/translationCore/issues/77)
+- Fixed translationAcademy so that it displays its content in translationNotes [\#76](https://github.com/unfoldingWord-dev/translationCore/issues/76)
+- USFM Projects Folder [\#75](https://github.com/unfoldingWord-dev/translationCore/issues/75)
+- Create UFW page for tC [\#73](https://github.com/unfoldingWord-dev/translationCore/issues/73)
+- Highlighting words instead of changing the color of words. [\#71](https://github.com/unfoldingWord-dev/translationCore/issues/71)
+- translationNotes menuView is rendering repeated verses for a project [\#70](https://github.com/unfoldingWord-dev/translationCore/issues/70)
+- Make translationNotes display both gateway language and target language for the current verse so that it is more consistent with translationWords [\#68](https://github.com/unfoldingWord-dev/translationCore/issues/68)
+- Integrate commentBox with translationNotes [\#67](https://github.com/unfoldingWord-dev/translationCore/issues/67)
+- Save data for translationNotes and add the ability to retrieve that data when the user re-opens the app [\#66](https://github.com/unfoldingWord-dev/translationCore/issues/66)
+- Generate Reports for translationNotes [\#65](https://github.com/unfoldingWord-dev/translationCore/issues/65)
+- Loading Bar looks unresponsive [\#60](https://github.com/unfoldingWord-dev/translationCore/issues/60)
+- Reports not opening or taking too long. [\#49](https://github.com/unfoldingWord-dev/translationCore/issues/49)
+- Sync Error for own project [\#48](https://github.com/unfoldingWord-dev/translationCore/issues/48)
+- Provide usual ways to quit app [\#47](https://github.com/unfoldingWord-dev/translationCore/issues/47)
+- UI for browsing projects on git.door43.org [\#45](https://github.com/unfoldingWord-dev/translationCore/issues/45)
+- Reopen last project when refreshing and reloading app [\#44](https://github.com/unfoldingWord-dev/translationCore/issues/44)
+- Create Translation Studio Projects for all the books in the Van Dykes Arabic New Testament [\#34](https://github.com/unfoldingWord-dev/translationCore/issues/34)
+- Exporting USFM File \(Book\) [\#30](https://github.com/unfoldingWord-dev/translationCore/issues/30)
+- Open a USFM File \(Book\) as a Project [\#29](https://github.com/unfoldingWord-dev/translationCore/issues/29)
+- USFM Support [\#28](https://github.com/unfoldingWord-dev/translationCore/issues/28)
+- Handling projects with missing chapter numbers \(projects that use chunks\) [\#22](https://github.com/unfoldingWord-dev/translationCore/issues/22)
+- Integrate proposeChanges with TranslationsNotes [\#17](https://github.com/unfoldingWord-dev/translationCore/issues/17)
+- Modify TranslationNotes so that it can mark phrases as wrong / correct  the same way as translationwords  [\#16](https://github.com/unfoldingWord-dev/translationCore/issues/16)
+
+**Merged pull requests:**
+
+- tA data parsing  improvement [\#137](https://github.com/unfoldingWord-dev/translationCore/pull/137) ([mannycolon](https://github.com/mannycolon))
+- translationNotes Parse Fixes [\#136](https://github.com/unfoldingWord-dev/translationCore/pull/136) ([EvanWiederspan](https://github.com/EvanWiederspan))
+- Implement well label design [\#135](https://github.com/unfoldingWord-dev/translationCore/pull/135) ([ihoegen](https://github.com/ihoegen))
+- Added new radio buttons and fix Username/Alias saving in metadata for Reports  [\#133](https://github.com/unfoldingWord-dev/translationCore/pull/133) ([mannycolon](https://github.com/mannycolon))
+- Show check apps if a project is selected [\#132](https://github.com/unfoldingWord-dev/translationCore/pull/132) ([ihoegen](https://github.com/ihoegen))
+- Update README [\#130](https://github.com/unfoldingWord-dev/translationCore/pull/130) ([ihoegen](https://github.com/ihoegen))
+- Display and load recent projects [\#129](https://github.com/unfoldingWord-dev/translationCore/pull/129) ([ihoegen](https://github.com/ihoegen))
+- Hides Example Check Module For Non Developers [\#126](https://github.com/unfoldingWord-dev/translationCore/pull/126) ([RoyalSix](https://github.com/RoyalSix))
+- Fix loading of existing USFM projects [\#125](https://github.com/unfoldingWord-dev/translationCore/pull/125) ([ihoegen](https://github.com/ihoegen))
+- integrated api notification for better user experience [\#124](https://github.com/unfoldingWord-dev/translationCore/pull/124) ([mannycolon](https://github.com/mannycolon))
+- Fix project opening [\#103](https://github.com/unfoldingWord-dev/translationCore/pull/103) ([ihoegen](https://github.com/ihoegen))
+- UI/UX Changes [\#102](https://github.com/unfoldingWord-dev/translationCore/pull/102) ([mannycolon](https://github.com/mannycolon))
+- Speed up opening of reports [\#95](https://github.com/unfoldingWord-dev/translationCore/pull/95) ([ihoegen](https://github.com/ihoegen))
+- Make it so the application doesn't crash if a verse is missing [\#89](https://github.com/unfoldingWord-dev/translationCore/pull/89) ([ihoegen](https://github.com/ihoegen))
+- Project Viewer [\#88](https://github.com/unfoldingWord-dev/translationCore/pull/88) ([ihoegen](https://github.com/ihoegen))
+- fixed minor bug in targetVerseDisplay.js [\#87](https://github.com/unfoldingWord-dev/translationCore/pull/87) ([mannycolon](https://github.com/mannycolon))
+- TranslationNotes  [\#80](https://github.com/unfoldingWord-dev/translationCore/pull/80) ([mannycolon](https://github.com/mannycolon))
+- Better error handling for sync [\#74](https://github.com/unfoldingWord-dev/translationCore/pull/74) ([ihoegen](https://github.com/ihoegen))
+- Bring in USFM Support [\#64](https://github.com/unfoldingWord-dev/translationCore/pull/64) ([ihoegen](https://github.com/ihoegen))
+- Add persistence to translationCore [\#59](https://github.com/unfoldingWord-dev/translationCore/pull/59) ([ihoegen](https://github.com/ihoegen))
+- Fixed report generation in the build [\#56](https://github.com/unfoldingWord-dev/translationCore/pull/56) ([ihoegen](https://github.com/ihoegen))
+- Fix report styling issue on builds [\#55](https://github.com/unfoldingWord-dev/translationCore/pull/55) ([ihoegen](https://github.com/ihoegen))
+- Sort check apps [\#23](https://github.com/unfoldingWord-dev/translationCore/pull/23) ([lancelebanoff](https://github.com/lancelebanoff))
+
+## [v0.1.1](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.1) (2016-08-24)
+[Full Changelog](https://github.com/unfoldingWord-dev/translationCore/compare/v0.1.0...v0.1.1)
+
+**Closed issues:**
+
+- Update all references to .auth to Authorization.json [\#53](https://github.com/unfoldingWord-dev/translationCore/issues/53)
+- Address why an empty authorization file still permits api calls [\#37](https://github.com/unfoldingWord-dev/translationCore/issues/37)
+- Add Greek Morphology for the lexicon popovers [\#36](https://github.com/unfoldingWord-dev/translationCore/issues/36)
+- Support for languages read from right to left [\#32](https://github.com/unfoldingWord-dev/translationCore/issues/32)
+- Move all authentication tokens into a single file.  [\#18](https://github.com/unfoldingWord-dev/translationCore/issues/18)
+-  Centralize the authentication tokens [\#15](https://github.com/unfoldingWord-dev/translationCore/issues/15)
+- Write a guide for app setup for new developers  [\#14](https://github.com/unfoldingWord-dev/translationCore/issues/14)
+- Creating Builds [\#11](https://github.com/unfoldingWord-dev/translationCore/issues/11)
+- Ease of setup for new developers [\#8](https://github.com/unfoldingWord-dev/translationCore/issues/8)
+
+**Merged pull requests:**
+
+- Add parts of speech to greek popovers [\#51](https://github.com/unfoldingWord-dev/translationCore/pull/51) ([ihoegen](https://github.com/ihoegen))
+- Stable Build Branch [\#40](https://github.com/unfoldingWord-dev/translationCore/pull/40) ([ihoegen](https://github.com/ihoegen))
+- Instructions for developers [\#38](https://github.com/unfoldingWord-dev/translationCore/pull/38) ([ihoegen](https://github.com/ihoegen))
+
+## [v0.1.0](https://github.com/unfoldingWord-dev/translationCore/tree/v0.1.0) (2016-08-18)
+**Closed issues:**
+
+- Connect the repo to Reviewable [\#21](https://github.com/unfoldingWord-dev/translationCore/issues/21)
+- Greek Lexicon Popups [\#13](https://github.com/unfoldingWord-dev/translationCore/issues/13)
+- translationNotes: Ensure All Data Saves Properly [\#4](https://github.com/unfoldingWord-dev/translationCore/issues/4)
+- translationNotes: UI/UX refined [\#3](https://github.com/unfoldingWord-dev/translationCore/issues/3)
+- translationNotes: Complete Report View [\#2](https://github.com/unfoldingWord-dev/translationCore/issues/2)
+- translationNotes: Complete Checking Interface [\#1](https://github.com/unfoldingWord-dev/translationCore/issues/1)
+
+**Merged pull requests:**
+
+- Fixed capitalization typos, and used different methods where they were appropriate [\#31](https://github.com/unfoldingWord-dev/translationCore/pull/31) ([therealsamf](https://github.com/therealsamf))
+- Simplified Authentication Process [\#26](https://github.com/unfoldingWord-dev/translationCore/pull/26) ([RoyalSix](https://github.com/RoyalSix))
+- Stops unnecessary TPane re-render [\#20](https://github.com/unfoldingWord-dev/translationCore/pull/20) ([lancelebanoff](https://github.com/lancelebanoff))
+- Js module progress fix [\#19](https://github.com/unfoldingWord-dev/translationCore/pull/19) ([RoyalSix](https://github.com/RoyalSix))
+- Add greek popover [\#12](https://github.com/unfoldingWord-dev/translationCore/pull/12) ([ihoegen](https://github.com/ihoegen))
+- integrated new logo and hover on sidebar buttons [\#10](https://github.com/unfoldingWord-dev/translationCore/pull/10) ([mannycolon](https://github.com/mannycolon))
+- Updating Greek popover [\#9](https://github.com/unfoldingWord-dev/translationCore/pull/9) ([ihoegen](https://github.com/ihoegen))
+- Check Progress Bar [\#7](https://github.com/unfoldingWord-dev/translationCore/pull/7) ([RoyalSix](https://github.com/RoyalSix))
+- Took away the very unnecessary submit button when loading from online [\#6](https://github.com/unfoldingWord-dev/translationCore/pull/6) ([RoyalSix](https://github.com/RoyalSix))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
#### This pull request addresses:

This adds a changelog via https://github.com/skywinder/github-changelog-generator, using this command:

```github_changelog_generator -u unfoldingWord-dev -p translationCore -t YOUR_TOKEN_HERE --exclude-labels 'Task,Reviewed/WontFix,Reviewed/Invalid,Reviewed/Duplicate,Kind/SPIKE' --bug-labels 'Kind/Bug' --enhancement-labels 'Kind/Enhancement'```

@benjore What do you think?  We would rerun this each time before a release so that it correctly lists the information for that release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3292)
<!-- Reviewable:end -->
