### PR TITLE
Fix - #3236 - Corrected error message if manifest doesn't exist

### DIFF
--- a/__tests__/ManifestValidationHelpers.test.js
+++ b/__tests__/ManifestValidationHelpers.test.js
@@ -4,19 +4,21 @@
 
 jest.mock('fs-extra');
 import fs from 'fs-extra';
+import path from 'path';
 //helpers
 import * as ManifestValidationHelpers from '../src/js/helpers/ProjectValidation/ManifestValidationHelpers';
-const MANIFEST_EXISTS_PATH = 'path/to/project/where/manifest/exists';
-const MANIFEST_NOT_EXISTS_PATH = 'path/to/project/where/manifest/doesnt/exists';
+const MANIFEST_EXISTS_PATH = path.join('path', 'to', 'project', 'where', 'manifest', 'exists');
+const MANIFEST_NOT_EXISTS_PATH = path.join('path', 'to', 'project', 'where', 'manifest', 'doesnt', 'exists');
 beforeEach(() => {
   fs.__setMockFS({
     [MANIFEST_EXISTS_PATH]: [],
-    [MANIFEST_EXISTS_PATH + '/manifest.json']: []
+    [path.join(MANIFEST_EXISTS_PATH, 'manifest.json')]: []
   });
 });
 
 describe('ManifestValidationHelpers.manifestExists', () => {
   test('should return that the manifest exists', async () => {
+    console.log(MANIFEST_EXISTS_PATH);
     let result = await ManifestValidationHelpers.manifestExists(MANIFEST_EXISTS_PATH);
     expect(result).toBeTruthy();
   });
@@ -25,7 +27,7 @@ describe('ManifestValidationHelpers.manifestExists', () => {
       await ManifestValidationHelpers.manifestExists(MANIFEST_NOT_EXISTS_PATH);
     }
     catch (e) {
-      expect(e).toBe('Manifest does not exist.');
+      expect(e).toBe('Unable to find the manifest for project '+path.basename(MANIFEST_NOT_EXISTS_PATH)+'. It will not be loaded.');
     }
   });
 });

--- a/src/js/helpers/ProjectValidation/ManifestValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ManifestValidationHelpers.js
@@ -9,7 +9,7 @@ export function manifestExists(projectPath) {
   return new Promise((resolve, reject) => {
     let exists = fs.existsSync(path.join(projectPath, 'manifest.json'));
     if (exists) resolve(true);
-    else reject('Manifest does not exist.');
+    else reject('Unable to find the manifest for project '+path.basename(projectPath)+'. It will not be loaded.');
   });
 }
 


### PR DESCRIPTION
#### This pull request addresses:

QA Fail that the error message for #3236 was too vague/unhelpful. Now reads as https://github.com/unfoldingWord-dev/translationCore/issues/3236#issuecomment-352130910 specifies.

#### How to test this pull request:

Import a Door43 project that doesn't have a manifest file. The message should be correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3536)
<!-- Reviewable:end -->
