### PR TITLE
Fix - #3296 - Fix for QA Fail - Makes Home page progress bar update after tool use

### DIFF
--- a/__tests__/OverviewToolCard.test.js
+++ b/__tests__/OverviewToolCard.test.js
@@ -5,6 +5,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import ToolCard from '../src/js/components/home/overview/ToolCard';
+import * as ProjectDetailsActions from '../src/js/actions/ProjectDetailsActions';
 import renderer from 'react-test-renderer';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import * as LocalImportWorkflowActions from '../src/js/actions/Import/LocalImportWorkflowActions';
@@ -86,7 +87,11 @@ describe('Tool Card component Tests', () => {
           }
         }
       },
-      actions: {}
+      actions: {
+        getProjectProgressForTools: (toolName) => {
+          ProjectDetailsActions.getProjectProgressForTools(toolName);
+        }
+      }
     };
     const component = renderer.create(
       <MuiThemeProvider>

--- a/src/js/components/home/overview/ToolCard.js
+++ b/src/js/components/home/overview/ToolCard.js
@@ -2,11 +2,20 @@
 import React, { Component } from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 // components
 import TemplateCard from '../TemplateCard';
 import ToolCardProgress from '../toolsManagement/ToolCardProgress';
+// actions
+import * as ProjectDetailsActions from '../../../actions/ProjectDetailsActions';
 
 class ToolCard extends Component {
+
+  componentWillMount() {
+    if(this.props.reducers.toolsReducer.currentToolName) {
+      this.props.actions.getProjectProgressForTools(this.props.reducers.toolsReducer.currentToolName);
+    }
+  }
 
   /**
   * @description generates the heading for the component
@@ -29,7 +38,7 @@ class ToolCard extends Component {
     const { currentToolTitle, currentToolName } = this.props.reducers.toolsReducer;
     const { currentProjectToolsProgress } = this.props.reducers.projectDetailsReducer;
 
-    if (currentToolTitle) { // once currentToolTitle is there then we can get groupsData
+    if (currentToolName) { // once currentToolName is there then we can get groupsData
       let progress = currentProjectToolsProgress[currentToolName];
       content = (
         <div style={{ display: 'flex', justifyContent: 'space-between', margin: '-10px 0 -24px 0' }}>
@@ -77,4 +86,26 @@ ToolCard.propTypes = {
   actions: PropTypes.object.isRequired
 };
 
-export default ToolCard;
+const mapStateToProps = (state) => {
+  return {
+    reducers: {
+      toolsReducer: state.toolsReducer,
+      projectDetailsReducer: state.projectDetailsReducer
+    }
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    actions: {
+      getProjectProgressForTools: (toolName) => {
+        dispatch(ProjectDetailsActions.getProjectProgressForTools(toolName));
+      }
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ToolCard);

--- a/src/js/components/home/overview/ToolCard.js
+++ b/src/js/components/home/overview/ToolCard.js
@@ -2,12 +2,9 @@
 import React, { Component } from 'react';
 import { Glyphicon } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 // components
 import TemplateCard from '../TemplateCard';
 import ToolCardProgress from '../toolsManagement/ToolCardProgress';
-// actions
-import * as ProjectDetailsActions from '../../../actions/ProjectDetailsActions';
 
 class ToolCard extends Component {
 
@@ -38,7 +35,7 @@ class ToolCard extends Component {
     const { currentToolTitle, currentToolName } = this.props.reducers.toolsReducer;
     const { currentProjectToolsProgress } = this.props.reducers.projectDetailsReducer;
 
-    if (currentToolName) { // once currentToolName is there then we can get groupsData
+    if (currentToolTitle) { // once currentToolTitle is there then we can get groupsData
       let progress = currentProjectToolsProgress[currentToolName];
       content = (
         <div style={{ display: 'flex', justifyContent: 'space-between', margin: '-10px 0 -24px 0' }}>
@@ -86,26 +83,4 @@ ToolCard.propTypes = {
   actions: PropTypes.object.isRequired
 };
 
-const mapStateToProps = (state) => {
-  return {
-    reducers: {
-      toolsReducer: state.toolsReducer,
-      projectDetailsReducer: state.projectDetailsReducer
-    }
-  };
-};
-
-const mapDispatchToProps = (dispatch) => {
-  return {
-    actions: {
-      getProjectProgressForTools: (toolName) => {
-        dispatch(ProjectDetailsActions.getProjectProgressForTools(toolName));
-      }
-    }
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ToolCard);
+export default ToolCard;

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -24,7 +24,6 @@ import * as USFMExportActions from '../../actions/USFMExportActions';
 import * as ProjectInformationCheckActions from '../../actions/ProjectInformationCheckActions';
 import * as ProjectDetailsActions from '../../actions/ProjectDetailsActions';
 
-
 class HomeContainer extends Component {
 
   componentWillMount() {

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -22,16 +22,16 @@ import * as CSVExportActions from '../../actions/CSVExportActions';
 import * as ProjectUploadActions from '../../actions/ProjectUploadActions';
 import * as USFMExportActions from '../../actions/USFMExportActions';
 import * as ProjectInformationCheckActions from '../../actions/ProjectInformationCheckActions';
+import * as ProjectDetailsActions from '../../actions/ProjectDetailsActions';
+
 
 class HomeContainer extends Component {
-
 
   componentWillMount() {
     if (this.props.reducers.loginReducer.userdata.username) {
       this.props.actions.updateStepLabel(1, this.props.reducers.loginReducer.userdata.username);
     }
   }
-
 
   componentWillReceiveProps() {
     this.props.actions.getStepperNextButtonIsDisabled();
@@ -156,6 +156,9 @@ const mapDispatchToProps = (dispatch) => {
       },
       openOnlyProjectDetailsScreen: (projectSaveLocation) => {
         dispatch(ProjectInformationCheckActions.openOnlyProjectDetailsScreen(projectSaveLocation));
+      },
+      getProjectProgressForTools: (toolName) => {
+        dispatch(ProjectDetailsActions.getProjectProgressForTools(toolName));
       }
     }
   };


### PR DESCRIPTION
#### This pull request addresses:

QA Fail Fix for #3296 

#### How to test this pull request:

Check out branch `fix-richmahn-3296-qa-fail-fix` and run the app. Overview page should load without a tool card since no tool selected. Select project and then a tool and then do some work in that tool. Click on the "Home" tab/step while in the tool...the home page should show the new progress percentage correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3693)
<!-- Reviewable:end -->
