### PR TITLE
Reduce Build Size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "7zip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
+      "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA="
+    },
     "@paulcbetts/mime-db": {
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/@paulcbetts/mime-db/-/mime-db-1.22.4.tgz",
@@ -49,11 +54,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
       "integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q==",
       "dev": true
-    },
-    "7zip": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
-      "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA="
     },
     "abab": {
       "version": "1.0.4",
@@ -5011,14 +5011,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5027,6 +5019,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -9029,6 +9029,7 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
       "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -9060,7 +9061,6 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
@@ -9127,6 +9127,24 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -9481,24 +9499,6 @@
               "requires": {
                 "read": "1.0.7"
               }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
             }
           }
         },
@@ -14198,14 +14198,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -14242,6 +14234,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -15246,9 +15246,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.0-beta.24",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.24.tgz",
-      "integrity": "sha512-bCDDujiVoPOvIXXxC2+gdeVcsobro3k0U8UKLcnKuTN5AZI9jtc86Ju2GccII6bWxj71w3EDLrQ/tDe84PmEqA==",
+      "version": "1.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.25.tgz",
+      "integrity": "sha512-i4F/nkvt6GWxbNjpRpp5czejOCepdFwkofyNLH4HoMKXve5GfvYIpxUAP01nReHMxiwA72aD93yy2ka6lSQyew==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "simple-git": "1.43.0",
     "sudo-prompt": "6.2.1",
     "truncate-utf8-bytes": "1.0.2",
-    "usfm-js": "1.0.0-beta.24",
+    "usfm-js": "1.0.0-beta.25",
     "xregexp": "3.2.0",
     "yamljs": "0.3.0",
     "zip-folder": "1.0.0"


### PR DESCRIPTION
#### This pull request addresses:
This PR removes usfm-js __tests__ folder from the build

#### How to test this pull request:
run ```npm run release-osx``` and make sure it builds and the build is ~312MB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3773)
<!-- Reviewable:end -->
