### PR TITLE
Bugfix 3724/broken usfm import

### DIFF
--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -109,4 +109,33 @@ describe('UsfmFileConversionHelpers', () => {
     await UsfmFileConversionHelpers.moveUsfmFileFromSourceToImports(path.join('path', 'to', 'project', 'eph.usfm'), mockManifest, 'project_folder_name');
     expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
   });
+
+  test('generateTargetLanguageBibleFromUsfm with valid USFM should succeed', async () => {
+    // given
+    fs.__setMockFS({
+    });
+    let mockManifest = {
+      project: {
+        id: 'eph'
+      },
+      target_language: {
+        id: "en"
+      }
+    };
+    const newUsfmProjectImportsPath = path.join(IMPORTS_PATH, 'project_folder_name', 'eph');
+
+    //when
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+
+    //then
+    {
+      expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
+
+      const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
+      expect(Object.keys(chapter1_data).length - 1).toEqual(16);
+
+      const chapter2_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '2.json'));
+      expect(Object.keys(chapter2_data).length - 1).toEqual(0);
+    }
+  });
 });

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -118,7 +118,10 @@ export function populateEmptyChapterAlignmentData() {
  * @return {Array} alignmentObjects from verse text
  */
 export const generateBlankAlignments = (verseData) => {
-    const combinedVerse = WordAlignmentHelpers.combineGreekVerse(verseData);
+  if(verseData.verseObjects) {
+    verseData = verseData.verseObjects;
+  }
+  const combinedVerse = WordAlignmentHelpers.combineGreekVerse(verseData);
     const alignments = verseData
     .filter((wordData)=>{
       return (typeof(wordData) === 'object') && (wordData.word || wordData.type === 'word');

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -6,6 +6,7 @@ import usfmjs from 'usfm-js';
 // helpers
 import * as usfmHelpers from '../usfmHelpers';
 import * as manifestHelpers from '../manifestHelpers';
+import * as VerseObjectHelpers from "../VerseObjectHelpers";
 // contstants
 const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
 
@@ -93,7 +94,7 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
         const bibleChapter = {};
         Object.keys(chaptersObject[chapter]).forEach((verse) => {
           const verseParts = chaptersObject[chapter][verse];
-          bibleChapter[verse] = verseParts.join(' ');
+          bibleChapter[verse] = VerseObjectHelpers.mergeVerseData(verseParts).trim();
           verseFound = true;
         });
         const filename = parseInt(chapter, 10) + '.json';

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -6,7 +6,6 @@ import usfmjs from 'usfm-js';
 // helpers
 import * as usfmHelpers from '../usfmHelpers';
 import * as manifestHelpers from '../manifestHelpers';
-import * as VerseObjectHelpers from "../VerseObjectHelpers";
 // contstants
 const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
 
@@ -94,7 +93,7 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
         const bibleChapter = {};
         Object.keys(chaptersObject[chapter]).forEach((verse) => {
           const verseParts = chaptersObject[chapter][verse];
-          bibleChapter[verse] = VerseObjectHelpers.mergeVerseData(verseParts).trim();
+          bibleChapter[verse] = getUsfmForVerseContent(verseParts).trim();
           verseFound = true;
         });
         const filename = parseInt(chapter, 10) + '.json';
@@ -132,4 +131,22 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
       reject(error);
     }
   });
+};
+
+/**
+ * @description merge verse data into a string
+ * @param {Object|Array} verseData
+ * @return {String}
+ */
+export const getUsfmForVerseContent = (verseData) => {
+  const outputData = {
+    "chapters": {},
+    "headers": [],
+    "verses": {
+      "0": verseData
+    }
+  };
+  const USFM = usfmjs.toUSFM(outputData, {chunk: true});
+  const split = USFM.split("\\v 0 ");
+  return split.length > 1 ? split[1] : USFM;
 };

--- a/src/js/helpers/VerseObjectHelpers.js
+++ b/src/js/helpers/VerseObjectHelpers.js
@@ -131,12 +131,12 @@ export const mergeVerseData = (verseData) => {
   if (verseData.verseObjects) {
     verseData = verseData.verseObjects;
   }
-  const verseArray = verseData.map((verse) => {
-    if (typeof verse === 'string') {
-      return verse;
+  const verseArray = verseData.map((part) => {
+    if (typeof part === 'string') {
+      return part;
     }
-    if (verse.text) {
-      return verse.text;
+    if (part.text) {
+      return part.text;
     }
     return null;
   });

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -6,7 +6,7 @@ import * as manifestHelpers from './manifestHelpers';
 import usfmjs from 'usfm-js';
 
 /**
- * Concatenates an array of string into a verse.
+ * Concatenates an array of words into a verse.
  * @param {array} verseArray - array of strings in a verse.
  * @return {string} combined verse
  */
@@ -160,7 +160,7 @@ export const convertAlignmentDataToUSFM = (wordAlignmentDataPath, projectTargetL
       setVerseObjectsInAlignmentJSON(usfmToJSONObject, chapterNumber, verseNumber, verseObjects);
     }
   }
-  //Have iterated through all chapters and verses and stroed verse objects from alignment data
+  //Have iterated through all chapters and verses and stored verse objects from alignment data
   //returning usfm string
   return usfmjs.toUSFM(usfmToJSONObject);
 };


### PR DESCRIPTION
#### This pull request addresses:

Stores project chapter data in USFM format.


#### How to test this pull request:

depends on https://github.com/translationCoreApps/ScripturePane/pull/86 to strip out USFM markers such as \s5 and \p in scripturePane

USFM import should now work.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3746)
<!-- Reviewable:end -->
