### PR TITLE
Fix - #3085 - Hi-res import online problem

### DIFF
--- a/src/js/components/home/projectsManagement/OnlineImportModal/index.js
+++ b/src/js/components/home/projectsManagement/OnlineImportModal/index.js
@@ -65,7 +65,7 @@ export default class OnlineImportModal extends Component {
     return (
       <MuiThemeProvider>
         <Dialog
-          contentStyle={{ minHeight: "550px", height: "550px", width: "900px", maxWidth: "900px" }}
+          contentStyle={{ height: "100%", width: "900px", maxWidth: "900px" }}
           style={{ padding: "0px" }}
           autoDetectWindowHeight={true}
           autoScrollBodyContent={true}


### PR DESCRIPTION
#### This pull request addresses:

Issue #3085 


#### How to test this pull request:

Use a hi-res monitor, go to the Import from Door43 modal, on a high-res when you shrink the window, the buttons in the modal are unreachable (too far at the bottom)

Didn't find an easy way to test this, and was just a small change that needed to make sure the modal container was at a height of 100%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3374)
<!-- Reviewable:end -->
