### PR TITLE
Bugfix #3758/preserve header info on USFM import

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -226,5 +226,7 @@ fs.copySync = copySync;
 fs.renameSync = renameSync;
 fs.ensureDirSync = ensureDirSync;
 fs.statSync = statSync;
+fs.fstatSync = statSync;
+fs.lstatSync = statSync;
 
 module.exports = fs;

--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+import path from 'path-extra';
+import ospath from 'ospath';
+import fs from "fs-extra";
+//helpers
+import * as USFMExportActions from '../src/js/actions/USFMExportActions';
+import * as UsfmHelpers from "../src/js/helpers/usfmHelpers";
+const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
+const RESOURCE_PATH = path.join(ospath.home(), 'Development','Electron','translationCore', 'tC_resources', 'resources');
+
+describe('USFMExportActions', () => {
+  const sourceProject = 'en_gal';
+  const headers = [
+    {
+      "tag": "id",
+      "content": "GAL N/A cdh_Chambeali_ltr Mon Sep 11 2017 16:44:56 GMT-0700 (PDT) tc"
+    },
+    {
+      "tag": "h",
+      "content": "Galatians"
+    },
+    {
+      "tag": "mt",
+      "content": "Galatians"
+    },
+    {
+      "tag": "s5",
+      "type": "section"
+    }
+  ];
+
+  beforeEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+    fs.__setMockFS({}); // initialize to empty
+    const sourcePath = "__tests__/fixtures/project/";
+    let copyFiles = [sourceProject];
+    fs.__loadFilesIntoMockFs(copyFiles, sourcePath, PROJECTS_PATH);
+    const resourcePath = "__tests__/fixtures/resources/";
+    copyFiles = ['en/bibles/ulb/v11'];
+    fs.__loadFilesIntoMockFs(copyFiles, resourcePath, RESOURCE_PATH);
+  });
+  afterEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+  });
+
+  test('should convert project with headers.json', () => {
+    // given
+    const projectFolder = path.join(PROJECTS_PATH, sourceProject);
+    fs.outputJsonSync(path.join(projectFolder, 'gal', 'headers.json'), headers);
+
+    // when
+    const results = USFMExportActions.setUpUSFMJSONObject(projectFolder);
+
+    // then
+    expect(results).toBeTruthy();
+    validateHeaderTagPresent(results.headers, 'id');
+    validateHeaderTag(results.headers, headers, 'h');
+  });
+
+  //
+  // helpers
+  //
+
+  function validateHeaderTag(results_header_data, expected_header_data, tag) {
+    const data = UsfmHelpers.getHeaderTag(results_header_data, tag);
+    const expected_data = UsfmHelpers.getHeaderTag(expected_header_data, tag);
+    expect(data).toEqual(expected_data);
+  }
+
+  function validateHeaderTagPresent(results_header_data,tag) {
+    const data = UsfmHelpers.getHeaderTag(results_header_data, tag);
+    expect(data).toBeTruthy();
+  }
+});

--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -55,8 +55,25 @@ describe('USFMExportActions', () => {
 
     // then
     expect(results).toBeTruthy();
-    validateHeaderTagPresent(results.headers, 'id');
+    validateHeaderTagPresent(results.headers, 'id', true);
     validateHeaderTag(results.headers, headers, 'h');
+    validateHeaderTag(results.headers, headers, 'mt');
+    validateHeaderTag(results.headers, headers, 's5');
+  });
+
+  test('should convert project without headers.json', () => {
+    // given
+    const projectFolder = path.join(PROJECTS_PATH, sourceProject);
+
+    // when
+    const results = USFMExportActions.setUpUSFMJSONObject(projectFolder);
+
+    // then
+    expect(results).toBeTruthy();
+    validateHeaderTagPresent(results.headers, 'id', true);
+    validateHeaderTag(results.headers, headers, 'h');
+    validateHeaderTagPresent(results.headers, 'mt', false);
+    validateHeaderTagPresent(results.headers, 's5', false);
   });
 
   //
@@ -69,8 +86,12 @@ describe('USFMExportActions', () => {
     expect(data).toEqual(expected_data);
   }
 
-  function validateHeaderTagPresent(results_header_data,tag) {
+  function validateHeaderTagPresent(results_header_data,tag, present) {
     const data = UsfmHelpers.getHeaderTag(results_header_data, tag);
-    expect(data).toBeTruthy();
+    if (present) {
+      expect(data).toBeTruthy();
+    } else {
+      expect(data).not.toBeTruthy();
+    }
   }
 });

--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -1,3 +1,5 @@
+import * as UsfmHelpers from "../src/js/helpers/usfmHelpers";
+
 jest.mock('fs-extra');
 import React from 'react';
 import fs from 'fs-extra';
@@ -27,6 +29,8 @@ const moveUsfmRejectionMessage = (
 const validUsfmString = `
 \\id TIT N/A cdh_Chambeali_ltr Mon Sep 11 2017 16:44:56 GMT-0700 (PDT) tc
 \\h Titus
+\\mt Titus
+\\s5
 \\c 1
 \\p
 \\v 1 तिन्हा जो तांई चुणेया जे से बेकसुर हो। अत्ते इक ई लाड़ी वाळे होणे चहिंदे। तिन्हेरे बच्चे विस्वासी होणे चहिंदे अत्ते बेलगाम अत्ते बागी ना हो।
@@ -136,6 +140,12 @@ describe('UsfmFileConversionHelpers', () => {
     const chapter2_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '2.json'));
     expect(Object.keys(chapter2_data).length - 1).toEqual(0);
 
+    // verify header info is preserved
+    const header_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, 'headers.json'));
+    validateUsfmTag(header_data, 'id');
+    validateUsfmTag(header_data, 'h');
+    validateUsfmTag(header_data, 'mt');
+    validateUsfmTag(header_data, 's5');
   });
 
   test('generateTargetLanguageBibleFromUsfm with aligned USFM should succeed', async () => {
@@ -169,3 +179,18 @@ describe('UsfmFileConversionHelpers', () => {
     expect(chapter1_data[5]).toEqual("For to which of the angels did God ever say, \"You are my son, today I have become your father\"? Or to which of the angels did God ever say, \"I will be a father to him, and he will be a son to me\"?");
   });
 });
+
+//
+// helpers
+//
+
+function validateUsfmTag(header_data, tag) {
+  const data = UsfmHelpers.getHeaderTag(header_data, tag);
+  let match = "\\" + tag;
+  if (data) {
+    match += " " + data;
+  }
+  const index = validUsfmString.indexOf(match);
+  const found = (index >= 0);
+  expect(found).toBeTruthy();
+}

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -83,7 +83,7 @@ export function setUpUSFMJSONObject(projectPath) {
 
   let usfmJSONObject = {};
   let currentFolderChapters = fs.readdirSync(path.join(projectPath, bookName));
-  for (var currentChapterFile of currentFolderChapters) {
+  for (let currentChapterFile of currentFolderChapters) {
     let currentChapter = path.parse(currentChapterFile).name;
     let chapterNumber = parseInt(currentChapter);
     /**Skipping on non-number keys*/
@@ -106,8 +106,6 @@ export function setUpUSFMJSONObject(projectPath) {
  *
  * @param {string} filePath - File path to the specified usfm export save location
  * @param {string} projectName - Name of the project being exported (This can be altered by the user
- * @param {string} cancelledTitle
- * @param {string} loadingTitle
  * when saving)
  */
 export function storeUSFMSaveLocation(filePath, projectName) {

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -37,7 +37,7 @@ export function exportToUSFM(projectPath) {
         let projectName = path.parse(projectPath).base;
         /**File path from file chooser*/
         let filePath = exportHelpers.getFilePath(projectName, usfmSaveLocation, 'usfm');
-        /**Getting new projet name to save incase the user changed the save file name*/
+        /**Getting new project name to save incase the user changed the save file name*/
         projectName = path.parse(filePath).base.replace('.usfm', '');
         /** Saving the location for future exports */
         dispatch(storeUSFMSaveLocation(filePath, projectName));
@@ -112,7 +112,7 @@ export function setUpUSFMJSONObject(projectPath) {
  */
 export function storeUSFMSaveLocation(filePath, projectName) {
   return {
-    type: types.SET_USFM_SAVE_LOCATION, 
+    type: types.SET_USFM_SAVE_LOCATION,
     usfmSaveLocation: filePath.split(projectName)[0]
   };
 }

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -86,7 +86,8 @@ export const moveUsfmFileFromSourceToImports = async (sourceProjectPath, manifes
 export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, selectedProjectFilename) => {
   return new Promise ((resolve, reject) => {
     try {
-      const chaptersObject = usfmjs.toJSON(usfmData).chapters;
+      const importObject = usfmjs.toJSON(usfmData);
+      const chaptersObject = importObject.chapters;
       const bibleDataFolderName = manifest.project.id || selectedProjectFilename;
       let verseFound = false;
       Object.keys(chaptersObject).forEach((chapter) => {
@@ -100,6 +101,8 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
         const projectBibleDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, filename);
         fs.outputJsonSync(projectBibleDataPath, bibleChapter);
       });
+      const projectBibleDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, 'headers.json');
+      fs.outputJsonSync(projectBibleDataPath, importObject.headers);
       if (!verseFound) {
         reject(
           <div>

--- a/src/js/helpers/exportHelpers.js
+++ b/src/js/helpers/exportHelpers.js
@@ -66,10 +66,10 @@ export function getHeaderTags(projectSaveLocation) {
   let resourceName = sourceTranslation && sourceTranslation.language_id && sourceTranslation.resource_id ?
     `${sourceTranslation.language_id.toUpperCase()}_${sourceTranslation.resource_id.toUpperCase()}` :
     'N/A';
-  /**This will look like: EN_ULB Kiswahili_sw_ltr to be included in the usfm id.
+  /**This will look like: EN_ULB sw_Kiswahili_ltr to be included in the usfm id.
    * This will make it easier to read for tC later on */
   let targetLanguageCode = manifest.target_language ?
-    `${manifest.target_language.name.split(' ').join('⋅')}_${manifest.target_language.id}_${manifest.target_language.direction}` :
+    `${manifest.target_language.id}_${manifest.target_language.name.split(' ').join('⋅')}_${manifest.target_language.direction}` :
     'N/A';
   /**Date object when project was las changed in FS */
   let lastEdited = fs.statSync(path.join(projectSaveLocation), bookName).atime;

--- a/src/js/helpers/exportHelpers.js
+++ b/src/js/helpers/exportHelpers.js
@@ -66,10 +66,10 @@ export function getHeaderTags(projectSaveLocation) {
   let resourceName = sourceTranslation && sourceTranslation.language_id && sourceTranslation.resource_id ?
     `${sourceTranslation.language_id.toUpperCase()}_${sourceTranslation.resource_id.toUpperCase()}` :
     'N/A';
-  /**This will look like: ar_العربية_rtl to be included in the usfm id.
+  /**This will look like: EN_ULB Kiswahili_sw_ltr to be included in the usfm id.
    * This will make it easier to read for tC later on */
   let targetLanguageCode = manifest.target_language ?
-    `${manifest.target_language.id}_${manifest.target_language.name}_${manifest.target_language.direction}` :
+    `${manifest.target_language.name.split(' ').join('⋅')}_${manifest.target_language.id}_${manifest.target_language.direction}` :
     'N/A';
   /**Date object when project was las changed in FS */
   let lastEdited = fs.statSync(path.join(projectSaveLocation), bookName).atime;

--- a/src/js/helpers/exportHelpers.js
+++ b/src/js/helpers/exportHelpers.js
@@ -75,7 +75,7 @@ export function getHeaderTags(projectSaveLocation) {
   let lastEdited = fs.statSync(path.join(projectSaveLocation), bookName).atime;
   let bookNameUppercase = bookName.toUpperCase();
   let headers = LoadHelpers.loadFile(path.join(projectSaveLocation, bookName), 'headers.json');
-  headers = headers || {};
+  headers = headers || [];
   /**Note the indication here of tc on the end of the id. This will act as a flag to ensure the correct parsing*/
   const id = {
     "content": `${bookNameUppercase} ${resourceName} ${targetLanguageCode} ${lastEdited} tc`,

--- a/src/js/helpers/usfmHelpers.js
+++ b/src/js/helpers/usfmHelpers.js
@@ -76,7 +76,7 @@ export function getUSFMDetails(usfmObject) {
     let isSpaceDelimited = id.split(" ").length > 1;
     let isCommaDelimited = id.split(",").length > 1;
     if (isSpaceDelimited) {
-      // i.e. TIT EN_ULB Kiswahili_sw_ltr Wed Jul 26 2017 22:14:55 GMT-0700 (PDT) tc.
+      // i.e. TIT EN_ULB sw_Kiswahili_ltr Wed Jul 26 2017 22:14:55 GMT-0700 (PDT) tc.
       // Could have attached commas if both comma delimited and space delimited
       headerIDArray = id.split(" ");
       headerIDArray.forEach((element, index) => {
@@ -84,7 +84,7 @@ export function getUSFMDetails(usfmObject) {
       });
       details.book.id = headerIDArray[0].trim().toLowerCase();
     } else if (isCommaDelimited) {
-      // i.e. TIT, Gourmanchéma_gux_ltr, EN_ULB, Thu Jul 20 2017 16:03:48 GMT-0700 (PDT), tc.
+      // i.e. TIT, sw_Kiswahili_ltr, EN_ULB, Thu Jul 20 2017 16:03:48 GMT-0700 (PDT), tc.
       headerIDArray = id.split(",");
       details.book.id = headerIDArray[0].trim().toLowerCase();
     }
@@ -110,8 +110,8 @@ export function getUSFMDetails(usfmObject) {
       for (let index in headerIDArray) {
         let languageCodeArray = headerIDArray[index].trim().split('_');
         if (languageCodeArray.length === 3) {
-          details.language.name = languageCodeArray[0].split('⋅').join(' '); // replace spaces
-          details.language.id = languageCodeArray[1].toLowerCase();
+          details.language.id = languageCodeArray[0].toLowerCase();
+          details.language.name = languageCodeArray[1].split('⋅').join(' '); // replace spaces
           details.language.direction = languageCodeArray[2].toLowerCase();
         }
       }

--- a/src/js/helpers/usfmHelpers.js
+++ b/src/js/helpers/usfmHelpers.js
@@ -76,7 +76,7 @@ export function getUSFMDetails(usfmObject) {
     let isSpaceDelimited = id.split(" ").length > 1;
     let isCommaDelimited = id.split(",").length > 1;
     if (isSpaceDelimited) {
-      // i.e. TIT EN_ULB sw_Kiswahili_ltr Wed Jul 26 2017 22:14:55 GMT-0700 (PDT) tc.
+      // i.e. TIT EN_ULB Kiswahili_sw_ltr Wed Jul 26 2017 22:14:55 GMT-0700 (PDT) tc.
       // Could have attached commas if both comma delimited and space delimited
       headerIDArray = id.split(" ");
       headerIDArray.forEach((element, index) => {
@@ -84,7 +84,7 @@ export function getUSFMDetails(usfmObject) {
       });
       details.book.id = headerIDArray[0].trim().toLowerCase();
     } else if (isCommaDelimited) {
-      // i.e. TIT, gux_Gourmanchéma_ltr, EN_ULB, Thu Jul 20 2017 16:03:48 GMT-0700 (PDT), tc.
+      // i.e. TIT, Gourmanchéma_gux_ltr, EN_ULB, Thu Jul 20 2017 16:03:48 GMT-0700 (PDT), tc.
       headerIDArray = id.split(",");
       details.book.id = headerIDArray[0].trim().toLowerCase();
     }
@@ -105,13 +105,13 @@ export function getUSFMDetails(usfmObject) {
     }
 
     let tcField = headerIDArray[headerIDArray.length - 1] || '';
-    if (tcField.trim() == 'tc') {
+    if (tcField.trim() === 'tc') {
       // Checking for tC field to parse with more information than standard usfm.
-      for (var index in headerIDArray) {
+      for (let index in headerIDArray) {
         let languageCodeArray = headerIDArray[index].trim().split('_');
-        if (languageCodeArray.length == 3) {
-          details.language.id = languageCodeArray[0].toLowerCase();
-          details.language.name = languageCodeArray[1];
+        if (languageCodeArray.length === 3) {
+          details.language.name = languageCodeArray[0].split('⋅').join(' '); // replace spaces
+          details.language.id = languageCodeArray[1].toLowerCase();
           details.language.direction = languageCodeArray[2].toLowerCase();
         }
       }

--- a/src/js/helpers/usfmHelpers.js
+++ b/src/js/helpers/usfmHelpers.js
@@ -111,7 +111,7 @@ export function getUSFMDetails(usfmObject) {
         let languageCodeArray = headerIDArray[index].trim().split('_');
         if (languageCodeArray.length === 3) {
           details.language.id = languageCodeArray[0].toLowerCase();
-          details.language.name = languageCodeArray[1].split('⋅').join(' '); // replace spaces
+          details.language.name = languageCodeArray[1].split('⋅').join(' '); // restore spaces
           details.language.direction = languageCodeArray[2].toLowerCase();
         }
       }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Preserve USFM header data on USFM import in headers.json
- Include data in headers.json on USFM export.

#### Please include detailed Test instructions for your pull request:
- import local USFM project and verify that `headers.json` is created in project data folder for book (e.g. `projects/en_tit/tit/headers.json`)
- export project to USFM and verify that attributes in `headers.json` are added to USFM file before first chapter marker.  Exception is that id tag (`\id`) will be overwritten with latest data.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3797)
<!-- Reviewable:end -->
