### PR TITLE
Feature #3188/Import Aligned EN ULB into Resources

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -55,14 +55,21 @@ function outputFileSync(filePath, data) {
   mockFS[filePath] = data;
 }
 
+/**
+ * create subdirs and add file name to them
+ * @param filePath
+ */
 function addFileToParentDirectory(filePath) {
   const dir = path.dirname(filePath);
-  if (!mockFS[dir]) {
-    mockFS[dir] = [];
-  }
   const filename = path.basename(filePath);
-  if (mockFS[dir].indexOf(filename) < 0) {
-    mockFS[dir].push(filename);
+  if (filename) {
+    if (!mockFS[dir]) {
+      mockFS[dir] = [];
+      addFileToParentDirectory(dir);
+    }
+    if (mockFS[dir].indexOf(filename) < 0) {
+      mockFS[dir].push(filename);
+    }
   }
 }
 

--- a/__tests__/MissingVerseActions.test.js
+++ b/__tests__/MissingVerseActions.test.js
@@ -40,15 +40,12 @@ describe('MissingVersesActions.onlineImport()', () => {
     // reset mock filesystem data
     fs.__resetMockFS();
     // Set up mocked out filePath and data in mock filesystem before each test
-    fs.__setMockFS({
-      [bibleIndexLocation]: index_json,
-      [importProjectPath]: ['manifest.json'],
-      [path.join(importProjectPath, 'manifest.json')]: manifest_json,
-      [importBookPath]: ['4.json','5.json', 'manifest.json'],
-      [path.join(importBookPath, 'manifest.json')]: manifest_json,
-      [path.join(importBookPath, '4.json')]: ch4_json,
-      [path.join(importBookPath, '5.json')]: ch5_json
-    });
+    fs.__setMockFS({});
+    fs.outputJsonSync(bibleIndexLocation, index_json);
+    fs.outputJsonSync(path.join(importProjectPath, 'manifest.json'), manifest_json);
+    fs.outputJsonSync(path.join(importBookPath, 'manifest.json'), manifest_json);
+    fs.outputJsonSync(path.join(importBookPath, '4.json'), ch4_json);
+    fs.outputJsonSync(path.join(importBookPath, '5.json'), ch5_json);
 
     initialState = {
       projectDetailsReducer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "translationCore",
-  "version": "0.8.1-alpha.15",
+  "version": "0.8.1-alpha.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15246,9 +15246,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.0-beta.24",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.24.tgz",
-      "integrity": "sha512-bCDDujiVoPOvIXXxC2+gdeVcsobro3k0U8UKLcnKuTN5AZI9jtc86Ju2GccII6bWxj71w3EDLrQ/tDe84PmEqA==",
+      "version": "1.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.25.tgz",
+      "integrity": "sha512-i4F/nkvt6GWxbNjpRpp5czejOCepdFwkofyNLH4HoMKXve5GfvYIpxUAP01nReHMxiwA72aD93yy2ka6lSQyew==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translationCore",
   "productName": "translationCore",
-  "version": "0.8.1-alpha.15",
+  "version": "0.8.1-alpha.16",
   "manifestVersion": "2",
   "description": "A bridge between TS and TM",
   "main": "src/main.js",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "simple-git": "1.43.0",
     "sudo-prompt": "6.2.1",
     "truncate-utf8-bytes": "1.0.2",
-    "usfm-js": "1.0.0-beta.24",
+    "usfm-js": "1.0.0-beta.25",
     "xregexp": "3.2.0",
     "yamljs": "0.3.0",
     "zip-folder": "1.0.0"

--- a/src/js/actions/TargetLanguageActions.js
+++ b/src/js/actions/TargetLanguageActions.js
@@ -96,7 +96,7 @@ function saveTargetBible(projectPath, manifest, bookData) {
 export function generateTargetBibleFromProjectPath(projectPath, manifest) {
   let bookData = {};
   // get the bibleIndex to get the list of expected chapters
-  const bibleIndex = getBibleIndex('en', 'ulb', 'v11');
+  const bibleIndex = getBibleIndex('en', 'ulb');
   if(!bibleIndex[manifest.project.id]) {
     console.warn(`Invalid book key ${manifest.project.id}. Expected a book of the Bible.`);
     return;

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -3,6 +3,7 @@ import path from 'path-extra';
 import ospath from 'ospath';
 // helpers
 import * as MissingVersesHelpers from './ProjectValidation/MissingVersesHelpers';
+import {getLatestVersionInPath} from "./ResourcesHelpers";
 /**
  * Gets a tool's progress
  * @param {String} pathToCheckDataFiles
@@ -50,12 +51,7 @@ export function getWordAlignmentProgress(pathToWordAlignmentData, bookId) {
   let groupsObject = {};
   let checked = 0;
   let totalChecks = 0;
-  let bibleFolderPath = path.join(ospath.home(), 'translationCore','resources', 'grc', 'bibles', 'ugnt'); // ex. user/NAME/translationCore/resources/en/bibles/ulb
-  let versionNumbers = fs.readdirSync(bibleFolderPath).filter(folder => { // filter out .DS_Store
-    return folder !== '.DS_Store';
-  }); // ex. v9
-  const versionNumber = versionNumbers[versionNumbers.length-1];
-  let expectedVerses = MissingVersesHelpers.getExpectedBookVerses(bookId, 'grc', 'ugnt', versionNumber);
+  let expectedVerses = MissingVersesHelpers.getExpectedBookVerses(bookId, 'grc', 'ugnt');
   if (fs.existsSync(pathToWordAlignmentData)) {
     let groupDataFiles = fs.readdirSync(pathToWordAlignmentData).filter(file => { // filter out .DS_Store
       return path.extname(file) === '.json';
@@ -63,8 +59,8 @@ export function getWordAlignmentProgress(pathToWordAlignmentData, bookId) {
     groupDataFiles.forEach((chapterFileName) => {
       groupsObject[path.parse(chapterFileName).name] = fs.readJsonSync(path.join(pathToWordAlignmentData, chapterFileName));
     });
-    for (var chapterNumber in groupsObject) {
-      for (var verseNumber in groupsObject[chapterNumber]) {
+    for (let chapterNumber in groupsObject) {
+      for (let verseNumber in groupsObject[chapterNumber]) {
         let verseDone = !groupsObject[chapterNumber][verseNumber].wordBank.length;
         if (verseDone) checked++;
       }

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
-import ospath from 'ospath';
 // helpers
 import * as MissingVersesHelpers from './ProjectValidation/MissingVersesHelpers';
-import {getLatestVersionInPath} from "./ResourcesHelpers";
 /**
  * Gets a tool's progress
  * @param {String} pathToCheckDataFiles

--- a/src/js/helpers/ProjectValidation/MissingVersesHelpers.js
+++ b/src/js/helpers/ProjectValidation/MissingVersesHelpers.js
@@ -62,7 +62,10 @@ export function getExpectedBookVerses(bookAbbr, languageId = 'en', bookName = 'u
   if (version) {
     indexLocation = path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName, version, 'index.json');
   } else {
-    const versionPath = getLatestVersionInPath(path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName));
+    let versionPath = getLatestVersionInPath(path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName));
+    if (versionPath === null) { // if failed, return nothing
+      return {};
+    }
     indexLocation = path.join(versionPath, 'index.json');
   }
   let expectedVersesBooks = fs.readJSONSync(indexLocation);

--- a/src/js/helpers/ProjectValidation/MissingVersesHelpers.js
+++ b/src/js/helpers/ProjectValidation/MissingVersesHelpers.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
+import {getLatestVersionInPath} from "../ResourcesHelpers";
 // constants
 const USER_RESOURCES_DIR = path.join(ospath.home(), 'translationCore/resources');
 
@@ -50,11 +51,20 @@ export function findMissingVerses(usfmFilePath, bookAbbr) {
 
 /**
  * Retrieves the authoritative list of verses in a book
- * @param bookAbbr
- * @return {*}
+ * @param {string} bookAbbr
+ * @param {string} languageId
+ * @param {string} bookName
+ * @param {string} optional version, if null then get latest
+ * @return {Object} verses in book
  */
-export function getExpectedBookVerses(bookAbbr, languageId = 'en', bookName = 'ulb', version = 'v11') {
-  let indexLocation = path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName, version, 'index.json');
+export function getExpectedBookVerses(bookAbbr, languageId = 'en', bookName = 'ulb', version = null) {
+  let indexLocation;
+  if (version) {
+    indexLocation = path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName, version, 'index.json');
+  } else {
+    const versionPath = getLatestVersionInPath(path.join(USER_RESOURCES_DIR, languageId, 'bibles', bookName));
+    indexLocation = path.join(versionPath, 'index.json');
+  }
   let expectedVersesBooks = fs.readJSONSync(indexLocation);
   return expectedVersesBooks[bookAbbr];
 }

--- a/src/js/helpers/bibleHelpers.js
+++ b/src/js/helpers/bibleHelpers.js
@@ -2,6 +2,7 @@
 import Path from 'path-extra';
 import fs from 'fs-extra';
 import BooksOfBible from '../../../tC_resources/resources/books';
+import {getLatestVersionInPath} from "./ResourcesHelpers";
 
 /**
  *
@@ -37,20 +38,14 @@ export function isOldTestament(projectBook) {
 export const isProjectMissingVerses = (projectDir, bookId, resourceDir) => {
   try {
     let languageId = 'en';
-    let indexLocation = Path.join(
-      resourceDir,
-      languageId,
-      'bibles',
-      'ulb',
-      'v11',
-      'index.json'
-    );
-    let expectedVerses = fs.readJSONSync(indexLocation);
-    let actualVersesObject = {};
-    let currentFolderChapters = fs.readdirSync(Path.join(projectDir, bookId));
+    const resourcePath = Path.join(resourceDir, languageId, 'bibles', 'ulb');
+    const versionPath = getLatestVersionInPath(resourcePath);
+    const indexLocation = Path.join(versionPath, 'index.json');
+    const expectedVerses = fs.readJSONSync(indexLocation);
+    const actualVersesObject = {};
+    const currentFolderChapters = fs.readdirSync(Path.join(projectDir, bookId));
     let chapterLength = 0;
-    actualVersesObject = {};
-    for (var currentChapterFile of currentFolderChapters) {
+    for (let currentChapterFile of currentFolderChapters) {
       let currentChapter = Path.parse(currentChapterFile).name;
       if (!parseInt(currentChapter)) continue;
       chapterLength++;
@@ -59,7 +54,7 @@ export const isProjectMissingVerses = (projectDir, bookId, resourceDir) => {
         let currentChapterObject = fs.readJSONSync(
           Path.join(projectDir, bookId, currentChapterFile)
         );
-        for (var verseIndex in currentChapterObject) {
+        for (let verseIndex in currentChapterObject) {
           let verse = currentChapterObject[verseIndex];
           if (verse && verseIndex > 0) verseLength++;
         }


### PR DESCRIPTION
#### This pull request addresses:

Switched ulb version from v11 to v12.1 and had to update tc to not use hard coded paths.


#### How to test this pull request:

Dependencies:
https://github.com/translationCoreApps/ScripturePane/pull/90
https://github.com/translationCoreApps/tC_Resources/pull/19


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3778)
<!-- Reviewable:end -->
