### PR TITLE
Bugfix #3757/Splitting Greek Words messes up word order.

### DIFF
--- a/__tests__/WordAlignmentActions.test.js
+++ b/__tests__/WordAlignmentActions.test.js
@@ -10,12 +10,13 @@ describe('WordAlignmentActions.unmergeAlignments', () => {
   it('should reorder unordered greek', () => {
     const testPath = '__tests__/fixtures/splitWords/heb1:1_outOfOrder.json';
     const testData = fs.readJSONSync(testPath);
-    const fromAlignmentIndex = 8;
+    const fromAlignmentIndex = 7;
     const alignmentsInitial = JSON.parse(JSON.stringify(testData.alignmentsInitial));
 
     const { alignments, wordBank } = WordAlignmentActions.unmergeAlignments(
       testData.removeItem, alignmentsInitial, testData.wordBank, fromAlignmentIndex, testData.greek, testData.verseString
     );
     expect(alignments).toEqual(testData.alignmentsFinal);
+    expect(wordBank.length).toEqual(2);
   });
 });

--- a/__tests__/WordAlignmentActions.test.js
+++ b/__tests__/WordAlignmentActions.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import fs from 'fs-extra';
+//actions
+import * as WordAlignmentActions from '../src/js/actions/WordAlignmentActions';
+jest.unmock('fs-extra');
+
+
+describe('WordAlignmentActions.unmergeAlignments', () => {
+
+  it('should reorder unordered greek', () => {
+    const testPath = '__tests__/fixtures/splitWords/heb1:1_outOfOrder.json';
+    const testData = fs.readJSONSync(testPath);
+    const fromAlignmentIndex = 8;
+    const alignmentsInitial = JSON.parse(JSON.stringify(testData.alignmentsInitial));
+
+    const { alignments, wordBank } = WordAlignmentActions.unmergeAlignments(
+      testData.removeItem, alignmentsInitial, testData.wordBank, fromAlignmentIndex, testData.greek, testData.verseString
+    );
+    expect(alignments).toEqual(testData.alignmentsFinal);
+  });
+});

--- a/__tests__/fixtures/splitWords/heb1:1_outOfOrder.json
+++ b/__tests__/fixtures/splitWords/heb1:1_outOfOrder.json
@@ -1,0 +1,533 @@
+{
+  "verseString": "Long ago God spoke to our ancestors through the prophets at many times and in many ways.",
+  "removeItem": {
+    "word": "πατράσιν",
+    "lemma": "πατήρ",
+    "morph": "Gr,N,,,,,DMP,",
+    "strong": "G39620",
+    "occurrence": 1,
+    "occurrences": 1
+  },
+  "alignmentsInitial": [
+    {
+      "topWords": [
+        {
+          "word": "τοῖς",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "strong": "G35880",
+          "occurrence": 2,
+          "occurrences": 2,
+          "alignmentIndex": 9,
+          "type": "topWord"
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πολυμερῶς",
+          "strong": "G41810",
+          "lemma": "πολυμερῶς",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strong": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πολυτρόπως",
+          "strong": "G41870",
+          "lemma": "πολυτρόπως",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πάλαι",
+          "strong": "G38190",
+          "lemma": "πάλαι",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὁ",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεὸς",
+          "strong": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "λαλήσας",
+          "strong": "G29800",
+          "lemma": "λαλέω",
+          "morph": "Gr,V,PAA,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "τοῖς",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 2
+        },
+        {
+          "word": "πατράσιν",
+          "lemma": "πατήρ",
+          "morph": "Gr,N,,,,,DMP,",
+          "strong": "G39620",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "topWord"
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "προφήταις",
+          "strong": "G43960",
+          "lemma": "προφήτης",
+          "morph": "Gr,N,,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    }
+  ],
+  "alignmentsFinal": [
+    {
+      "topWords": [
+        {
+          "word": "πολυμερῶς",
+          "strong": "G41810",
+          "lemma": "πολυμερῶς",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strong": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πολυτρόπως",
+          "strong": "G41870",
+          "lemma": "πολυτρόπως",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πάλαι",
+          "strong": "G38190",
+          "lemma": "πάλαι",
+          "morph": "Gr,D,,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "ὁ",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεὸς",
+          "strong": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "λαλήσας",
+          "strong": "G29800",
+          "lemma": "λαλέω",
+          "morph": "Gr,V,PAA,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "τοῖς",
+          "strong": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "πατράσιν",
+          "lemma": "πατήρ",
+          "morph": "Gr,N,,,,,DMP,",
+          "strong": "G39620",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐν",
+          "strong": "G17220",
+          "lemma": "ἐν",
+          "morph": "Gr,P,,,,,D,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "τοῖς",
+          "lemma": "ὁ",
+          "morph": "Gr,EA,,,,DMP,",
+          "strong": "G35880",
+          "occurrence": 2,
+          "occurrences": 2,
+          "alignmentIndex": 9,
+          "type": "topWord"
+        }
+      ],
+      "bottomWords": []
+    },
+    {
+      "topWords": [
+        {
+          "word": "προφήταις",
+          "strong": "G43960",
+          "lemma": "προφήτης",
+          "morph": "Gr,N,,,,,DMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": []
+    }
+  ],
+  "greek": [
+    {
+      "type": "text",
+      "text": "\n"
+    },
+    {
+      "tag": "p",
+      "type": "paragraph",
+      "text": "\n"
+    },
+    {
+      "text": "πολυμερῶς",
+      "tag": "w",
+      "type": "word",
+      "lemma": "πολυμερῶς",
+      "strong": "G41810",
+      "morph": "Gr,D,,,,,,,,,"
+    },
+    {
+      "text": "καὶ",
+      "tag": "w",
+      "type": "word",
+      "lemma": "καί",
+      "strong": "G25320",
+      "morph": "Gr,CC,,,,,,,,"
+    },
+    {
+      "text": "πολυτρόπως",
+      "tag": "w",
+      "type": "word",
+      "lemma": "πολυτρόπως",
+      "strong": "G41870",
+      "morph": "Gr,D,,,,,,,,,"
+    },
+    {
+      "text": "πάλαι",
+      "tag": "w",
+      "type": "word",
+      "lemma": "πάλαι",
+      "strong": "G38190",
+      "morph": "Gr,D,,,,,,,,,"
+    },
+    {
+      "type": "text",
+      "text": ",\n"
+    },
+    {
+      "text": "ὁ",
+      "tag": "w",
+      "type": "word",
+      "lemma": "ὁ",
+      "strong": "G35880",
+      "morph": "Gr,EA,,,,NMS,"
+    },
+    {
+      "text": "Θεὸς",
+      "tag": "w",
+      "type": "word",
+      "lemma": "θεός",
+      "strong": "G23160",
+      "morph": "Gr,N,,,,,NMS,"
+    },
+    {
+      "type": "text",
+      "text": ",\n"
+    },
+    {
+      "text": "λαλήσας",
+      "tag": "w",
+      "type": "word",
+      "lemma": "λαλέω",
+      "strong": "G29800",
+      "morph": "Gr,V,PAA,NMS,"
+    },
+    {
+      "text": "τοῖς",
+      "tag": "w",
+      "type": "word",
+      "lemma": "ὁ",
+      "strong": "G35880",
+      "morph": "Gr,EA,,,,DMP,"
+    },
+    {
+      "text": "πατράσιν",
+      "tag": "w",
+      "type": "word",
+      "lemma": "πατήρ",
+      "strong": "G39620",
+      "morph": "Gr,N,,,,,DMP,"
+    },
+    {
+      "text": "ἐν",
+      "tag": "w",
+      "type": "word",
+      "lemma": "ἐν",
+      "strong": "G17220",
+      "morph": "Gr,P,,,,,D,,,"
+    },
+    {
+      "text": "τοῖς",
+      "tag": "w",
+      "type": "word",
+      "lemma": "ὁ",
+      "strong": "G35880",
+      "morph": "Gr,EA,,,,DMP,"
+    },
+    {
+      "text": "προφήταις",
+      "tag": "w",
+      "type": "word",
+      "lemma": "προφήτης",
+      "strong": "G43960",
+      "morph": "Gr,N,,,,,DMP,"
+    },
+    {
+      "type": "text",
+      "text": "\n"
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "Long",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "ago",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "spoke",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "to",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "our",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "ancestors",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "through",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "prophets",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "at",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "many",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "times",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "in",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "many",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "ways",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/__tests__/fixtures/splitWords/heb1:1_outOfOrder.json
+++ b/__tests__/fixtures/splitWords/heb1:1_outOfOrder.json
@@ -9,22 +9,59 @@
     "occurrences": 1
   },
   "alignmentsInitial": [
-    {
-      "topWords": [
-        {
-          "word": "τοῖς",
-          "lemma": "ὁ",
-          "morph": "Gr,EA,,,,DMP,",
-          "strong": "G35880",
-          "occurrence": 2,
-          "occurrences": 2,
-          "alignmentIndex": 9,
-          "type": "topWord"
-        }
-      ],
-      "bottomWords": []
-    },
-    {
+      {
+        "topWords": [
+          {
+            "word": "ἐν",
+            "strong": "G17220",
+            "lemma": "ἐν",
+            "morph": "Gr,P,,,,,D,,,",
+            "occurrence": 1,
+            "occurrences": 1
+          },
+          {
+            "word": "τοῖς",
+            "lemma": "ὁ",
+            "morph": "Gr,EA,,,,DMP,",
+            "strong": "G35880",
+            "occurrence": 2,
+            "occurrences": 2,
+            "alignmentIndex": 9,
+            "type": "topWord"
+          },
+          {
+            "word": "προφήταις",
+            "lemma": "προφήτης",
+            "morph": "Gr,N,,,,,DMP,",
+            "strong": "G43960",
+            "occurrence": 1,
+            "occurrences": 1,
+            "alignmentIndex": 8,
+            "type": "topWord"
+          }
+        ],
+        "bottomWords": [
+          {
+            "word": "through",
+            "occurrence": 1,
+            "occurrences": 1,
+            "type": "bottomWord"
+          },
+          {
+            "word": "the",
+            "occurrence": 1,
+            "occurrences": 1,
+            "type": "bottomWord"
+          },
+          {
+            "word": "prophets",
+            "occurrence": 1,
+            "occurrences": 1,
+            "type": "bottomWord"
+          }
+        ]
+      },
+      {
       "topWords": [
         {
           "word": "πολυμερῶς",
@@ -35,7 +72,26 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "at",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "many",
+          "occurrence": 1,
+          "occurrences": 2,
+          "type": "bottomWord"
+        },
+        {
+          "word": "times",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -48,7 +104,14 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "and",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -61,7 +124,26 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "many",
+          "occurrence": 2,
+          "occurrences": 2,
+          "type": "bottomWord"
+        },
+        {
+          "word": "ways",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -74,7 +156,20 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "Long",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "ago",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -85,12 +180,7 @@
           "morph": "Gr,EA,,,,NMS,",
           "occurrence": 1,
           "occurrences": 1
-        }
-      ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+        },
         {
           "word": "Θεὸς",
           "strong": "G23160",
@@ -100,7 +190,14 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "God",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -113,7 +210,20 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "spoke",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "to",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -132,36 +242,24 @@
           "strong": "G39620",
           "occurrence": 1,
           "occurrences": 1,
+          "alignmentIndex": 6,
           "type": "topWord"
         }
       ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+      "bottomWords": [
         {
-          "word": "ἐν",
-          "strong": "G17220",
-          "lemma": "ἐν",
-          "morph": "Gr,P,,,,,D,,,",
+          "word": "our",
           "occurrence": 1,
-          "occurrences": 1
-        }
-      ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
         {
-          "word": "προφήταις",
-          "strong": "G43960",
-          "lemma": "προφήτης",
-          "morph": "Gr,N,,,,,DMP,",
+          "word": "ancestors",
           "occurrence": 1,
-          "occurrences": 1
+          "occurrences": 1,
+          "type": "bottomWord"
         }
-      ],
-      "bottomWords": []
+      ]
     }
   ],
   "alignmentsFinal": [
@@ -176,7 +274,26 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "at",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "many",
+          "occurrence": 1,
+          "occurrences": 2,
+          "type": "bottomWord"
+        },
+        {
+          "word": "times",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -189,7 +306,14 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "and",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -202,7 +326,26 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "in",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "many",
+          "occurrence": 2,
+          "occurrences": 2,
+          "type": "bottomWord"
+        },
+        {
+          "word": "ways",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -215,7 +358,20 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "Long",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "ago",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -226,12 +382,7 @@
           "morph": "Gr,EA,,,,NMS,",
           "occurrence": 1,
           "occurrences": 1
-        }
-      ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+        },
         {
           "word": "Θεὸς",
           "strong": "G23160",
@@ -241,7 +392,14 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "God",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -254,7 +412,20 @@
           "occurrences": 1
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "spoke",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "to",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     },
     {
       "topWords": [
@@ -291,12 +462,7 @@
           "morph": "Gr,P,,,,,D,,,",
           "occurrence": 1,
           "occurrences": 1
-        }
-      ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+        },
         {
           "word": "τοῖς",
           "lemma": "ὁ",
@@ -306,22 +472,38 @@
           "occurrences": 2,
           "alignmentIndex": 9,
           "type": "topWord"
-        }
-      ],
-      "bottomWords": []
-    },
-    {
-      "topWords": [
+        },
         {
           "word": "προφήταις",
-          "strong": "G43960",
           "lemma": "προφήτης",
           "morph": "Gr,N,,,,,DMP,",
+          "strong": "G43960",
           "occurrence": 1,
-          "occurrences": 1
+          "occurrences": 1,
+          "alignmentIndex": 8,
+          "type": "topWord"
         }
       ],
-      "bottomWords": []
+      "bottomWords": [
+        {
+          "word": "through",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "the",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        },
+        {
+          "word": "prophets",
+          "occurrence": 1,
+          "occurrences": 1,
+          "type": "bottomWord"
+        }
+      ]
     }
   ],
   "greek": [
@@ -443,91 +625,5 @@
       "text": "\n"
     }
   ],
-  "wordBank": [
-    {
-      "word": "Long",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "ago",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "God",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "spoke",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "to",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "our",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "ancestors",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "through",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "the",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "prophets",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "at",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "many",
-      "occurrence": 1,
-      "occurrences": 2
-    },
-    {
-      "word": "times",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "and",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "in",
-      "occurrence": 1,
-      "occurrences": 1
-    },
-    {
-      "word": "many",
-      "occurrence": 2,
-      "occurrences": 2
-    },
-    {
-      "word": "ways",
-      "occurrence": 1,
-      "occurrences": 1
-    }
-  ]
+  "wordBank": []
 }

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -32,10 +32,15 @@ export const getWordText = (wordObject) => {
 
 export const populateOccurrencesInWordObjects = (wordObjects) => {
   const string = combineGreekVerse(wordObjects);
-  return wordObjects.map((wordObject, index) => {
-    wordObject.occurrence = stringHelpers.occurrenceInString(string, index, getWordText(wordObject));
-    wordObject.occurrences = stringHelpers.occurrencesInString(string, getWordText(wordObject));
-    return wordObject;
+  let index = 0; // only count verseObject words
+  return wordObjects.map((wordObject) => {
+    const wordText = getWordText(wordObject);
+    if (wordText) { // if verseObject is word
+      wordObject.occurrence = stringHelpers.occurrenceInString(string, index++, wordText);
+      wordObject.occurrences = stringHelpers.occurrencesInString(string, wordText);
+      return wordObject;
+    }
+    return null;
   });
 };
 /**

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -41,8 +41,9 @@ export const populateOccurrencesInWordObjects = (wordObjects) => {
       return wordObject;
     }
     return null;
-  });
+  }).filter(wordObject => (wordObject != null));
 };
+
 /**
  * @description wordObjectArray via string
  * @param {String} string - The string to search in

--- a/src/js/helpers/stringHelpers.js
+++ b/src/js/helpers/stringHelpers.js
@@ -37,9 +37,9 @@ export const tokenizeWithPunctuation = (string) => {
 export const occurrenceInString = (string, currentWordIndex, subString) => {
   let occurrence = 0;
   const tokens = tokenize(string);
-  tokens.forEach((token, index) => {
-    if (index <= currentWordIndex && token === subString) occurrence ++;
-  });
+  for (let i = 0; i <= currentWordIndex; i++) {
+    if (tokens[i] === subString) occurrence ++;
+  }
   return occurrence;
 };
 /**

--- a/src/js/helpers/stringHelpers.js
+++ b/src/js/helpers/stringHelpers.js
@@ -38,7 +38,7 @@ export const occurrenceInString = (string, currentWordIndex, subString) => {
   let occurrence = 0;
   const tokens = tokenize(string);
   tokens.forEach((token, index) => {
-    if (token === subString && index <= currentWordIndex) occurrence ++;
+    if (index <= currentWordIndex && token === subString) occurrence ++;
   });
   return occurrence;
 };


### PR DESCRIPTION
#### This pull request addresses:

Fixes for sorting by greek text data in verseObject format.  

#### How to test this pull request:

Setup for testing:
- depends on WA set to branch: `sandbox-feature-usfm3`
- depends on SP set to this PR: https://github.com/translationCoreApps/ScripturePane/pull/87
- do `npm i`

Steps to produce original issue:
- do USFM import of English Hebrew ULB 59-HEB.usfm (attached to issue)
- open into wordAlignment tool.
- on heb 1:1 drag `πατράσιν` onto `τοῖς` before it
- drag `πατράσιν` to right to separate

Previously, this resulted in an instance of `τοῖς` moved to front of the greek word cards.

But now in wordAlignment, Combining and splitting greek words should not mess up greek word order.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3759)
<!-- Reviewable:end -->
