### PR TITLE
Allow all New Testament books in non-developer mode for 0.8.1 limited release 

### DIFF
--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -63,7 +63,7 @@ export function displayTools() {
           dispatch(BodyUIActions.goToStep(3));
         } else {
           dispatch(RecentProjectsActions.getProjectsFromFolder());
-          reject('This version of translationCore only supports Titus projects.');
+          reject('This version of translationCore only supports New Testament Projects.');
         }
       } catch (error) {
         console.error(error);

--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -10,7 +10,7 @@ import * as AlertModalActions from '../AlertModalActions';
 import * as ProjectDetailsActions from '../ProjectDetailsActions';
 import * as ProjectImportStepperActions from '../ProjectImportStepperActions';
 //helpers
-import * as manifestHelpers from '../../helpers/manifestHelpers';
+import * as bibleHelpers from '../../helpers/bibleHelpers';
 // constants
 const PROJECTS_PATH = path.join(path.homedir(), 'translationCore', 'projects');
 
@@ -49,16 +49,15 @@ export const migrateValidateLoadProject = (selectedProjectFilename) => {
 };
 
 /**
- * @description - Opening the tools screen upon making sure the project is
- * not a titus or in the user is in developer
+ * @description - Opening the tools screen upon making sure the
+ * project is not a titus or in the user is in developer.
  */
 export function displayTools() {
   return ((dispatch, getState) => {
     return new Promise ((resolve, reject) => {
       try {
-        const { currentSettings } = getState().settingsReducer;
         const { manifest } = getState().projectDetailsReducer;
-        if (manifestHelpers.checkIfValidBetaProject(manifest) || currentSettings.developerMode) {
+        if (bibleHelpers.isNewTestamentBook(manifest.project.id)) {
           dispatch(ToolsMetadataActions.getToolsMetadatas());
           // Go to toolsCards page
           dispatch(BodyUIActions.goToStep(3));
@@ -75,13 +74,13 @@ export function displayTools() {
 }
 
 /**
- * @description - Wrapper to clear everything in the store that could
- * prevent a new project from loading
+ * @description - Wrapper to clear everything in the store that
+ * could prevent a new project from loading.
  */
 export function clearLastProject() {
   return ((dispatch) => {
     /**
-     * ATTENTION: THE project details reducer must be reset
+     * ATTENTION: The project details reducer must be reset
      * before any other action being called to avoid
      * autosaving messing up with the project data.
      */

--- a/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import React from 'react';
 //helpers
 import * as usfmHelpers from '../usfmHelpers';
+import * as bibleHelpers from '../../helpers/bibleHelpers';
 //static
 import books from '../../../../tC_resources/resources/books';
 
@@ -188,10 +189,8 @@ export function isUSFMProject(projectPath) {
 
 export function verifyValidBetaProject(state) {
   return new Promise((resolve, reject) => {
-    let { currentSettings } = state.settingsReducer;
     let { manifest } = state.projectDetailsReducer;
-    if (currentSettings && currentSettings.developerMode) return resolve();
-    else if (manifest && manifest.project && manifest.project.id === "tit") return resolve();
+    if (manifest && manifest.project && bibleHelpers.isNewTestamentBook(manifest.project.id)) return resolve();
     else return reject('This version of translationCore only supports Titus projects.');
   });
 }

--- a/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
@@ -191,6 +191,6 @@ export function verifyValidBetaProject(state) {
   return new Promise((resolve, reject) => {
     let { manifest } = state.projectDetailsReducer;
     if (manifest && manifest.project && bibleHelpers.isNewTestamentBook(manifest.project.id)) return resolve();
-    else return reject('This version of translationCore only supports Titus projects.');
+    else return reject('This version of translationCore only supports New Testament Projects.');
   });
 }

--- a/src/js/helpers/bibleHelpers.js
+++ b/src/js/helpers/bibleHelpers.js
@@ -2,6 +2,16 @@
 import Path from 'path-extra';
 import fs from 'fs-extra';
 import BooksOfBible from '../../../tC_resources/resources/books';
+import BooksOfTheBible from '../common/BooksOfTheBible';
+
+/**
+ * returns true if the book id is a new testament and false if not.
+ * @param {String} bibleId - book abbreviation.
+ * @returns {bool}
+ */
+export const isNewTestamentBook = (bibleId) => {
+  return BooksOfTheBible.newTestament[bibleId] ? true : false;
+};
 
 /**
  *


### PR DESCRIPTION
#### This pull request addresses:
- Allow all New Testament books in non-developer mode for 0.8.1 limited release 


#### How to test this pull request:

- Try to load non-titus projects in developer mode and in non-developer mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3490)
<!-- Reviewable:end -->
