### PR TITLE
Only showing cancel import process alert when going through project validation

### DIFF
--- a/__tests__/ProjectImportStepperActions.test.js
+++ b/__tests__/ProjectImportStepperActions.test.js
@@ -1,12 +1,15 @@
 /* eslint-env jest */
 import React from 'react';
-import * as ProjectImportStepperActions from '../src/js/actions/ProjectImportStepperActions';
-import consts from '../src/js/actions/ActionTypes';
+import path from 'path-extra';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import consts from '../src/js/actions/ActionTypes';
+import * as ProjectImportStepperActions from '../src/js/actions/ProjectImportStepperActions';
 // Mock store set up
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+// constants
+const PROJECTS_PATH = path.join(path.homedir(), 'translationCore', 'projects');
 const PROJECT_INFORMATION_CHECK_NAMESPACE = 'projectInformationCheck';
 const MISSING_VERSES_NAMESPACE = 'missingVersesCheck';
 jest.mock('../src/js/actions/TargetLanguageActions', () => ({
@@ -141,19 +144,21 @@ describe('ProjectImportStepperActions.removeProjectValidationStep', () => {
 });
 
 describe('ProjectImportStepperActions.confirmContinueOrCancelImportValidation', () => {
-  it('should cancel the import stepper process', () => {
+  test('should cancel the import stepper process', () => {
     const expectedActions = [
       {
         type: 'OPEN_OPTION_DIALOG',
-        alertMessage: 'Canceling now will abort the import process and the project\n         will need to be reimported before it can be used.',
+        alertMessage: `Canceling now will abort the import process and the project will need to be reimported before it can be used.`,
         callback: expect.any(Function),
         button1Text: 'Continue Import',
         button2Text: 'Cancel Import'
       }
     ];
-    let store = mockStore({});
-    var ProjectImportStepperActions = require('../src/js/actions/ProjectImportStepperActions');
-    ProjectImportStepperActions.cancelProjectValidationStepper = jest.fn();
+    const store = mockStore({
+      projectDetailsReducer: {
+        projectSaveLocation: ''
+      }
+    });
     store.dispatch(ProjectImportStepperActions.confirmContinueOrCancelImportValidation());
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -1,3 +1,4 @@
+import path from 'path-extra';
 import consts from './ActionTypes';
 // actions
 import * as ProjectLoadingActions from './MyProjects/ProjectLoadingActions';
@@ -176,25 +177,31 @@ export function cancelProjectValidationStepper() {
  * and different actions are dispatches based on user response.
  */
 export const confirmContinueOrCancelImportValidation = () => {
-  return((dispatch) => {
-    dispatch(
-      AlertModalActions.openOptionDialog(
-        `Canceling now will abort the import process and the project
-         will need to be reimported before it can be used.`,
-         (result) => {
-          if (result === 'Cancel Import') {
-            // if 'cancel import' then close
-            // alert and cancel import process.
-            dispatch(AlertModalActions.closeAlertDialog());
-            dispatch(cancelProjectValidationStepper());
-          } else {
-            // if 'Continue Import' then just close alert
-            dispatch(AlertModalActions.closeAlertDialog());
-          }
-        },
-        'Continue Import',
-        'Cancel Import'
-      )
-    );
+  return((dispatch, getState) => {
+    const { projectSaveLocation } = getState().projectDetailsReducer;
+    const isInProjectsFolder = projectSaveLocation.includes(path.join('translationCore', 'projects'));
+
+    if (isInProjectsFolder) {
+      dispatch(cancelProjectValidationStepper());
+    } else {
+      dispatch(
+        AlertModalActions.openOptionDialog(
+          `Canceling now will abort the import process and the project will need to be reimported before it can be used.`,
+           (result) => {
+            if (result === 'Cancel Import') {
+              // if 'cancel import' then close
+              // alert and cancel import process.
+              dispatch(AlertModalActions.closeAlertDialog());
+              dispatch(cancelProjectValidationStepper());
+            } else {
+              // if 'Continue Import' then just close alert
+              dispatch(AlertModalActions.closeAlertDialog());
+            }
+          },
+          'Continue Import',
+          'Cancel Import'
+        )
+      );
+    }
   });
 };


### PR DESCRIPTION
#### This pull request addresses:
- Only showing cancel import process alert when going through project validation

#### How to test this pull request:
- Load a project from local or online and when the validation stepper opens cancel it and an alert should open. 

- Load a project from `my projects list` and click cancel in the project validation stepper and no alert should open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3491)
<!-- Reviewable:end -->
