### PR TITLE
BugFix #3543/Problems in Word Alignment when there are quote marks in the BHP

### DIFF
--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -63,6 +63,22 @@ export const loadBiblesChapter = (contextId) => {
           let fileName = chapter + '.json';
           if(fs.existsSync(path.join(bibleVersionPath, bookId, fileName))) {
             let bibleChapterData = fs.readJsonSync(path.join(bibleVersionPath, bookId, fileName));
+
+            if(bibleID === 'bhp') { // cleanup punctuation in greek
+              for (let verseNum of Object.keys(bibleChapterData)) {
+                const verse = bibleChapterData[verseNum];
+                if (typeof verse !== 'string') {
+                  let newVerse = [];
+                  for (let word of verse) {
+                    if (word && typeof word !== 'string') { // strip out punctuation
+                      newVerse.push(word);
+                    }
+                  }
+                  bibleChapterData[verseNum] = newVerse;
+                }
+              }
+            }
+
             bibleData[chapter] = bibleChapterData;
             // get bibles manifest file
             let bibleManifest = ResourcesHelpers.getBibleManifest(bibleVersionPath, bibleID);


### PR DESCRIPTION
#### This pull request addresses:

Had problem with determining the word number when BHP had punctuation.  Each punctuation would throw the word count off by one.  This fixes the issue by cleaning the greek word list when loaded into the app.


#### How to test this pull request:

Import a Hebrew USFM project.  Then open word alignment tool.  go to verse 1:5 and should be able to join and disconnect greek words.

hebrew project can be found in Problems in #3561 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3561)
<!-- Reviewable:end -->
