### PR TITLE
QA Fix/Change language name search results to be in case insensitive order

### DIFF
--- a/__tests__/LanguageHelpers.test.js
+++ b/__tests__/LanguageHelpers.test.js
@@ -38,10 +38,12 @@ describe('Test LanguageHelpers',()=>{
     for (let i = 1; i < langCount; i++) {
       const langA = languages[i - 1];
       const langB = languages[i];
-      if (!(langA.name <= langB.name)) {
+      const aNameLC = langA.name.toLowerCase();
+      const bNameLC = langB.name.toLowerCase();
+      if (!(aNameLC <= bNameLC)) {
         console.log("Language prompts out of order '" + langA.name + "' and '" + langB.name + "'");
       }
-      expect(langA.name <= langB.name).toBeTruthy();
+      expect(aNameLC <= bNameLC).toBeTruthy();
       if (i === 1) {
         expect(langA.code.length).toBeGreaterThan(0);
         expect(langA.name.length).toBeGreaterThan(0);

--- a/src/js/helpers/LanguageHelpers.js
+++ b/src/js/helpers/LanguageHelpers.js
@@ -45,12 +45,28 @@ export const getLanguagesSortedByName = () => {
 
     // create sorted list by name
     languageListByName = [];
-    for (let name of Object.keys(languageNames).sort()) {
+    for (let name of Object.keys(languageNames)) {
       languageListByName.push(languageNames[name]);
     }
   }
+  languageListByName = sortByNamesCaseInsensitive(languageListByName);
   return languageListByName;
 };
+
+/**
+ * get keys of dictionary sorted with case insensitive sore
+ * @param {dictionary} languageNames
+ * @return {string[]}
+ */
+export const sortByNamesCaseInsensitive = (languageListByName=> {
+  const sorted = languageListByName.sort((a, b) => {
+    const aLC = a.name.toLowerCase();
+    const bLC = b.name.toLowerCase();
+    const retValue = aLC < bLC ? -1 : 1;
+    return retValue;
+  });
+  return sorted;
+});
 
 /**
  * load dictionary with language codes both by localized and english


### PR DESCRIPTION
#### This pull request addresses:

QA fail of issue: https://github.com/unfoldingWord-dev/translationCore/issues/2528

Change language name search results to be in case insensitive order.


#### How to test this pull request:

Go into Projects, and for one of the project cards, click on menu and select 'Edit Project Details'.
For Language Name type in 'fra'.  Should see `français` entry below `Frankish` in drop down menu and not near bottom.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3431)
<!-- Reviewable:end -->
