### PR TITLE
Bugfix #3432/USFM import allows MP3 and PDF content.

### DIFF
--- a/__tests__/usfmHelpers.test.js
+++ b/__tests__/usfmHelpers.test.js
@@ -116,7 +116,7 @@ describe('USFM Details', () => {
 
     expect(usfm[2][5]).toBeUndefined();
     expect(usfm[2][6]).toBeUndefined();
-    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,']);
+    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,', "of those in heaven and on earth and under the earth."]);
     expect(30 - Object.keys(usfm[2]).length).toEqual(2);
 
     expect(usfm[3][5]).toBeUndefined();
@@ -145,7 +145,7 @@ describe('USFM Details', () => {
 
     expect(usfm[2]).not.toBeUndefined();
     expect(Object.keys(usfm[2])).toHaveLength(30);
-    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,']);
+    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,', "of those in heaven and on earth and under the earth."]);
 
     expect(usfm[3]).not.toBeUndefined();
     expect(Object.keys(usfm[3])).toHaveLength(21);
@@ -195,7 +195,7 @@ describe('USFM Details', () => {
 
     expect(usfm[2]).not.toBeUndefined();
     expect(Object.keys(usfm[2])).toHaveLength(30);
-    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,']);
+    expect(usfm[2][10]).toEqual(['So at the name of Jesus every knee should bow,', "of those in heaven and on earth and under the earth."]);
 
     expect(usfm[3]).not.toBeUndefined();
     expect(Object.keys(usfm[3])).toHaveLength(21);

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -45,12 +45,13 @@ export const localImport = () => {
       dispatch(MyProjectsActions.getMyProjects());
       await dispatch(ProjectLoadingActions.displayTools());
     } catch (error) {
+      const errorMessage = error || "Import Error!"; // default warning if exception is not set
       // Catch all errors in nested functions above
-      if (error.type !== 'div') console.warn(error);
+      if ( error && (error.type !== 'div')) console.warn(error);
       // clear last project must be called before any other action.
       // to avoid troggering autosaving.
       dispatch(ProjectLoadingActions.clearLastProject());
-      dispatch(AlertModalActions.openAlertDialog(error));
+      dispatch(AlertModalActions.openAlertDialog(errorMessage));
       dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
       // remove failed project import
       dispatch(ProjectImportFilesystemActions.deleteProjectFromImportsFolder());

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -25,15 +25,16 @@ export const convertToProjectFormat = async (sourceProjectPath, selectedProjectF
 export const verifyIsValidUsfmFile = async (sourceProjectPath) => {
   return new Promise ((resolve, reject) => {
     const usfmData = usfmHelpers.loadUSFMFile(path.join(sourceProjectPath));
-    if (usfmData.includes('\\h') || usfmData.includes('\\id') || usfmData.includes('\\v'))
+    if (usfmData.includes('\\h ') || usfmData.includes('\\id ')) { // moved verse checking to generateTargetLanguageBibleFromUsfm
       resolve(usfmData);
-    else
+    } else {
       reject(
         <div>
-          The project you selected ({sourceProjectPath}) is an invalid usfm project. <br />
+          The project you selected ({sourceProjectPath}) is an invalid usfm project. <br/>
           Please verify the project you selected is a valid usfm file.
         </div>
       );
+    }
   });
 };
 
@@ -86,16 +87,31 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
     try {
       const chaptersObject = usfmjs.toJSON(usfmData).chapters;
       const bibleDataFolderName = manifest.project.id || selectedProjectFilename;
+      let verseFound = false;
       Object.keys(chaptersObject).forEach((chapter) => {
         const bibleChapter = {};
         Object.keys(chaptersObject[chapter]).forEach((verse) => {
           const verseParts = chaptersObject[chapter][verse];
           bibleChapter[verse] = verseParts.join(' ');
+          verseFound = true;
         });
         const filename = parseInt(chapter, 10) + '.json';
         const projectBibleDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, filename);
         fs.outputJsonSync(projectBibleDataPath, bibleChapter);
       });
+      if (!verseFound) {
+        reject(
+          <div>
+            {
+              selectedProjectFilename ?
+                `No chapter & verse found in project (${selectedProjectFilename}).`
+                :
+                `No chapter & verse found in your project.`
+            }
+          </div>
+        );
+        return;
+      }
       // generating and saving manifest for target language for scripture pane to use as reference
       const targetLanguageManifest = {
         language_id: manifest.target_language.id || "",
@@ -111,7 +127,7 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
       resolve();
     } catch (error) {
       console.log(error);
-      reject();
+      reject(error);
     }
   });
 };


### PR DESCRIPTION
#### This pull request addresses:

Improves validation of file content on USFM import.  Header and id USFM tags now check for space after.  Better chapter & verse validation.

#### How to test this pull request:

Try importing file in https://github.com/unfoldingWord-dev/translationCore/issues/3432.

Should get an error that files cannot be imported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3544)
<!-- Reviewable:end -->
