### PR TITLE
Only adding redux-logger middleware when using `npm run start-with-logger`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3152,6 +3152,12 @@
         }
       }
     },
+    "electron-react-devtools": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/electron-react-devtools/-/electron-react-devtools-0.5.3.tgz",
+      "integrity": "sha1-x07bEkXcHP4TgLkwFs1OtYjtALc=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.31",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
@@ -13229,6 +13235,14 @@
         "warning": "3.0.0"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
+      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
     "react-localize-redux": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/react-localize-redux/-/react-localize-redux-2.14.1.tgz",
@@ -13295,6 +13309,16 @@
         "remarkable": "1.7.1"
       }
     },
+    "react-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.2.0.tgz",
+      "integrity": "sha512-wyU69vL/oRrbWlzWMxWtSzc/9CeRsLcFAN9W+jWH8vO6PTbyn+2AFtbhILmtBsWzwTqt6sqhi/DQL8XkTbn+sQ==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.0",
+        "react-input-autosize": "2.2.1"
+      }
+    },
     "react-spotlight-clickable": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/react-spotlight-clickable/-/react-spotlight-clickable-1.0.5.tgz",
@@ -13320,6 +13344,14 @@
         "fbjs": "0.8.16",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
+      }
+    },
+    "react-toggle": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.0.2.tgz",
+      "integrity": "sha512-EPTWnN7gQHgEAUEmjheanZXNzY5TPnQeyyHfEs3YshaiWZf5WNjfYDrglO5F1Hl/dNveX18i4l0grTEsYH2Ccw==",
+      "requires": {
+        "classnames": "2.2.5"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "src/main.js",
   "scripts": {
     "start": "electron src/main.js",
+    "start-with-logger": "REDUX_LOGGER=true npm run start",
     "update-version": "node ./scripts/versionScript.js",
     "lint": "eslint ./src",
     "test": "eslint ./src && jest",

--- a/src/js/redux/configureStore.js
+++ b/src/js/redux/configureStore.js
@@ -4,16 +4,20 @@ import promise from 'redux-promise';
 import rootReducers from '../reducers/index.js';
 import { createLogger } from 'redux-logger';
 
-//  preloadedState will be used for Data persistence
+let middlewares = [
+  thunkMiddleware,
+  promise
+];
+
+// if REDUX_LOGGER=true add redux-logger to middlewares
+if (process.env.REDUX_LOGGER) {
+  middlewares.push(createLogger());
+}
 
 export default function configureStore(persistedState) {
   return createStore(
     rootReducers,
     persistedState,
-    applyMiddleware(
-      thunkMiddleware,
-      createLogger(),
-      promise
-    )
+    applyMiddleware(...middlewares)
   );
 }


### PR DESCRIPTION
#### This pull request addresses:

- Only adding redux-logger middleware when using `npm run start-with-logger`
- Removes redux-logger from production and npm start
- now only works when running `npm run start-with-logger`

#### How to test this pull request:

- Run `npm run start` and you shouldn't see redux logs in the console.
- Run `npm run start-with-logger` and you should see redux logs in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3760)
<!-- Reviewable:end -->
