### PR TITLE
Fixed bug where non-titus projects would not show the correct alert a…

### DIFF
--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -43,7 +43,7 @@ export const localImport = () => {
       await dispatch(ProjectValidationActions.validate(importProjectPath));
       await dispatch(ProjectImportFilesystemActions.move());
       dispatch(MyProjectsActions.getMyProjects());
-      dispatch(ProjectLoadingActions.displayTools());
+      await dispatch(ProjectLoadingActions.displayTools());
     } catch (error) {
       // Catch all errors in nested functions above
       if (error.type !== 'div') console.warn(error);

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -35,7 +35,7 @@ export const onlineImport = () => {
         await dispatch(ProjectValidationActions.validate(importProjectPath));
         await dispatch(ProjectImportFilesystemActions.move());
         dispatch(MyProjectsActions.getMyProjects());
-        dispatch(ProjectLoadingActions.displayTools());
+        await dispatch(ProjectLoadingActions.displayTools());
       } catch (error) {
         // Catch all errors in nested functions above
         if (error.type !== 'div') console.warn(error);


### PR DESCRIPTION
#### This pull request addresses:

- Non-titus projects alert wasn't working after the import refactor


#### How to test this pull request:

- In non-developer mode try to load a non-titus project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3487)
<!-- Reviewable:end -->
