### PR TITLE
added v prefix to release branches

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,13 +40,19 @@ gulp.task('set_mode', () => {
 
   if(process.env.TRAVIS_TAG) {
     console.log('Tag mode');
+    if(!process.env.TRAVIS_TAG.startsWith('v')) {
+      throw new Error(`The tag must be prefixed with a "v".`);
+    }
     if(process.env.TRAVIS_TAG !== `v${p.version}`) {
       throw new Error(`The package version does not match the tag name. Expected ${process.env.TRAVIS_TAG} but found ${p.version}`);
     }
   } else if(process.env.TRAVIS_BRANCH && process.env.TRAVIS_BRANCH.startsWith('release-')) {
     console.log('Release mode');
     let branchVersion = process.env.TRAVIS_BRANCH.replace(/^release-/, '');
-    if(branchVersion !== p.version) {
+    if(!branchVersion.startsWith('v')) {
+      throw new Error(`The release branch version must be prefixed with a "v".`);
+    }
+    if(branchVersion !== `v${p.version}`) {
       throw new Error(`The package version does not match the release branch version. Expected ${branchVersion} but found ${p.version}`);
     }
   } else {


### PR DESCRIPTION
#### This pull request addresses:

Fixes #3653.

This adds some final tweaks to the builds for consistency.
A `v` is now required when creating release branches. e.g. `release-v0.8.1` instead of just `release-0.8.1`.

#### How to test this pull request:

To test this you must
1. create a new test branch from this branch.
2. change the version string to some test value e.g. `0.9.9999`
3. create the proper tag then push it and the test branch to this repo.

The release should be built correctly and visible at http://tc-release.unfoldingword.surge.sh/.
After you are done delete the tag and test branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3652)
<!-- Reviewable:end -->
