### PR TITLE
Fixed bug with words being generated in the `wordbank` when there's actually missing verse

### DIFF
--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -33,16 +33,30 @@ export const loadAlignmentData = () => {
       },
       contextIdReducer: {
         contextId: {
-          reference: { bookId, chapter }
+          reference: { bookId, chapter, verse }
+        }
+      },
+      resourcesReducer: {
+        bibles: {
+          targetLanguage
         }
       }
     } = getState();
+
+
     let _alignmentData = JSON.parse(JSON.stringify(alignmentData));
     const alignmentDataPath = path.join('.apps', 'translationCore', 'alignmentData');
     const filePath = path.join(alignmentDataPath, bookId, chapter + '.json');
     const loadPath = path.join(projectSaveLocation, filePath);
-    if (fs.existsSync(loadPath)) {
-      const chapterData = fs.readJsonSync(loadPath);
+    const chapterData = fs.readJsonSync(loadPath);
+
+    /* Check if the number of words in the current generated alignmentData
+     * chapter verse is the same as the current targetLanguage chapter verse.
+     * If it is the are different then regenerate wordbank for current verse/check.
+     */
+    if (chapterData[verse].wordBank.length !== targetLanguage[chapter][verse].split(' ').length) {
+      dispatch(populateEmptyChapterAlignmentData());
+    } else if (fs.existsSync(loadPath)) {
       _alignmentData[chapter] = chapterData;
       dispatch(updateAlignmentData(_alignmentData));
     } else {


### PR DESCRIPTION
#### This pull request addresses:

- Fixed bug with word being generated in the `wordbank` when the verse is actually missing


#### How to test this pull request:

- Load [en_tit.zip](https://github.com/unfoldingWord-dev/translationCore/files/1443575/en_tit.zip) and make sure that both missing verses **Titus 1:3** and **Titus 1:14** don't have words in the **wordbank** or in the word bank area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3526)
<!-- Reviewable:end -->
