### PR TITLE
Fixed bug that caused multiple copies of React being loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -445,7 +445,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000791",
+        "caniuse-db": "1.0.30000795",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -458,8 +458,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000791",
-            "electron-to-chromium": "1.3.30"
+            "caniuse-db": "1.0.30000795",
+            "electron-to-chromium": "1.3.31"
           }
         }
       }
@@ -1149,9 +1149,9 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.1",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -1444,12 +1444,12 @@
       }
     },
     "browserslist": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.1.tgz",
-      "integrity": "sha512-Gp4oJOQOby5TpOJJuUtCrGE0KSJOUYVa/I+/3eD/TRWEK8jqZuJPAK1t+VuG6jp0keudrqtxlH4MbYbmylun9g==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000791",
-        "electron-to-chromium": "1.3.30"
+        "caniuse-lite": "1.0.30000792",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "bser": {
@@ -1553,7 +1553,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000791",
+        "caniuse-db": "1.0.30000795",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1564,22 +1564,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000791",
-            "electron-to-chromium": "1.3.30"
+            "caniuse-db": "1.0.30000795",
+            "electron-to-chromium": "1.3.31"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000791",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000791.tgz",
-      "integrity": "sha1-Bnh/VsrvQwChfjXRN0RxI731Nvk=",
+      "version": "1.0.30000795",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000795.tgz",
+      "integrity": "sha1-ZE8D+rAN2L0Wk+Xh5w2Gsxxc/s4=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000791.tgz",
-      "integrity": "sha1-jjV0Xv1IOj4ju301CZAybSMZ/BY="
+      "version": "1.0.30000792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1685,9 +1685,9 @@
       "dev": true
     },
     "circular-json-es6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/circular-json-es6/-/circular-json-es6-2.0.1.tgz",
-      "integrity": "sha1-yfTjffdKZVztckXTECC/W1zTTvY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/circular-json-es6/-/circular-json-es6-2.0.2.tgz",
+      "integrity": "sha512-ODYONMMNb3p658Zv+Pp+/XPa5s6q7afhz3Tzyvo+VRh9WIrJ64J76ZC4GQxnlye/NesTn09jvOiuE8+xxfpwhQ==",
       "dev": true
     },
     "clap": {
@@ -2301,7 +2301,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "dashdash": {
@@ -2843,7 +2843,7 @@
         "resolve": "1.5.0",
         "rimraf": "2.6.2",
         "sass-lookup": "1.1.0",
-        "sass.js": "0.10.7",
+        "sass.js": "0.10.8",
         "sorcery": "0.10.0",
         "stylus": "0.54.5",
         "stylus-lookup": "1.0.2",
@@ -2859,7 +2859,7 @@
         "7zip": "0.0.6",
         "cross-unzip": "0.0.2",
         "rimraf": "2.6.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "electron-download": {
@@ -2874,8 +2874,8 @@
         "minimist": "1.2.0",
         "nugget": "2.0.1",
         "path-exists": "2.1.0",
-        "rc": "1.2.3",
-        "semver": "5.4.1",
+        "rc": "1.2.4",
+        "semver": "5.5.0",
         "sumchecker": "1.3.1"
       },
       "dependencies": {
@@ -2919,9 +2919,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz",
-      "integrity": "sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.8.tgz",
+      "integrity": "sha1-8Ln63e2eHlTsNfqJh3tcbDTHvEA=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -2950,7 +2950,7 @@
         "camelize": "1.0.0",
         "debug": "3.1.0",
         "electron-download": "4.1.0",
-        "electron-osx-sign": "0.4.7",
+        "electron-osx-sign": "0.4.8",
         "extract-zip": "1.6.6",
         "fs-extra": "4.0.3",
         "get-package-info": "1.0.0",
@@ -2963,7 +2963,7 @@
         "resolve": "1.5.0",
         "run-series": "1.1.4",
         "sanitize-filename": "1.6.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "debug": {
@@ -2987,8 +2987,8 @@
             "minimist": "1.2.0",
             "nugget": "2.0.1",
             "path-exists": "3.0.0",
-            "rc": "1.2.3",
-            "semver": "5.4.1",
+            "rc": "1.2.4",
+            "semver": "5.5.0",
             "sumchecker": "2.0.2"
           },
           "dependencies": {
@@ -3149,23 +3149,15 @@
         }
       }
     },
-    "electron-releases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
-      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw=="
-    },
     "electron-to-chromium": {
-      "version": "1.3.30",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
-      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
-      "requires": {
-        "electron-releases": "2.1.0"
-      }
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
     },
     "element-resize-detector": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.12.tgz",
-      "integrity": "sha1-iz/W7t2hf5wAs2Cg6i35knroC6I=",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.13.tgz",
+      "integrity": "sha1-9hkH6YqRsa0hX5J5C8FRE99oRE0=",
       "requires": {
         "batch-processor": "1.0.0"
       }
@@ -3213,7 +3205,7 @@
         "object.entries": "1.0.4",
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "cheerio": {
@@ -3262,14 +3254,14 @@
       "integrity": "sha512-j2Ak+cPvDlCFQeV5w1nzZl6hbpNb1YCurrtffH6OO+9lTXGASZECDFBBy5LMD6oVaFvgXJx532GZcpGD39xnHw==",
       "dev": true,
       "requires": {
-        "circular-json-es6": "2.0.1",
+        "circular-json-es6": "2.0.2",
         "deep-equal-ident": "1.1.1"
       }
     },
     "enzyme-to-json": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz",
-      "integrity": "sha512-d8IfzVpwunct+bw6uWujjHKtskyLwWGKkAguouAdTMNTaTmoC0Y0N0mWpeOq+bFDM4YljRXmBRIsO6QNWrlZzA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.1.tgz",
+      "integrity": "sha512-PrgRyZAgEwOrh5/8BtBWrwGcv1mC7yNohytIciAX6SUqDaXg1BlU8CepYQ9BgnDP1i1jTB65qJJITMMCph+T6A==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -3318,9 +3310,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -3334,7 +3326,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3345,7 +3337,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -3353,9 +3345,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "es6-set": {
@@ -3365,7 +3357,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3378,7 +3370,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "es6-weak-map": {
@@ -3388,7 +3380,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -3453,7 +3445,7 @@
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.17.1",
-        "is-resolvable": "1.0.1",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.7.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
@@ -3570,7 +3562,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "event-stream": {
@@ -3947,9 +3939,9 @@
           }
         },
         "extglob": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.3.tgz",
-          "integrity": "sha512-AyptZexgu7qppEPq59DtN/XJGZDrLcVxSHai+4hdgMMS9EpF4GBvygcWWApno8lL9qSjVpYt7Raao28qzJX1ww==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
             "array-unique": "0.3.2",
@@ -4091,7 +4083,7 @@
             "braces": "2.3.0",
             "define-property": "1.0.0",
             "extend-shallow": "2.0.1",
-            "extglob": "2.0.3",
+            "extglob": "2.0.4",
             "fragment-cache": "0.2.1",
             "kind-of": "6.0.2",
             "nanomatch": "1.2.7",
@@ -4215,16 +4207,6 @@
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
         "universalify": "0.1.1"
-      },
-      "dependencies": {
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
       }
     },
     "fs-readdir-recursive": {
@@ -4251,15 +4233,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4269,21 +4249,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4293,49 +4270,42 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4344,8 +4314,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -4353,8 +4322,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -4362,8 +4330,7 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -4372,34 +4339,29 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -4407,26 +4369,22 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "boom": "2.10.1"
@@ -4434,8 +4392,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4444,8 +4401,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4453,8 +4409,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4463,35 +4418,30 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4500,28 +4450,24 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4532,14 +4478,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -4550,8 +4494,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4562,8 +4505,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4579,8 +4521,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4589,8 +4530,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4598,8 +4538,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -4612,21 +4551,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4636,15 +4572,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "boom": "2.10.1",
@@ -4655,14 +4589,12 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4673,8 +4605,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -4683,21 +4614,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -4705,28 +4633,24 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4735,22 +4659,19 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4759,22 +4680,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4786,8 +4704,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4795,14 +4712,12 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -4810,8 +4725,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -4819,14 +4733,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4834,15 +4746,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4861,8 +4771,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4872,8 +4781,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4885,28 +4793,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -4914,22 +4818,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4939,41 +4840,35 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4985,8 +4880,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4994,8 +4888,7 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -5009,8 +4902,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5040,8 +4932,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -5049,35 +4940,30 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -5085,8 +4971,7 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5103,8 +4988,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5112,8 +4996,7 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -5121,8 +5004,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5132,15 +5014,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5148,15 +5028,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -5166,8 +5044,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5183,8 +5060,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5193,8 +5069,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5203,35 +5078,30 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5240,8 +5110,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5250,8 +5119,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -5615,9 +5483,9 @@
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
@@ -5777,7 +5645,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "handlebars": {
@@ -6491,9 +6359,9 @@
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -6734,7 +6602,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -6917,7 +6785,7 @@
             "jest-snapshot": "21.2.1",
             "jest-util": "21.2.1",
             "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
+            "node-notifier": "5.2.1",
             "pify": "3.0.0",
             "slash": "1.0.0",
             "string-length": "2.0.0",
@@ -7272,7 +7140,7 @@
       "dev": true,
       "requires": {
         "enzyme-matchers": "4.0.2",
-        "enzyme-to-json": "3.3.0"
+        "enzyme-to-json": "3.3.1"
       }
     },
     "jest-get-type": {
@@ -7291,7 +7159,7 @@
         "graceful-fs": "4.1.11",
         "jest-docblock": "21.2.0",
         "micromatch": "2.3.11",
-        "sane": "2.2.0",
+        "sane": "2.3.0",
         "worker-farm": "1.5.2"
       }
     },
@@ -7892,9 +7760,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
+      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
       "dev": true
     },
     "js-string-escape": {
@@ -7996,6 +7864,14 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -8271,7 +8147,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -8993,13 +8869,13 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
       }
@@ -9030,7 +8906,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -9165,43 +9041,35 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+          "bundled": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "bundled": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+          "bundled": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
+          "bundled": true
         },
         "aproba": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
+          "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+          "bundled": true
         },
         "bluebird": {
           "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+          "bundled": true
         },
         "cacache": {
           "version": "9.2.9",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
-          "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+          "bundled": true,
           "requires": {
             "bluebird": "3.5.0",
             "chownr": "1.0.1",
@@ -9220,8 +9088,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+              "bundled": true,
               "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
@@ -9229,37 +9096,31 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+                  "bundled": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                  "bundled": true
                 }
               }
             },
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+              "bundled": true
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
-          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
+          "bundled": true
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+          "bundled": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1"
@@ -9267,8 +9128,7 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "bundled": true,
           "requires": {
             "strip-ansi": "3.0.1",
             "wcwidth": "1.0.1"
@@ -9276,39 +9136,34 @@
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "requires": {
                 "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                  "bundled": true
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+              "bundled": true,
               "requires": {
                 "defaults": "1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "requires": {
                     "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+                      "bundled": true
                     }
                   }
                 }
@@ -9318,8 +9173,7 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+          "bundled": true,
           "requires": {
             "ini": "1.3.4",
             "proto-list": "1.2.4"
@@ -9327,25 +9181,21 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+              "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+          "bundled": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+          "bundled": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "bundled": true,
           "requires": {
             "asap": "2.0.5",
             "wrappy": "1.0.2"
@@ -9353,20 +9203,17 @@
           "dependencies": {
             "asap": {
               "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+              "bundled": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
+          "bundled": true
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
@@ -9375,8 +9222,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
@@ -9386,8 +9232,7 @@
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -9397,8 +9242,7 @@
         },
         "fstream-npm": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
-          "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
+          "bundled": true,
           "requires": {
             "fstream-ignore": "1.0.5",
             "inherits": "2.0.3"
@@ -9406,8 +9250,7 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+              "bundled": true,
               "requires": {
                 "fstream": "1.0.11",
                 "inherits": "2.0.3",
@@ -9416,16 +9259,14 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                  "bundled": true,
                   "requires": {
                     "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                      "bundled": true,
                       "requires": {
                         "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
@@ -9433,13 +9274,11 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                          "bundled": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                          "bundled": true
                         }
                       }
                     }
@@ -9451,8 +9290,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -9464,21 +9302,18 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+              "bundled": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "requires": {
                 "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                  "bundled": true,
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -9486,13 +9321,11 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                      "bundled": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                      "bundled": true
                     }
                   }
                 }
@@ -9500,40 +9333,33 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+              "bundled": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+          "bundled": true
         },
         "iferr": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+          "bundled": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+          "bundled": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -9541,18 +9367,15 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+          "bundled": true
         },
         "init-package-json": {
           "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
-          "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
+          "bundled": true,
           "requires": {
             "glob": "7.1.2",
             "npm-package-arg": "5.1.2",
@@ -9566,8 +9389,7 @@
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+              "bundled": true,
               "requires": {
                 "read": "1.0.7"
               }
@@ -9576,8 +9398,7 @@
         },
         "JSONStream": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "bundled": true,
           "requires": {
             "jsonparse": "1.3.1",
             "through": "2.3.8"
@@ -9585,35 +9406,29 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+              "bundled": true
             },
             "through": {
               "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+              "bundled": true
             }
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
+          "bundled": true
         },
         "lockfile": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
+          "bundled": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+          "bundled": true,
           "requires": {
             "lodash._createset": "4.0.3",
             "lodash._root": "3.0.1"
@@ -9621,68 +9436,56 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
+              "bundled": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+              "bundled": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "requires": {
             "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+          "bundled": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+          "bundled": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+          "bundled": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
+          "bundled": true
         },
         "lru-cache": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -9690,20 +9493,17 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+              "bundled": true
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+              "bundled": true
             }
           }
         },
         "mississippi": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-          "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+          "bundled": true,
           "requires": {
             "concat-stream": "1.6.0",
             "duplexify": "3.5.0",
@@ -9719,8 +9519,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.2",
@@ -9729,15 +9528,13 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+                  "bundled": true
                 }
               }
             },
             "duplexify": {
               "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-              "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+              "bundled": true,
               "requires": {
                 "end-of-stream": "1.0.0",
                 "inherits": "2.0.3",
@@ -9747,16 +9544,14 @@
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+                  "bundled": true,
                   "requires": {
                     "once": "1.3.3"
                   },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "bundled": true,
                       "requires": {
                         "wrappy": "1.0.2"
                       }
@@ -9765,23 +9560,20 @@
                 },
                 "stream-shift": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+                  "bundled": true
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+              "bundled": true,
               "requires": {
                 "once": "1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.2"
@@ -9789,8 +9581,7 @@
             },
             "from2": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.2"
@@ -9798,8 +9589,7 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+              "bundled": true,
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
@@ -9808,15 +9598,13 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+                  "bundled": true
                 }
               }
             },
             "pump": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-              "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+              "bundled": true,
               "requires": {
                 "end-of-stream": "1.4.0",
                 "once": "1.4.0"
@@ -9824,8 +9612,7 @@
             },
             "pumpify": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-              "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+              "bundled": true,
               "requires": {
                 "duplexify": "3.5.0",
                 "inherits": "2.0.3",
@@ -9834,8 +9621,7 @@
             },
             "stream-each": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
-              "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
+              "bundled": true,
               "requires": {
                 "end-of-stream": "1.4.0",
                 "stream-shift": "1.0.0"
@@ -9843,15 +9629,13 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+                  "bundled": true
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+              "bundled": true,
               "requires": {
                 "readable-stream": "2.3.2",
                 "xtend": "4.0.1"
@@ -9859,8 +9643,7 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                  "bundled": true
                 }
               }
             }
@@ -9868,23 +9651,20 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "bundled": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+          "bundled": true,
           "requires": {
             "aproba": "1.1.2",
             "copy-concurrently": "1.0.3",
@@ -9896,8 +9676,7 @@
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
-              "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
+              "bundled": true,
               "requires": {
                 "aproba": "1.1.2",
                 "fs-write-stream-atomic": "1.0.10",
@@ -9909,8 +9688,7 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+              "bundled": true,
               "requires": {
                 "aproba": "1.1.2"
               }
@@ -9919,8 +9697,7 @@
         },
         "node-gyp": {
           "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+          "bundled": true,
           "requires": {
             "fstream": "1.0.11",
             "glob": "7.1.2",
@@ -9939,16 +9716,14 @@
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "requires": {
                 "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                  "bundled": true,
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -9956,13 +9731,11 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                      "bundled": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                      "bundled": true
                     }
                   }
                 }
@@ -9970,8 +9743,7 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "bundled": true,
               "requires": {
                 "abbrev": "1.1.0"
               }
@@ -9980,8 +9752,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "requires": {
             "abbrev": "1.1.0",
             "osenv": "0.1.4"
@@ -9989,8 +9760,7 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "bundled": true,
           "requires": {
             "hosted-git-info": "2.5.0",
             "is-builtin-module": "1.0.0",
@@ -10000,16 +9770,14 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "requires": {
                 "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                  "bundled": true
                 }
               }
             }
@@ -10017,21 +9785,18 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
+          "bundled": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+          "bundled": true,
           "requires": {
             "semver": "5.3.0"
           }
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-          "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+          "bundled": true,
           "requires": {
             "hosted-git-info": "2.5.0",
             "osenv": "0.1.4",
@@ -10041,8 +9806,7 @@
         },
         "npm-registry-client": {
           "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
-          "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
+          "bundled": true,
           "requires": {
             "concat-stream": "1.6.0",
             "graceful-fs": "4.1.11",
@@ -10059,8 +9823,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.2",
@@ -10069,8 +9832,7 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+                  "bundled": true
                 }
               }
             }
@@ -10078,13 +9840,11 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
-          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
+          "bundled": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -10094,8 +9854,7 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+              "bundled": true,
               "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.2"
@@ -10103,20 +9862,17 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+                  "bundled": true
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "bundled": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "bundled": true,
               "requires": {
                 "aproba": "1.1.2",
                 "console-control-strings": "1.1.0",
@@ -10130,18 +9886,15 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                  "bundled": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+                  "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "bundled": true,
                   "requires": {
                     "code-point-at": "1.1.0",
                     "is-fullwidth-code-point": "1.0.0",
@@ -10150,21 +9903,18 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                      "bundled": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "bundled": true,
                       "requires": {
                         "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                          "bundled": true
                         }
                       }
                     }
@@ -10172,23 +9922,20 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                      "bundled": true
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-                  "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+                  "bundled": true,
                   "requires": {
                     "string-width": "1.0.2"
                   }
@@ -10197,28 +9944,24 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+              "bundled": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "opener": {
           "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -10226,20 +9969,17 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+              "bundled": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+              "bundled": true
             }
           }
         },
         "pacote": {
           "version": "2.7.38",
-          "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
-          "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
+          "bundled": true,
           "requires": {
             "bluebird": "3.5.0",
             "cacache": "9.2.9",
@@ -10266,8 +10006,7 @@
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.4.13",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.13.tgz",
-              "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
+              "bundled": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
                 "cacache": "9.2.9",
@@ -10284,24 +10023,21 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
-                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
+                  "bundled": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+                      "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                          "bundled": true
                         }
                       }
                     }
@@ -10309,13 +10045,11 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.7.3",
-                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
-                  "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I="
+                  "bundled": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
-                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
+                  "bundled": true,
                   "requires": {
                     "agent-base": "4.1.0",
                     "debug": "2.6.8"
@@ -10323,24 +10057,21 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
-                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                      "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                          "bundled": true,
                           "requires": {
                             "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+                              "bundled": true
                             }
                           }
                         }
@@ -10348,16 +10079,14 @@
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                      "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                          "bundled": true
                         }
                       }
                     }
@@ -10365,8 +10094,7 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.0.0.tgz",
-                  "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
+                  "bundled": true,
                   "requires": {
                     "agent-base": "4.1.0",
                     "debug": "2.6.8"
@@ -10374,24 +10102,21 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
-                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                      "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                          "bundled": true,
                           "requires": {
                             "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+                              "bundled": true
                             }
                           }
                         }
@@ -10399,16 +10124,14 @@
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                      "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                          "bundled": true
                         }
                       }
                     }
@@ -10416,8 +10139,7 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
-                  "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
+                  "bundled": true,
                   "requires": {
                     "encoding": "0.1.12",
                     "json-parse-helpfulerror": "1.0.3",
@@ -10426,31 +10148,27 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+                      "bundled": true,
                       "requires": {
                         "iconv-lite": "0.4.18"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.18",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-                          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+                          "bundled": true
                         }
                       }
                     },
                     "json-parse-helpfulerror": {
                       "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-                      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+                      "bundled": true,
                       "requires": {
                         "jju": "1.3.0"
                       },
                       "dependencies": {
                         "jju": {
                           "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                          "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
+                          "bundled": true
                         }
                       }
                     }
@@ -10458,8 +10176,7 @@
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
-                  "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
+                  "bundled": true,
                   "requires": {
                     "agent-base": "4.1.0",
                     "socks": "1.1.10"
@@ -10467,24 +10184,21 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
-                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
+                      "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+                          "bundled": true,
                           "requires": {
                             "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+                              "bundled": true
                             }
                           }
                         }
@@ -10492,8 +10206,7 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
-                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+                      "bundled": true,
                       "requires": {
                         "ip": "1.1.5",
                         "smart-buffer": "1.1.15"
@@ -10501,13 +10214,11 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+                          "bundled": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+                          "bundled": true
                         }
                       }
                     }
@@ -10517,16 +10228,14 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "requires": {
                 "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                  "bundled": true,
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -10534,13 +10243,11 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                      "bundled": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                      "bundled": true
                     }
                   }
                 }
@@ -10548,8 +10255,7 @@
             },
             "npm-pick-manifest": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
-              "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
+              "bundled": true,
               "requires": {
                 "npm-package-arg": "5.1.2",
                 "semver": "5.3.0"
@@ -10557,8 +10263,7 @@
             },
             "promise-retry": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+              "bundled": true,
               "requires": {
                 "err-code": "1.1.2",
                 "retry": "0.10.1"
@@ -10566,30 +10271,26 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-                  "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+                  "bundled": true
                 }
               }
             },
             "protoduck": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
-              "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
+              "bundled": true,
               "requires": {
                 "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
+                  "bundled": true
                 }
               }
             },
             "tar-fs": {
               "version": "1.15.3",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-              "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
+              "bundled": true,
               "requires": {
                 "chownr": "1.0.1",
                 "mkdirp": "0.5.1",
@@ -10599,8 +10300,7 @@
               "dependencies": {
                 "pump": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+                  "bundled": true,
                   "requires": {
                     "end-of-stream": "1.4.0",
                     "once": "1.4.0"
@@ -10608,8 +10308,7 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+                      "bundled": true,
                       "requires": {
                         "once": "1.4.0"
                       }
@@ -10620,8 +10319,7 @@
             },
             "tar-stream": {
               "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-              "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+              "bundled": true,
               "requires": {
                 "bl": "1.2.1",
                 "end-of-stream": "1.4.0",
@@ -10631,24 +10329,21 @@
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-                  "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+                  "bundled": true,
                   "requires": {
                     "readable-stream": "2.3.2"
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+                  "bundled": true,
                   "requires": {
                     "once": "1.4.0"
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                  "bundled": true
                 }
               }
             }
@@ -10656,41 +10351,35 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+          "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+          "bundled": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "requires": {
             "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+              "bundled": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
@@ -10703,15 +10392,13 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+              "bundled": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
-          "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
+          "bundled": true,
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -10721,16 +10408,14 @@
           "dependencies": {
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+              "bundled": true,
               "requires": {
                 "jju": "1.3.0"
               },
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                  "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
+                  "bundled": true
                 }
               }
             }
@@ -10738,8 +10423,7 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
-          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
+          "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -10750,8 +10434,7 @@
         },
         "readable-stream": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+          "bundled": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -10764,38 +10447,32 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+              "bundled": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+              "bundled": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+              "bundled": true
             },
             "string_decoder": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+              "bundled": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+          "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -10805,8 +10482,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -10834,48 +10510,40 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+              "bundled": true
             },
             "aws4": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+              "bundled": true
             },
             "caseless": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+              "bundled": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "requires": {
                 "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                  "bundled": true
                 }
               }
             },
             "extend": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+              "bundled": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+              "bundled": true
             },
             "form-data": {
               "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+              "bundled": true,
               "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
@@ -10884,15 +10552,13 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+                  "bundled": true
                 }
               }
             },
             "har-validator": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+              "bundled": true,
               "requires": {
                 "ajv": "4.11.8",
                 "har-schema": "1.0.5"
@@ -10900,8 +10566,7 @@
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                  "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                  "bundled": true,
                   "requires": {
                     "co": "4.6.0",
                     "json-stable-stringify": "1.0.1"
@@ -10909,21 +10574,18 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+                      "bundled": true
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                      "bundled": true,
                       "requires": {
                         "jsonify": "0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+                          "bundled": true
                         }
                       }
                     }
@@ -10931,15 +10593,13 @@
                 },
                 "har-schema": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                  "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+                  "bundled": true
                 }
               }
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "bundled": true,
               "requires": {
                 "boom": "2.10.1",
                 "cryptiles": "2.0.5",
@@ -10949,29 +10609,25 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "bundled": true,
                   "requires": {
                     "hoek": "2.16.3"
                   }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "requires": {
                     "boom": "2.10.1"
                   }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                  "bundled": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "requires": {
                     "hoek": "2.16.3"
                   }
@@ -10980,8 +10636,7 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "bundled": true,
               "requires": {
                 "assert-plus": "0.2.0",
                 "jsprim": "1.4.0",
@@ -10990,13 +10645,11 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+                  "bundled": true
                 },
                 "jsprim": {
                   "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                  "bundled": true,
                   "requires": {
                     "assert-plus": "1.0.0",
                     "extsprintf": "1.0.2",
@@ -11006,23 +10659,19 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                      "bundled": true
                     },
                     "extsprintf": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                      "bundled": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+                      "bundled": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "bundled": true,
                       "requires": {
                         "extsprintf": "1.0.2"
                       }
@@ -11031,8 +10680,7 @@
                 },
                 "sshpk": {
                   "version": "1.13.1",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+                  "bundled": true,
                   "requires": {
                     "asn1": "0.2.3",
                     "assert-plus": "1.0.0",
@@ -11046,18 +10694,15 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+                      "bundled": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                      "bundled": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                      "bundled": true,
                       "optional": true,
                       "requires": {
                         "tweetnacl": "0.14.5"
@@ -11065,16 +10710,14 @@
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                      "bundled": true,
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "bundled": true,
                       "optional": true,
                       "requires": {
                         "jsbn": "0.1.1"
@@ -11082,22 +10725,19 @@
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                      "bundled": true,
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                      "bundled": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                      "bundled": true,
                       "optional": true
                     }
                   }
@@ -11106,73 +10746,61 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+              "bundled": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+              "bundled": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+              "bundled": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+              "bundled": true,
               "requires": {
                 "mime-db": "1.27.0"
               },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                  "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+                  "bundled": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+              "bundled": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+              "bundled": true
             },
             "qs": {
               "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+              "bundled": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+              "bundled": true
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "bundled": true,
               "requires": {
                 "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                  "bundled": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "bundled": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -11181,31 +10809,26 @@
         },
         "retry": {
           "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+          "bundled": true
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "bundled": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "readable-stream": "2.3.2"
@@ -11213,18 +10836,15 @@
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+          "bundled": true
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
+          "bundled": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+          "bundled": true,
           "requires": {
             "from2": "1.3.0",
             "stream-iterate": "1.2.0"
@@ -11232,8 +10852,7 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14"
@@ -11241,8 +10860,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                  "bundled": true,
                   "requires": {
                     "core-util-is": "1.0.2",
                     "inherits": "2.0.3",
@@ -11252,18 +10870,15 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                      "bundled": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                      "bundled": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                      "bundled": true
                     }
                   }
                 }
@@ -11271,8 +10886,7 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+              "bundled": true,
               "requires": {
                 "readable-stream": "2.3.2",
                 "stream-shift": "1.0.0"
@@ -11280,8 +10894,7 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+                  "bundled": true
                 }
               }
             }
@@ -11289,31 +10902,27 @@
         },
         "ssri": {
           "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-          "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+              "bundled": true
             }
           }
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -11322,8 +10931,7 @@
           "dependencies": {
             "block-stream": {
               "version": "0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "bundled": true,
               "requires": {
                 "inherits": "2.0.3"
               }
@@ -11332,31 +10940,26 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+          "bundled": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+          "bundled": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
+          "bundled": true
         },
         "unique-filename": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+          "bundled": true,
           "requires": {
             "unique-slug": "2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+              "bundled": true,
               "requires": {
                 "imurmurhash": "0.1.4"
               }
@@ -11365,13 +10968,11 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+          "bundled": true
         },
         "update-notifier": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
-          "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+          "bundled": true,
           "requires": {
             "boxen": "1.1.0",
             "chalk": "1.1.3",
@@ -11385,8 +10986,7 @@
           "dependencies": {
             "boxen": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
-              "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
+              "bundled": true,
               "requires": {
                 "ansi-align": "2.0.0",
                 "camelcase": "4.1.0",
@@ -11399,26 +10999,22 @@
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-                  "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+                  "bundled": true,
                   "requires": {
                     "string-width": "2.1.0"
                   }
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                  "bundled": true
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+                  "bundled": true
                 },
                 "string-width": {
                   "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-                  "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+                  "bundled": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
                     "strip-ansi": "4.0.0"
@@ -11426,13 +11022,11 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                      "bundled": true
                     },
                     "strip-ansi": {
                       "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                      "bundled": true,
                       "requires": {
                         "ansi-regex": "3.0.0"
                       }
@@ -11441,16 +11035,14 @@
                 },
                 "term-size": {
                   "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-                  "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+                  "bundled": true,
                   "requires": {
                     "execa": "0.4.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-                      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+                      "bundled": true,
                       "requires": {
                         "cross-spawn-async": "2.2.5",
                         "is-stream": "1.1.0",
@@ -11462,8 +11054,7 @@
                       "dependencies": {
                         "cross-spawn-async": {
                           "version": "2.2.5",
-                          "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-                          "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+                          "bundled": true,
                           "requires": {
                             "lru-cache": "4.1.1",
                             "which": "1.2.14"
@@ -11471,31 +11062,26 @@
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                          "bundled": true
                         },
                         "npm-run-path": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-                          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+                          "bundled": true,
                           "requires": {
                             "path-key": "1.0.0"
                           }
                         },
                         "object-assign": {
                           "version": "4.1.1",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                          "bundled": true
                         },
                         "path-key": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-                          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
+                          "bundled": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+                          "bundled": true
                         }
                       }
                     }
@@ -11503,16 +11089,14 @@
                 },
                 "widest-line": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+                  "bundled": true,
                   "requires": {
                     "string-width": "1.0.2"
                   },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "bundled": true,
                       "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -11521,36 +11105,31 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                          "bundled": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "bundled": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                              "bundled": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "bundled": true,
                           "requires": {
                             "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                              "bundled": true
                             }
                           }
                         }
@@ -11562,8 +11141,7 @@
             },
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "bundled": true,
               "requires": {
                 "ansi-styles": "2.2.1",
                 "escape-string-regexp": "1.0.5",
@@ -11574,55 +11152,47 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                  "bundled": true
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                  "bundled": true
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "bundled": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                      "bundled": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "bundled": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                      "bundled": true
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                  "bundled": true
                 }
               }
             },
             "configstore": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
-              "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
+              "bundled": true,
               "requires": {
                 "dot-prop": "4.1.1",
                 "graceful-fs": "4.1.11",
@@ -11634,46 +11204,40 @@
               "dependencies": {
                 "dot-prop": {
                   "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-                  "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
+                  "bundled": true,
                   "requires": {
                     "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+                      "bundled": true
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-                  "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+                  "bundled": true,
                   "requires": {
                     "pify": "2.3.0"
                   },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                      "bundled": true
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+                  "bundled": true,
                   "requires": {
                     "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+                      "bundled": true
                     }
                   }
                 }
@@ -11681,26 +11245,22 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+              "bundled": true
             },
             "is-npm": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+              "bundled": true
             },
             "latest-version": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+              "bundled": true,
               "requires": {
                 "package-json": "4.0.1"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-                  "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+                  "bundled": true,
                   "requires": {
                     "got": "6.7.1",
                     "registry-auth-token": "3.3.1",
@@ -11710,8 +11270,7 @@
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
-                      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+                      "bundled": true,
                       "requires": {
                         "create-error-class": "3.0.2",
                         "duplexer3": "0.1.4",
@@ -11728,71 +11287,59 @@
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
-                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+                          "bundled": true,
                           "requires": {
                             "capture-stack-trace": "1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+                              "bundled": true
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+                          "bundled": true
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                          "bundled": true
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+                          "bundled": true
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+                          "bundled": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                          "bundled": true
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+                          "bundled": true
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+                          "bundled": true
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+                          "bundled": true
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                          "bundled": true,
                           "requires": {
                             "prepend-http": "1.0.4"
                           },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+                              "bundled": true
                             }
                           }
                         }
@@ -11800,8 +11347,7 @@
                     },
                     "registry-auth-token": {
                       "version": "3.3.1",
-                      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-                      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+                      "bundled": true,
                       "requires": {
                         "rc": "1.2.1",
                         "safe-buffer": "5.1.1"
@@ -11809,8 +11355,7 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+                          "bundled": true,
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.4",
@@ -11820,18 +11365,15 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+                              "bundled": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                              "bundled": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+                              "bundled": true
                             }
                           }
                         }
@@ -11839,16 +11381,14 @@
                     },
                     "registry-url": {
                       "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+                      "bundled": true,
                       "requires": {
                         "rc": "1.2.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+                          "bundled": true,
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.4",
@@ -11858,18 +11398,15 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+                              "bundled": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                              "bundled": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+                              "bundled": true
                             }
                           }
                         }
@@ -11881,28 +11418,24 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+              "bundled": true,
               "requires": {
                 "semver": "5.3.0"
               }
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+              "bundled": true
             }
           }
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "requires": {
             "spdx-correct": "1.0.2",
             "spdx-expression-parse": "1.0.4"
@@ -11910,60 +11443,52 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+              "bundled": true,
               "requires": {
                 "spdx-license-ids": "1.2.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                  "bundled": true
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+              "bundled": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+          "bundled": true,
           "requires": {
             "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+              "bundled": true
             }
           }
         },
         "which": {
           "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "bundled": true,
           "requires": {
             "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+              "bundled": true
             }
           }
         },
         "worker-farm": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
-          "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
+          "bundled": true,
           "requires": {
             "errno": "0.1.4",
             "xtend": "4.0.1"
@@ -11971,35 +11496,30 @@
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+              "bundled": true,
               "requires": {
                 "prr": "0.0.0"
               },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+                  "bundled": true
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+              "bundled": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -12661,7 +12181,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -12804,8 +12324,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000791",
-            "electron-to-chromium": "1.3.30"
+            "caniuse-db": "1.0.30000795",
+            "electron-to-chromium": "1.3.31"
           }
         }
       }
@@ -13117,15 +12637,6 @@
             "jsonfile": "4.0.0",
             "universalify": "0.1.1"
           }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
         }
       }
     },
@@ -13205,9 +12716,9 @@
       }
     },
     "rc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.3.tgz",
-      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -13234,6 +12745,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
       "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -13290,7 +12802,7 @@
       "resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.3.3.tgz",
       "integrity": "sha1-XaMB4w3stEn7DO8aKrIQ35cMpx4=",
       "requires": {
-        "element-resize-detector": "1.1.12",
+        "element-resize-detector": "1.1.13",
         "invariant": "2.2.2",
         "prop-types": "15.6.0"
       }
@@ -13306,13 +12818,6 @@
         "invariant": "2.2.2",
         "lodash": "4.17.4",
         "prop-types": "15.6.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-        }
       }
     },
     "react-dnd-html5-backend": {
@@ -13392,13 +12897,6 @@
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-        }
       }
     },
     "react-remarkable": {
@@ -13773,7 +13271,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "require-directory": {
@@ -13939,9 +13437,9 @@
       }
     },
     "sane": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-      "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
+      "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
@@ -13993,9 +13491,9 @@
       }
     },
     "sass.js": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/sass.js/-/sass.js-0.10.7.tgz",
-      "integrity": "sha512-HsCpVBkxigI3iGtkhdCeZdOAwdF6djEB48rTtuGgCGJOi/rY7XxvH6qgILJRbGxzv4CLSkm2jexoruLZRvT6TQ==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/sass.js/-/sass.js-0.10.8.tgz",
+      "integrity": "sha512-HK8+oaOfb5fDpILmKeSG6Cl1Uk7zujsessffLGjSEuzXfM2WCpOxUjfnVu9MuYhPlzYg10Xxv2XXaJyp/y+yug==",
       "dev": true
     },
     "sax": {
@@ -14005,9 +13503,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "sequencify": {
       "version": "0.0.7",
@@ -14717,7 +14215,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "es6-promise": "4.2.2"
+        "es6-promise": "4.2.4"
       }
     },
     "supports-color": {
@@ -15555,9 +15053,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
     "v8flags": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "name": "unfoldingWord",
     "email": "info@unfoldingword.org"
   },
-  "license": "GPL2",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/unfoldingWord-dev/translationCore/issues"
   },
@@ -69,6 +69,7 @@
     "jest-enzyme": "4.0.1",
     "ncp": "2.0.0",
     "prettier": "1.8.2",
+    "react": "16.2.0",
     "react-addons-test-utils": "15.5.0",
     "react-test-renderer": "16.2.0",
     "redux-jest": "1.1.1",
@@ -106,7 +107,6 @@
     "opn": "5.1.0",
     "path-extra": "3.0.0",
     "prop-types": "15.6.0",
-    "react": "16.2.0",
     "react-bootstrap": "0.32.0",
     "react-container-dimensions": "1.3.3",
     "react-dnd": "2.5.4",


### PR DESCRIPTION
### This pull request addresses:

- Fixed bug that caused multiple copies of React being loaded


### How to test this pull request:
- Run `rm -rf node_modules` and `npm install` then `npm start`
- Open a project with **translationWords** and click the cancel button in the verse check area and then make a selection. The app should work as expected.

### Note:
```
For reusable components:
  1. Put a react dependency in both peerDependencies and devDependencies.
  2. Never put a react dependency in dependencies.

peerDependencies specifies which version(s) of React your reusable component 
supports/requires. When using npm 2 this also adds React to the list of modules 
to be installed, but this is no longer the case with npm 3.

devDependencies ensures React will be installed when you run npm install while
developing your component, or when running tests on Travis or similar.

Putting react in dependencies will cause multiple versions of React to be 
installed if somebody uses your component but has a different version of 
React in their own package.json - having multiple versions of React not only 
bloats the build, but also causes errors when different versions try to interact.
```
**Source:** https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-a-dependency-to-react-in-your-package-json-for

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3687)
<!-- Reviewable:end -->
