### PR TITLE
Feature bspidel fix

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -272,7 +272,7 @@ main modal. They basically override bootstrap styling for these components
   padding: 10px;
   position: absolute;
   z-index: 1;
-  bottom: 125%;
+  bottom: 50%;
   left: 50%;
   margin-left: -60px;
   opacity: 0;
@@ -283,8 +283,8 @@ main modal. They basically override bootstrap styling for these components
   content: "";
   position: absolute;
   top: 100%;
-  left: 50%;
-  margin-left: -5px;
+  left: 70%;
+  margin-left: -80px;
   border-width: 5px;
   border-style: solid;
   border-color: #555 transparent transparent transparent;


### PR DESCRIPTION
#### This pull request addresses:

overcomes tool tip shifting off top of card and being clipped

#### How to test this pull request:

Display project card with long language name such as: ab_jhn_reg
Hover over language name.
Note tool-tip is positioned entirely within card

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3694)
<!-- Reviewable:end -->
