### PR TITLE
Bugfix #3186/alignment usfm import

### DIFF
--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -4,7 +4,6 @@ import path from 'path';
 jest.unmock('fs-extra');
 //helpers
 import * as AlignmentHelpers from '../src/js/helpers/AlignmentHelpers';
-import usfm from "usfm-js";
 
 const RESOURCES = path.join('__tests__','fixtures','pivotAlignmentVerseObjects');
 

--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -163,5 +163,9 @@ describe('UsfmFileConversionHelpers', () => {
     const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
     expect(Object.keys(chapter1_data).length - 1).toEqual(13);
     expect(chapter1_data[1]).toEqual("Long ago God spoke to our ancestors through the prophets at many times and in many ways.");
+    // test apostrophe
+    expect(chapter1_data[3]).toEqual("He is the brightness of God's glory, the exact representation of his being. He even holds everything together by the word of his power. After he had made cleansing for sins, he sat down at the right hand of the Majesty on high.");
+    // test quotes
+    expect(chapter1_data[5]).toEqual("For to which of the angels did God ever say, \"You are my son, today I have become your father\"? Or to which of the angels did God ever say, \"I will be a father to him, and he will be a son to me\"?");
   });
 });

--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -128,14 +128,40 @@ describe('UsfmFileConversionHelpers', () => {
     await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
 
     //then
-    {
-      expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
+    expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
 
-      const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
-      expect(Object.keys(chapter1_data).length - 1).toEqual(16);
+    const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
+    expect(Object.keys(chapter1_data).length - 1).toEqual(16);
 
-      const chapter2_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '2.json'));
-      expect(Object.keys(chapter2_data).length - 1).toEqual(0);
-    }
+    const chapter2_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '2.json'));
+    expect(Object.keys(chapter2_data).length - 1).toEqual(0);
+
+  });
+
+  test('generateTargetLanguageBibleFromUsfm with aligned USFM should succeed', async () => {
+    // given
+    fs.__setMockFS({
+    });
+    let mockManifest = {
+      project: {
+        id: 'eph'
+      },
+      target_language: {
+        id: "en"
+      }
+    };
+    const newUsfmProjectImportsPath = path.join(IMPORTS_PATH, 'project_folder_name', 'eph');
+    const testDataPath = path.join('__tests__','fixtures','project','alignmentUsfmImport','59-HEB.usfm');
+    const validUsfmString = fs.__actual.readFileSync(testDataPath).toString();
+
+    //when
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+
+    //then
+    expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
+
+    const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
+    expect(Object.keys(chapter1_data).length - 1).toEqual(13);
+    expect(chapter1_data[1]).toEqual("Long ago God spoke to our ancestors through the prophets at many times and in many ways.");
   });
 });

--- a/__tests__/fixtures/project/alignmentUsfmImport/59-HEB.usfm
+++ b/__tests__/fixtures/project/alignmentUsfmImport/59-HEB.usfm
@@ -1,0 +1,328 @@
+\id HEB EN_ULB en_English_ltr Wed Feb 07 2018 14:30:14 GMT-0500 (EST) tc
+\h Hebrews
+\c 1
+\v 1 \k-s | strong="G38190" x-lemma="πάλαι" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="πάλαι"
+\w Long|x-occurrence="1" x-occurrences="1"\w*
+\w ago|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="Θεὸς"
+\w God|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G29800" x-lemma="λαλέω" x-morph="Gr,V,PAA,NMS," x-occurrence="1" x-occurrences="1" x-content="λαλήσας"
+\w spoke|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,DMP," x-occurrence="1" x-occurrences="2" x-content="τοῖς"
+\w our|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G39620" x-lemma="πατήρ" x-morph="Gr,N,,,,,DMP," x-occurrence="1" x-occurrences="1" x-content="πατράσιν"
+\w ancestors|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G17220" x-lemma="ἐν" x-morph="Gr,P,,,,,D,,," x-occurrence="1" x-occurrences="1" x-content="ἐν"
+\w through|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | x-lemma="προφήτης" x-morph="Gr,N,,,,,DMP," strong="G43960" x-occurrence="1" x-occurrences="1" x-alignmentIndex="10" x-content="προφήταις"
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w prophets|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G41810" x-lemma="πολυμερῶς" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="πολυμερῶς"
+\w at|x-occurrence="1" x-occurrences="1"\w*
+\w many|x-occurrence="1" x-occurrences="2"\w*
+\w times|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G25320" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="καὶ"
+\w and|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-s | strong="G41870" x-lemma="πολυτρόπως" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="πολυτρόπως"
+\w in|x-occurrence="1" x-occurrences="1"\w*
+\w many|x-occurrence="2" x-occurrences="2"\w*
+\w ways|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*. \v 2 \w But|x-occurrence="1" x-occurrences="1"\w*
+\w in|x-occurrence="1" x-occurrences="1"\w*
+\w these|x-occurrence="1" x-occurrences="1"\w*
+\w last|x-occurrence="1" x-occurrences="1"\w*
+\w days|x-occurrence="1" x-occurrences="1"\w*,\w he|x-occurrence="1" x-occurrences="2"\w*
+\w has|x-occurrence="1" x-occurrences="1"\w*
+\w spoken|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="2"\w*
+\w us|x-occurrence="1" x-occurrences="1"\w*
+\w through|x-occurrence="1" x-occurrences="2"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w Son|x-occurrence="1" x-occurrences="1"\w*,\w whom|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="2" x-occurrences="2"\w*
+\w appointed|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="2" x-occurrences="2"\w*
+\w be|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w heir|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w all|x-occurrence="1" x-occurrences="1"\w*
+\w things|x-occurrence="1" x-occurrences="1"\w*.\w It|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w through|x-occurrence="2" x-occurrences="2"\w*
+\w him|x-occurrence="1" x-occurrences="1"\w*
+\w that|x-occurrence="1" x-occurrences="1"\w*
+\w God|x-occurrence="1" x-occurrences="1"\w*
+\w also|x-occurrence="1" x-occurrences="1"\w*
+\w made|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w universe|x-occurrence="1" x-occurrences="1"\w*. \v 3 \w He|x-occurrence="1" x-occurrences="2"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="5"\w*
+\w brightness|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="4"\w*
+\w God|x-occurrence="1" x-occurrences="1"\w*'\w s|x-occurrence="1" x-occurrences="1"\w*
+\w glory|x-occurrence="1" x-occurrences="1"\w*,\w the|x-occurrence="2" x-occurrences="5"\w*
+\w exact|x-occurrence="1" x-occurrences="1"\w*
+\w representation|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="2" x-occurrences="4"\w*
+\w his|x-occurrence="1" x-occurrences="2"\w*
+\w being|x-occurrence="1" x-occurrences="1"\w*.\w He|x-occurrence="2" x-occurrences="2"\w*
+\w even|x-occurrence="1" x-occurrences="1"\w*
+\w holds|x-occurrence="1" x-occurrences="1"\w*
+\w everything|x-occurrence="1" x-occurrences="1"\w*
+\w together|x-occurrence="1" x-occurrences="1"\w*
+\w by|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="3" x-occurrences="5"\w*
+\w word|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="3" x-occurrences="4"\w*
+\w his|x-occurrence="2" x-occurrences="2"\w*
+\w power|x-occurrence="1" x-occurrences="1"\w*.\w After|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="1" x-occurrences="2"\w*
+\w had|x-occurrence="1" x-occurrences="1"\w*
+\w made|x-occurrence="1" x-occurrences="1"\w*
+\w cleansing|x-occurrence="1" x-occurrences="1"\w*
+\w for|x-occurrence="1" x-occurrences="1"\w*
+\w sins|x-occurrence="1" x-occurrences="1"\w*,\w he|x-occurrence="2" x-occurrences="2"\w*
+\w sat|x-occurrence="1" x-occurrences="1"\w*
+\w down|x-occurrence="1" x-occurrences="1"\w*
+\w at|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="4" x-occurrences="5"\w*
+\w right|x-occurrence="1" x-occurrences="1"\w*
+\w hand|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="4" x-occurrences="4"\w*
+\w the|x-occurrence="5" x-occurrences="5"\w*
+\w Majesty|x-occurrence="1" x-occurrences="1"\w*
+\w on|x-occurrence="1" x-occurrences="1"\w*
+\w high|x-occurrence="1" x-occurrences="1"\w*. \v 4 \w He|x-occurrence="1" x-occurrences="1"\w*
+\w has|x-occurrence="1" x-occurrences="2"\w*
+\w become|x-occurrence="1" x-occurrences="1"\w*
+\w just|x-occurrence="1" x-occurrences="1"\w*
+\w as|x-occurrence="1" x-occurrences="2"\w*
+\w superior|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\w as|x-occurrence="2" x-occurrences="2"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w name|x-occurrence="1" x-occurrences="2"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w has|x-occurrence="2" x-occurrences="2"\w*
+\w inherited|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w more|x-occurrence="1" x-occurrences="1"\w*
+\w excellent|x-occurrence="1" x-occurrences="1"\w*
+\w than|x-occurrence="1" x-occurrences="1"\w*
+\w their|x-occurrence="1" x-occurrences="1"\w*
+\w name|x-occurrence="2" x-occurrences="2"\w*. \v 5 \w For|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="4"\w*
+\w which|x-occurrence="1" x-occurrences="2"\w*
+\w of|x-occurrence="1" x-occurrences="2"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w angels|x-occurrence="1" x-occurrences="2"\w*
+\w did|x-occurrence="1" x-occurrences="2"\w*
+\w God|x-occurrence="1" x-occurrences="2"\w*
+\w ever|x-occurrence="1" x-occurrences="2"\w*
+\w say|x-occurrence="1" x-occurrences="2"\w*,"\w You|x-occurrence="1" x-occurrences="1"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\w my|x-occurrence="1" x-occurrences="1"\w*
+\w son|x-occurrence="1" x-occurrences="2"\w*,\w today|x-occurrence="1" x-occurrences="1"\w*
+\w I|x-occurrence="1" x-occurrences="2"\w*
+\w have|x-occurrence="1" x-occurrences="1"\w*
+\w become|x-occurrence="1" x-occurrences="1"\w*
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\w father|x-occurrence="1" x-occurrences="2"\w*"?\w Or|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="2" x-occurrences="4"\w*
+\w which|x-occurrence="2" x-occurrences="2"\w*
+\w of|x-occurrence="2" x-occurrences="2"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w angels|x-occurrence="2" x-occurrences="2"\w*
+\w did|x-occurrence="2" x-occurrences="2"\w*
+\w God|x-occurrence="2" x-occurrences="2"\w*
+\w ever|x-occurrence="2" x-occurrences="2"\w*
+\w say|x-occurrence="2" x-occurrences="2"\w*,"\w I|x-occurrence="2" x-occurrences="2"\w*
+\w will|x-occurrence="1" x-occurrences="2"\w*
+\w be|x-occurrence="1" x-occurrences="2"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w father|x-occurrence="2" x-occurrences="2"\w*
+\w to|x-occurrence="3" x-occurrences="4"\w*
+\w him|x-occurrence="1" x-occurrences="1"\w*,\w and|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="2" x-occurrences="2"\w*
+\w be|x-occurrence="2" x-occurrences="2"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w son|x-occurrence="2" x-occurrences="2"\w*
+\w to|x-occurrence="4" x-occurrences="4"\w*
+\w me|x-occurrence="1" x-occurrences="1"\w*"? \v 6 \w But|x-occurrence="1" x-occurrences="1"\w*
+\w again|x-occurrence="1" x-occurrences="1"\w*,\w when|x-occurrence="1" x-occurrences="1"\w*
+\w God|x-occurrence="1" x-occurrences="2"\w*
+\w brings|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w firstborn|x-occurrence="1" x-occurrences="1"\w*
+\w into|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w world|x-occurrence="1" x-occurrences="1"\w*,\w he|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*,"\w All|x-occurrence="1" x-occurrences="1"\w*
+\w God|x-occurrence="2" x-occurrences="2"\w*'\w s|x-occurrence="1" x-occurrences="1"\w*
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\w must|x-occurrence="1" x-occurrences="1"\w*
+\w worship|x-occurrence="1" x-occurrences="1"\w*
+\w him|x-occurrence="1" x-occurrences="1"\w*." \v 7 \w About|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w angels|x-occurrence="1" x-occurrences="2"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*,"\w He|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w one|x-occurrence="1" x-occurrences="1"\w*
+\w who|x-occurrence="1" x-occurrences="1"\w*
+\w makes|x-occurrence="1" x-occurrences="1"\w*
+\w his|x-occurrence="1" x-occurrences="2"\w*
+\w angels|x-occurrence="2" x-occurrences="2"\w*
+\w spirits|x-occurrence="1" x-occurrences="1"\w*,\w and|x-occurrence="1" x-occurrences="1"\w*
+\w his|x-occurrence="2" x-occurrences="2"\w*
+\w servants|x-occurrence="1" x-occurrences="1"\w*
+\w flames|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w fire|x-occurrence="1" x-occurrences="1"\w*." \v 8 \w But|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="2"\w*
+\w Son|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*,"\w Your|x-occurrence="1" x-occurrences="1"\w*
+\w throne|x-occurrence="1" x-occurrences="1"\w*,\w God|x-occurrence="1" x-occurrences="1"\w*,\w is|x-occurrence="1" x-occurrences="2"\w*
+\w forever|x-occurrence="1" x-occurrences="1"\w*
+\w and|x-occurrence="1" x-occurrences="1"\w*
+\w ever|x-occurrence="1" x-occurrences="1"\w*.\w The|x-occurrence="1" x-occurrences="1"\w*
+\w scepter|x-occurrence="1" x-occurrences="2"\w*
+\w of|x-occurrence="1" x-occurrences="2"\w*
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\w kingdom|x-occurrence="1" x-occurrences="1"\w*
+\w is|x-occurrence="2" x-occurrences="2"\w*
+\w the|x-occurrence="2" x-occurrences="2"\w*
+\w scepter|x-occurrence="2" x-occurrences="2"\w*
+\w of|x-occurrence="2" x-occurrences="2"\w*
+\w justice|x-occurrence="1" x-occurrences="1"\w*. \v 9 \w You|x-occurrence="1" x-occurrences="1"\w*
+\w have|x-occurrence="1" x-occurrences="1"\w*
+\w loved|x-occurrence="1" x-occurrences="1"\w*
+\w righteousness|x-occurrence="1" x-occurrences="1"\w*
+\w and|x-occurrence="1" x-occurrences="1"\w*
+\w hated|x-occurrence="1" x-occurrences="1"\w*
+\w lawlessness|x-occurrence="1" x-occurrences="1"\w*.\w Therefore|x-occurrence="1" x-occurrences="1"\w*
+\w God|x-occurrence="1" x-occurrences="2"\w*,\w your|x-occurrence="1" x-occurrences="2"\w*
+\w God|x-occurrence="2" x-occurrences="2"\w*,\w has|x-occurrence="1" x-occurrences="1"\w*
+\w anointed|x-occurrence="1" x-occurrences="1"\w*
+\w you|x-occurrence="1" x-occurrences="1"\w*
+\w with|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w oil|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w joy|x-occurrence="1" x-occurrences="1"\w*
+\w more|x-occurrence="1" x-occurrences="1"\w*
+\w than|x-occurrence="1" x-occurrences="1"\w*
+\w your|x-occurrence="2" x-occurrences="2"\w*
+\w companions|x-occurrence="1" x-occurrences="1"\w*." \v 10 "\w In|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="3"\w*
+\w beginning|x-occurrence="1" x-occurrences="1"\w*,\w Lord|x-occurrence="1" x-occurrences="1"\w*,\w you|x-occurrence="1" x-occurrences="1"\w*
+\w laid|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="2" x-occurrences="3"\w*
+\w earth|x-occurrence="1" x-occurrences="1"\w*'\w s|x-occurrence="1" x-occurrences="1"\w*
+\w foundation|x-occurrence="1" x-occurrences="1"\w*.\w The|x-occurrence="1" x-occurrences="1"\w*
+\w heavens|x-occurrence="1" x-occurrences="1"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="3" x-occurrences="3"\w*
+\w work|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\w hands|x-occurrence="1" x-occurrences="1"\w*. \v 11 \w They|x-occurrence="1" x-occurrences="2"\w*
+\w will|x-occurrence="1" x-occurrences="3"\w*
+\w perish|x-occurrence="1" x-occurrences="1"\w*,\w but|x-occurrence="1" x-occurrences="1"\w*
+\w you|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="2" x-occurrences="3"\w*
+\w continue|x-occurrence="1" x-occurrences="1"\w*.\w They|x-occurrence="2" x-occurrences="2"\w*
+\w will|x-occurrence="3" x-occurrences="3"\w*
+\w all|x-occurrence="1" x-occurrences="1"\w*
+\w wear|x-occurrence="1" x-occurrences="1"\w*
+\w out|x-occurrence="1" x-occurrences="1"\w*
+\w like|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w piece|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w clothing|x-occurrence="1" x-occurrences="1"\w*. \v 12 \w You|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="1" x-occurrences="2"\w*
+\w roll|x-occurrence="1" x-occurrences="1"\w*
+\w them|x-occurrence="1" x-occurrences="1"\w*
+\w up|x-occurrence="1" x-occurrences="1"\w*
+\w like|x-occurrence="1" x-occurrences="2"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w cloak|x-occurrence="1" x-occurrences="1"\w*,\w and|x-occurrence="1" x-occurrences="2"\w*
+\w they|x-occurrence="1" x-occurrences="1"\w*
+\w will|x-occurrence="2" x-occurrences="2"\w*
+\w be|x-occurrence="1" x-occurrences="1"\w*
+\w changed|x-occurrence="1" x-occurrences="1"\w*
+\w like|x-occurrence="2" x-occurrences="2"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w piece|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w clothing|x-occurrence="1" x-occurrences="1"\w*.\w But|x-occurrence="1" x-occurrences="1"\w*
+\w you|x-occurrence="1" x-occurrences="1"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w same|x-occurrence="1" x-occurrences="1"\w*,\w and|x-occurrence="2" x-occurrences="2"\w*
+\w your|x-occurrence="1" x-occurrences="1"\w*
+\w years|x-occurrence="1" x-occurrences="1"\w*
+\w do|x-occurrence="1" x-occurrences="1"\w*
+\w not|x-occurrence="1" x-occurrences="1"\w*
+\w end|x-occurrence="1" x-occurrences="1"\w*." \v 13 \w But|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="1"\w*
+\w which|x-occurrence="1" x-occurrences="1"\w*
+\w of|x-occurrence="1" x-occurrences="1"\w*
+\w the|x-occurrence="1" x-occurrences="1"\w*
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\w has|x-occurrence="1" x-occurrences="1"\w*
+\w God|x-occurrence="1" x-occurrences="1"\w*
+\w said|x-occurrence="1" x-occurrences="1"\w*
+\w at|x-occurrence="1" x-occurrences="2"\w*
+\w any|x-occurrence="1" x-occurrences="1"\w*
+\w time|x-occurrence="1" x-occurrences="1"\w*,"\w Sit|x-occurrence="1" x-occurrences="1"\w*
+\w at|x-occurrence="2" x-occurrences="2"\w*
+\w my|x-occurrence="1" x-occurrences="1"\w*
+\w right|x-occurrence="1" x-occurrences="1"\w*
+\w hand|x-occurrence="1" x-occurrences="1"\w*
+\w until|x-occurrence="1" x-occurrences="1"\w*
+\w I|x-occurrence="1" x-occurrences="1"\w*
+\w make|x-occurrence="1" x-occurrences="1"\w*
+\w your|x-occurrence="1" x-occurrences="2"\w*
+\w enemies|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w stool|x-occurrence="1" x-occurrences="1"\w*
+\w for|x-occurrence="1" x-occurrences="1"\w*
+\w your|x-occurrence="2" x-occurrences="2"\w*
+\w feet|x-occurrence="1" x-occurrences="1"\w*"? \v 14 \w Are|x-occurrence="1" x-occurrences="1"\w*
+\w not|x-occurrence="1" x-occurrences="1"\w*
+\w all|x-occurrence="1" x-occurrences="1"\w*
+\w angels|x-occurrence="1" x-occurrences="1"\w*
+\w spirits|x-occurrence="1" x-occurrences="1"\w*
+\w who|x-occurrence="1" x-occurrences="3"\w*
+\w serve|x-occurrence="1" x-occurrences="1"\w*,\w and|x-occurrence="1" x-occurrences="1"\w*
+\w who|x-occurrence="2" x-occurrences="3"\w*
+\w are|x-occurrence="1" x-occurrences="1"\w*
+\w sent|x-occurrence="1" x-occurrences="1"\w*
+\w to|x-occurrence="1" x-occurrences="1"\w*
+\w care|x-occurrence="1" x-occurrences="1"\w*
+\w for|x-occurrence="1" x-occurrences="1"\w*
+\w those|x-occurrence="1" x-occurrences="1"\w*
+\w who|x-occurrence="3" x-occurrences="3"\w*
+\w will|x-occurrence="1" x-occurrences="1"\w*
+\w inherit|x-occurrence="1" x-occurrences="1"\w*
+\w salvation|x-occurrence="1" x-occurrences="1"\w*?

--- a/__tests__/fixtures/project/alignmentUsfmImport/59-HEB.usfm
+++ b/__tests__/fixtures/project/alignmentUsfmImport/59-HEB.usfm
@@ -1,12 +1,14 @@
-\id HEB EN_ULB en_English_ltr Wed Feb 07 2018 14:30:14 GMT-0500 (EST) tc
+\id HEB EN_ULB en_English_ltr Wed Feb 07 2018 19:07:07 GMT-0500 (EST) tc
 \h Hebrews
 \c 1
 \v 1 \k-s | strong="G38190" x-lemma="πάλαι" x-morph="Gr,D,,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="πάλαι"
 \w Long|x-occurrence="1" x-occurrences="1"\w*
 \w ago|x-occurrence="1" x-occurrences="1"\w*
 \k-e\*
+\k-s | strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="ὁ"
 \k-s | strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="Θεὸς"
 \w God|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
 \k-e\*
 \k-s | strong="G29800" x-lemma="λαλέω" x-morph="Gr,V,PAA,NMS," x-occurrence="1" x-occurrences="1" x-content="λαλήσας"
 \w spoke|x-occurrence="1" x-occurrences="1"\w*
@@ -15,11 +17,13 @@
 \k-s | strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,DMP," x-occurrence="1" x-occurrences="2" x-content="τοῖς"
 \w our|x-occurrence="1" x-occurrences="1"\w*
 \k-e\*
+\k-s | strong="G35880" x-lemma="ὁ" x-morph="Gr,EA,,,,DMP," x-occurrence="2" x-occurrences="2" x-content="τοῖς"
 \k-s | strong="G39620" x-lemma="πατήρ" x-morph="Gr,N,,,,,DMP," x-occurrence="1" x-occurrences="1" x-content="πατράσιν"
-\w ancestors|x-occurrence="1" x-occurrences="1"\w*
-\k-e\*
 \k-s | strong="G17220" x-lemma="ἐν" x-morph="Gr,P,,,,,D,,," x-occurrence="1" x-occurrences="1" x-content="ἐν"
+\w ancestors|x-occurrence="1" x-occurrences="1"\w*
 \w through|x-occurrence="1" x-occurrences="1"\w*
+\k-e\*
+\k-e\*
 \k-e\*
 \k-s | x-lemma="προφήτης" x-morph="Gr,N,,,,,DMP," strong="G43960" x-occurrence="1" x-occurrences="1" x-alignmentIndex="10" x-content="προφήταις"
 \w the|x-occurrence="1" x-occurrences="1"\w*
@@ -133,7 +137,7 @@
 \w did|x-occurrence="1" x-occurrences="2"\w*
 \w God|x-occurrence="1" x-occurrences="2"\w*
 \w ever|x-occurrence="1" x-occurrences="2"\w*
-\w say|x-occurrence="1" x-occurrences="2"\w*,"\w You|x-occurrence="1" x-occurrences="1"\w*
+\w say|x-occurrence="1" x-occurrences="2"\w*, "\w You|x-occurrence="1" x-occurrences="1"\w*
 \w are|x-occurrence="1" x-occurrences="1"\w*
 \w my|x-occurrence="1" x-occurrences="1"\w*
 \w son|x-occurrence="1" x-occurrences="2"\w*,\w today|x-occurrence="1" x-occurrences="1"\w*
@@ -150,7 +154,7 @@
 \w did|x-occurrence="2" x-occurrences="2"\w*
 \w God|x-occurrence="2" x-occurrences="2"\w*
 \w ever|x-occurrence="2" x-occurrences="2"\w*
-\w say|x-occurrence="2" x-occurrences="2"\w*,"\w I|x-occurrence="2" x-occurrences="2"\w*
+\w say|x-occurrence="2" x-occurrences="2"\w*, "\w I|x-occurrence="2" x-occurrences="2"\w*
 \w will|x-occurrence="1" x-occurrences="2"\w*
 \w be|x-occurrence="1" x-occurrences="2"\w*
 \w a|x-occurrence="1" x-occurrences="2"\w*
@@ -172,7 +176,7 @@
 \w into|x-occurrence="1" x-occurrences="1"\w*
 \w the|x-occurrence="2" x-occurrences="2"\w*
 \w world|x-occurrence="1" x-occurrences="1"\w*,\w he|x-occurrence="1" x-occurrences="1"\w*
-\w says|x-occurrence="1" x-occurrences="1"\w*,"\w All|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*, "\w All|x-occurrence="1" x-occurrences="1"\w*
 \w God|x-occurrence="2" x-occurrences="2"\w*'\w s|x-occurrence="1" x-occurrences="1"\w*
 \w angels|x-occurrence="1" x-occurrences="1"\w*
 \w must|x-occurrence="1" x-occurrences="1"\w*
@@ -181,7 +185,7 @@
 \w the|x-occurrence="1" x-occurrences="2"\w*
 \w angels|x-occurrence="1" x-occurrences="2"\w*
 \w he|x-occurrence="1" x-occurrences="1"\w*
-\w says|x-occurrence="1" x-occurrences="1"\w*,"\w He|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*, "\w He|x-occurrence="1" x-occurrences="1"\w*
 \w is|x-occurrence="1" x-occurrences="1"\w*
 \w the|x-occurrence="2" x-occurrences="2"\w*
 \w one|x-occurrence="1" x-occurrences="1"\w*
@@ -199,7 +203,7 @@
 \w the|x-occurrence="1" x-occurrences="2"\w*
 \w Son|x-occurrence="1" x-occurrences="1"\w*
 \w he|x-occurrence="1" x-occurrences="1"\w*
-\w says|x-occurrence="1" x-occurrences="1"\w*,"\w Your|x-occurrence="1" x-occurrences="1"\w*
+\w says|x-occurrence="1" x-occurrences="1"\w*, "\w Your|x-occurrence="1" x-occurrences="1"\w*
 \w throne|x-occurrence="1" x-occurrences="1"\w*,\w God|x-occurrence="1" x-occurrences="1"\w*,\w is|x-occurrence="1" x-occurrences="2"\w*
 \w forever|x-occurrence="1" x-occurrences="1"\w*
 \w and|x-occurrence="1" x-occurrences="1"\w*
@@ -294,7 +298,7 @@
 \w said|x-occurrence="1" x-occurrences="1"\w*
 \w at|x-occurrence="1" x-occurrences="2"\w*
 \w any|x-occurrence="1" x-occurrences="1"\w*
-\w time|x-occurrence="1" x-occurrences="1"\w*,"\w Sit|x-occurrence="1" x-occurrences="1"\w*
+\w time|x-occurrence="1" x-occurrences="1"\w*, "\w Sit|x-occurrence="1" x-occurrences="1"\w*
 \w at|x-occurrence="2" x-occurrences="2"\w*
 \w my|x-occurrence="1" x-occurrences="1"\w*
 \w right|x-occurrence="1" x-occurrences="1"\w*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15483,9 +15483,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.22.tgz",
-      "integrity": "sha512-9R3wTZncSYmbmReobYPdIp/XGeFgtfXFgTKxQJ78nrAdIieTFkY9Qi8TgEs7utMqwVi9r8lYQv69MXsHV1aqxw==",
+      "version": "1.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.24.tgz",
+      "integrity": "sha512-bCDDujiVoPOvIXXxC2+gdeVcsobro3k0U8UKLcnKuTN5AZI9jtc86Ju2GccII6bWxj71w3EDLrQ/tDe84PmEqA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "simple-git": "1.43.0",
     "sudo-prompt": "6.2.1",
     "truncate-utf8-bytes": "1.0.2",
-    "usfm-js": "1.0.0-beta.22",
+    "usfm-js": "1.0.0-beta.24",
     "xregexp": "3.2.0",
     "yamljs": "0.3.0",
     "zip-folder": "1.0.0"

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -152,21 +152,29 @@ let parseMilestone = function (verseObject) {
  */
 export const getUsfmForVerseContent = (verseData) => {
   if (verseData.verseObjects) {
-    let lastObject = {};
+    let wordSpacing = '';
     verseData.verseObjects = verseData.verseObjects.map(verseObject => {
       let text = '';
       if (verseObject.type === 'word') {
-        text = (lastObject.text ? ' ': '') + verseObject.text;
+        text = wordSpacing + verseObject.text;
       } else if (verseObject.type === 'milestone') {
-        text = (lastObject.text ? ' ': '') + parseMilestone(verseObject);
+        text = wordSpacing + parseMilestone(verseObject);
       }
       if (text) { // replace with text object
         verseObject = {
           type: "text",
           text
         };
+        wordSpacing = ' ';
+      } else {
+        wordSpacing = ' ';
+        if (verseObject.type === 'text') {
+          const lastChar = verseObject.text.substr(-1);
+          if ((lastChar === "'") || (lastChar === '"')) { // special case: no extra spacing after quotes or apostrophes before words
+            wordSpacing = '';
+          }
+        }
       }
-      lastObject = verseObject;
       return verseObject;
     });
   }

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -133,12 +133,43 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
   });
 };
 
+let parseMilestone = function (verseObject) {
+  let text = "";
+  for (let child of verseObject.children) {
+    if (child.type === 'word') {
+      text += (text ? ' ' : '') + child.text;
+    } else if (child.type === 'milestone') {
+      text += (text ? ' ' : '') + parseMilestone(child);
+    }
+  }
+  return text;
+};
+
 /**
- * @description merge verse data into a string
+ * @description merge verse data into a string - flatten milestones and words and then save as USFM string
  * @param {Object|Array} verseData
  * @return {String}
  */
 export const getUsfmForVerseContent = (verseData) => {
+  if (verseData.verseObjects) {
+    let lastObject = {};
+    verseData.verseObjects = verseData.verseObjects.map(verseObject => {
+      let text = '';
+      if (verseObject.type === 'word') {
+        text = (lastObject.text ? ' ': '') + verseObject.text;
+      } else if (verseObject.type === 'milestone') {
+        text = (lastObject.text ? ' ': '') + parseMilestone(verseObject);
+      }
+      if (text) { // replace with text object
+        verseObject = {
+          type: "text",
+          text
+        };
+      }
+      lastObject = verseObject;
+      return verseObject;
+    });
+  }
   const outputData = {
     "chapters": {},
     "headers": [],

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -58,14 +58,16 @@ export const wordObjectArrayFromString = (string) => {
 /**
  * @description sorts wordObjectArray via string
  * @param {Array} wordObjectArray - array of wordObjects
- * @param {String|Array} stringData - The string to search in
+ * @param {String|Array|Object} stringData - The string to search in
  * @returns {Array} - sorted array of wordObjects
  */
 export const sortWordObjectsByString = (wordObjectArray, stringData) => {
-  if (stringData.constructor !== Array) {
-    stringData = wordObjectArrayFromString(stringData);
-  } else {
+  if (stringData.verseObjects) {
+    stringData = populateOccurrencesInWordObjects(stringData.verseObjects);
+  } else if (Array.isArray(stringData)) {
     stringData = populateOccurrencesInWordObjects(stringData);
+  } else {
+    stringData = wordObjectArrayFromString(stringData);
   }
   let _wordObjectArray = wordObjectArray.map((wordObject) => {
     const { word, occurrence, occurrences } = wordObject;
@@ -149,7 +151,7 @@ export const getAlignmentDataFromPath = (wordAlignmentDataPath, projectTargetLan
 
 /**
  * Method to set a key value in the usfm json object to easily account for missing keys
- * 
+ *
  * @param {object} usfmToJSONObject - Object of all verse object to be converted by usfm-jd library
  * @param {string} chapterNumber - Current chapter number key value
  * @param {string} verseNumber Current verse number key value
@@ -164,7 +166,7 @@ export const setVerseObjectsInAlignmentJSON = (usfmToJSONObject, chapterNumber, 
 
 /**
  * Wrapper for writing to the fs.
- * 
+ *
  * @param {string} usfm - Usfm data to be written to FS
  * @param {string} projectSaveLocation - Location of usfm to be written
  */
@@ -173,10 +175,10 @@ export const writeToFS = (exportFilePath, usfm) => {
 };
 
 /**
- * Gets the project name for an aligment export based on the 
+ * Gets the project name for an aligment export based on the
  * door43 standards.
- * 
- * @param {object} manifest 
+ *
+ * @param {object} manifest
  * @returns {string}
  */
 export function getProjectAlignmentName(manifest) {
@@ -189,7 +191,7 @@ export function getProjectAlignmentName(manifest) {
 
 /**
  * Method to retreive project alignment data and perform conversion in usfm 3
- * 
+ *
  * @param {string} projectSaveLocation - Full path to the users project to be exported
  * @returns {Promise}
  */


### PR DESCRIPTION
#### This pull request addresses:

Fixes issues with importing USFM3 alignment data:
- milestone markers were being shown in SP (words and milestones are now flattened before being saved).
- nested milestones were broken.

Greek word merging was broken.


#### How to test this pull request:

Depends on https://github.com/translationCoreApps/usfm-js/pull/30

do 'npm i'

After importing USFM3 alignment, should not see milestone markers in SP in WA.
Should be able to merge greek words.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3754)
<!-- Reviewable:end -->
