### PR TITLE
Fix #3366/tW crash on projects missing verses

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -41,6 +41,7 @@ function readdirSync(directoryPath) {
 }
 
 function writeFileSync(filePath, data) {
+  addFileToDirectory(filePath);
   mockFS[filePath] = data;
 }
 
@@ -50,15 +51,34 @@ function readFileSync(filePath) {
 }
 
 function outputFileSync(filePath, data) {
+  addFileToDirectory(filePath);
   mockFS[filePath] = data;
 }
 
+function addFileToDirectory(filePath) {
+  const dir = path.dirname(filePath);
+  if (!mockFS[dir]) {
+    mockFS[dir] = [];
+  }
+  const filename = path.basename(filePath);
+  if (mockFS[dir].indexOf(filename) < 0) {
+    mockFS[dir].push(filename);
+  }
+}
+
 function outputJsonSync(filePath, data) {
+  addFileToDirectory(filePath);
   mockFS[filePath] = data;
 }
 
 function readJsonSync(filePath) {
-  return mockFS[filePath];
+  if(!existsSync(filePath)) {
+    throw "File could not be read: " + filePath;
+  }
+  const data = mockFS[filePath];
+  // clone data so changes to object do not affect object in file system
+  const clonedData = JSON.parse(typeof data === 'string' ? data : JSON.stringify(data));
+  return clonedData;
 }
 
 function existsSync(path) {

--- a/__tests__/MissingVerseActions.test.js
+++ b/__tests__/MissingVerseActions.test.js
@@ -1,0 +1,91 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const importProjectName = 'gal_hsl';
+const IMPORTS_PATH = path.join(path.homedir(), 'translationCore', 'imports');
+import path from 'path-extra';
+import fs from "fs-extra";
+import * as MissingVersesActions from "../src/js/actions/MissingVersesActions";
+import * as MissingVersesHelpers from "../src/js/helpers/ProjectValidation/MissingVersesHelpers";
+const USER_RESOURCES_DIR = path.join(path.homedir(), 'translationCore/resources');
+jest.mock('fs-extra');
+jest.mock('../src/js/actions/ProjectImportStepperActions', () => ({
+  removeProjectValidationStep: () => {
+    return ((dispatch, getState) => {});
+  },
+  updateStepperIndex: () => {
+    return ((dispatch, getState) => {});
+  }
+}));
+
+
+describe('MissingVersesActions.onlineImport()', () => {
+  let ch4_json, ch5_json, manifest_json, initialState;
+  const bookName = 'gal';
+  const importProjectPath = path.join(IMPORTS_PATH, importProjectName);
+  const importBookPath = path.join(importProjectPath, bookName);
+  const bibleIndexLocation = path.join(USER_RESOURCES_DIR, 'en', 'bibles', 'ulb', 'v11', 'index.json');
+  const index_json = require('./fixtures/resources/en/bibles/ulb/v11/index.json');
+
+  beforeEach(() => {
+    ch4_json = {"1":":-("};
+    ch5_json = {"1":"Ai domin mu dawama ƴanttatu ne Almasihu ya ƴantadda mu. Kenan ku tsaya da kyau, kada ku sanya kanku ƙarƙashi ƙangin bauta.","2":"Ni Bulus ina gaya maku: dukan wanda ya amince aka yi masa kaciya, to Almasihu baya zama da anfani gare sa ba.","3":"Ina nanatawa cewa dukan wanda ya amince aka yi masa kaciya, to ya zamar masa wajibi ya kiyaye dukan shari'a.","4":"Dukan ku da kuke neman barataswa ta hanyar kaciya, ba ku da sauran taraya da Almasihu, kun wofinta alherin Almasihu.","5":"A cikin Ruhu ta hanyar bangaskiya mu ke da begen barataswa da kayi alkawali.","6":"Cikin Almasihu ba kaciya ko rashin kaciya ne keda mahimanci ba amma rayuwar bangaskiya ta hanyar ƙauna.","7":"Kun fara da kyau, wa ya sa kuka dena rayuwar cikin gaskiya?","8":"Wanan ra'ayi dai ba daga wanda ya kira ku bane.","9":"Ai yisti kaɗan ya isa ya tada curin gurasa.","10":"Na yi imanin da ba za ku cigaba da irin wanan rayuwa ba. Amma shi wanda ke rikitadda ku zaya karɓi sakamakon ɓanar sa, ko wanene shi.","11":"Ƴanuwa, in har yanzu ina goyonbayan kaciya, ina dalilin da ya sa ake tsanatamani? Kena kokowar da giciyen Almasihu ke sawa a cikina ta zama a wofi.","12":"Su masu tada hankalinku, ina fatan su maida kansu babani.","13":"Gama ƴan uwa Allah ya kira mu zuwa ga ƴanci, amma kadda ƴancin ku ya kasance ƙofar lalata, maimakon haka ku bauta wa juna a cikin ƙauna.","14":"Gama dukan shari'a tana dunƙule a cikin wanan dokar: <<ka ƙaunaci maƙaubcin ka kamar kankan>>.","15":"Amma idan kuna cakunan juna, kuna kuwa cin juna, ku yi hankali kada ku hallaka juna.","16":"Ku yi tafiya cikin ruhu, ta haka ba zaku aikata halin mutuntaka ba,","17":"gama halin mutuntataka yana gaba da na ruhu, haka ma ayukan ruhu suna gaba da aykan jiki. Su duka biyu suna adawa da juna, har ma ku rasa sanin abinda ku ke buƙata.","18":"Amma idan Ruhu ne ke bishe ku, to baku ƙalƙashi shari'a.","19":"Ai ayukan jiki a sarari suke, sune : fasiƙanci, lalata, sha'aw,","20":"bautar gumaka, sihiri, gaba, jayaya, kishi, fushi, hamanya, tsatsagu,","21":"hasada, kwaɗayi, buguwa, shashanci da kuma sauran abubuwa irin su, Ina faɗa maku kamar yadda na rigaya na faɗa maku, dukan masu aikata irin wanan rayuwa, basu da rabo a cikin mulkin Allah..","22":"Amma ƴaƴan Ruhu Ƙauna ce, farinciciki, salama, hankuri, kirki, nagarta, bangaskiya,","23":"nasiha, kamunkai; shari'a bata gaba da irin waɗanan halayan.","24":"Amma su wanɗanda ke na Almasihu Yesu sun giciye jiki da mugayen halayen sa.","25":"kada mu yi fahariya, kada mu cakuni juna, kaka mu yi ƙyashin juna.","26":"Idan cikin Ruhu mu ke rayuwa, to bari mu yi tafiya a cikin Ruhu,"};
+    manifest_json = {"generator":{"build":108,"name":"ts-android"},"target_language":{"direction":"ltr","id":"hsl","name":"Hausa Sign Language"},"project":{"id":"gal","name":"Galatians"},"source_translations":{"checking_level":3,"date_modified":20151120,"version":"2.0.0-beta15","language_id":"en","resource_id":"udb"},"checkers":[],"time_created":"2017-12-21T19:07:03.828Z","tools":[],"repo":"","tcInitialized":true,"finished_frames":["05-01","05-05","05-09","05-11","05-16","05-19","05-25","05-22","05-03","05-13"],"package_version":3,"project_id":"gal","finished_chunks":["05-01","05-05","05-09","05-11","05-16","05-19","05-25","05-22","05-03","05-13"],"tc_version":1,"license":"CC BY-SA 4.0"};
+
+    // reset mock filesystem data
+    fs.__resetMockFS();
+    // Set up mocked out filePath and data in mock filesystem before each test
+    fs.__setMockFS({
+      [bibleIndexLocation]: index_json,
+      [importProjectPath]: ['manifest.json'],
+      [path.join(importProjectPath, 'manifest.json')]: manifest_json,
+      [importBookPath]: ['4.json','5.json', 'manifest.json'],
+      [path.join(importBookPath, 'manifest.json')]: manifest_json,
+      [path.join(importBookPath, '4.json')]: ch4_json,
+      [path.join(importBookPath, '5.json')]: ch5_json
+    });
+
+    initialState = {
+      projectDetailsReducer: {
+        projectSaveLocation: importProjectPath,
+        manifest: manifest_json
+      }
+    };
+  });
+
+  it('on import error, should delete project', async () => {
+    // given
+    const store = mockStore(initialState);
+
+    // when
+    await store.dispatch(MissingVersesActions.finalize());
+
+    // then
+    validateVersesInBible(bookName, importBookPath);
+  });
+});
+
+//
+// helpers
+//
+
+function validateVersesInBible(bookName, importBookPath) {
+  const expectedBookVerses = MissingVersesHelpers.getExpectedBookVerses(bookName);
+  const chapters = parseInt(expectedBookVerses["chapters"], 10);
+  for (let chapter = 1; chapter <= chapters; chapter++) {
+    const chapterPath = path.join(importBookPath, chapter + '.json');
+    expect(fs.existsSync(chapterPath)).toBeTruthy();
+    const chapterJson = fs.readJSONSync(chapterPath);
+    const verses = parseInt(expectedBookVerses[chapter.toString()]);
+    for (let verseNum = 1; verseNum <= verses; verseNum++) {
+      const verse = chapterJson[verseNum];
+      const verseDefined = !!verse || (verse === '');
+      if (!verseDefined) {
+        console.log("Chapter " + chapter + ", verse " + verseNum + " not defined");
+        expect(verseDefined).toBeTruthy();
+      }
+    }
+  }
+}
+

--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -80,9 +80,10 @@ describe('UsfmFileConversionHelpers', () => {
     const manifestPath = path.join(IMPORTS_PATH, 'project_folder_name', 'manifest.json');
 
     expect.assertions(2);
-    await expect(
-      UsfmFileConversionHelpers.generateManifestForUsfm(validUsfmString, usfmFilePath, 'project_folder_name')
-    ).resolves.toEqual(fs.readJsonSync(manifestPath));
+    const results = await UsfmFileConversionHelpers.generateManifestForUsfm(validUsfmString, usfmFilePath, 'project_folder_name');
+    // normalize JSONs since dates in manifest are converted to strings.
+    const normalized = JSON.parse(JSON.stringify(results));
+    expect(normalized).toEqual(fs.readJsonSync(manifestPath));
     expect(fs.existsSync(manifestPath)).toBeTruthy();
   });
 


### PR DESCRIPTION
#### This pull request addresses:

Issue: https://github.com/unfoldingWord-dev/translationCore/issues/3366

On Import missing verses are inserted into chapter jsons as empty strings so we don't get null exceptions.

#### How to test this pull request:

import online project from https://git.door43.org/168b7e635905dd89/uw-gal-hsl

Open tW and should see not see empty panel.

#### Note:  coverage is down because duplicated code was removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3489)
<!-- Reviewable:end -->
