### PR TITLE
added option to select git for install

### DIFF
--- a/scripts/win_installer.iss
+++ b/scripts/win_installer.iss
@@ -78,8 +78,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
 
 [Files]
-Source: "{#RootPath}vendor\{#GitExecutable}"; DestDir: "{app}\vendor"; Flags: ignoreversion recursesubdirs deleteafterinstall
-Source: "{#RootPath}scripts\git\{#GitInstaller}"; DestDir: "{app}\vendor"; Flags: ignoreversion recursesubdirs deleteafterinstall
+Source: "{#RootPath}vendor\{#GitExecutable}"; DestDir: "{app}\vendor"; Components: git; Flags: ignoreversion recursesubdirs deleteafterinstall
+Source: "{#RootPath}scripts\git\{#GitInstaller}"; DestDir: "{app}\vendor"; Components: git; Flags: ignoreversion recursesubdirs deleteafterinstall
 Source: "{#BuildPath}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
@@ -89,11 +89,29 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: 
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: quicklaunchicon
 
 [Run]
-Filename: "{app}\vendor\{#GitExecutable}"; Parameters: "/SILENT /LOADINF=""{app}\vendor\{#GitInstaller}""";
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: postinstall skipifsilent
+Filename: "{app}\vendor\{#GitExecutable}"; Parameters: "/SILENT /LOADINF=""{app}\vendor\{#GitInstaller}"""; Components: git;
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: postinstall skipifsilent nowait shellexec
 
+[Components]
+Name: "git"; Description: "Install Git"; Types: full
 
 [Code]
+function IsGitInstalled: boolean;
+begin
+  result := False;
+  if RegKeyExists(HKLM, 'SOFTWARE\GitForWindows') then
+  begin
+    result := True;
+  end
+end;
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if CurPageID = wpSelectComponents then
+  begin
+    WizardForm.ComponentsList.Checked[0] := not IsGitInstalled;
+  end;
+end;
 {
 function InitializeSetup(): Boolean;
 var


### PR DESCRIPTION
#### This pull request addresses:

This improves #3269. This fix "should" cause Git to be un-checked for installation if it is already installed, but it doesn't seem to work on my system. However, now users can at least manually choose to not install Git.

> NOTE: on my system it was having trouble reading the Registry Key for WindowsForGit though it could read other keys like Windows just fine. I'm curious to see if this occurs on other system as well.
> If this works completely as expected then the Git component will be un-checked for installation if already installed, otherwise it will be checked.
> For me it's always showing as checked. :(

#### How to test this pull request:

Try installing the windows build.

You can build locally with the following commands:

```
$ npm i
$ gulp build --win
$ gulp release --win
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3392)
<!-- Reviewable:end -->
