### PR TITLE
removed tW from displaying as an option in the release

### DIFF
--- a/src/js/actions/ToolsMetadataActions.js
+++ b/src/js/actions/ToolsMetadataActions.js
@@ -3,7 +3,7 @@ import path from 'path-extra';
 import fs from 'fs-extra';
 // constant declarations
 const PACKAGE_SUBMODULE_LOCATION = path.join(__dirname, '../../../tC_apps');
-const TOOLS_TO_SHOW = ['wordAlignment', 'translationWords'];
+const TOOLS_TO_SHOW = ['wordAlignment'];
 
 export function getToolsMetadatas() {
   return ((dispatch) => {


### PR DESCRIPTION
#### This pull request addresses:

Removes tW from the tools list 


#### How to test this pull request:

Select a project, and make sure only Word Alignment tool shows up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3500)
<!-- Reviewable:end -->
