### PR TITLE
QA Fail #3209/Footnotes ending up in wordBank

### DIFF
--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -2,7 +2,6 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import consts from '../actions/ActionTypes';
-import usfmjs from "usfm-js";
 // helpers
 import * as WordAlignmentHelpers from '../helpers/WordAlignmentHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
@@ -152,7 +151,7 @@ export const generateBlankAlignments = (verseData) => {
  * @return {Array} alignmentObjects from verse text
  */
 export const generateWordBank = (verseText) => {
-  verseText = removeUsfmMarkers(verseText);
+  verseText = WordAlignmentHelpers.removeUsfmMarkers(verseText);
   const verseWords = stringHelpers.tokenize(verseText);
   // TODO: remove once occurrencesInString uses tokenizer, can't do that until bug is addressed with Greek
   const _verseText = verseWords.join(' ');
@@ -166,15 +165,4 @@ export const generateWordBank = (verseText) => {
     };
   });
   return wordBank;
-};
-
-/**
- * Method to filter usfm markers from a string
- * @param {String} verseText - The string to remove markers from
- * @return {String}
- */
-export const removeUsfmMarkers = (verseText) => {
-  const cleaned = usfmjs.removeMarker(verseText, ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']); // remove these markers, 'f' is predefined
-  // the rest are regex (these will be prefixed with '\\\\')
-  return cleaned;
 };

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -2,6 +2,7 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import consts from '../actions/ActionTypes';
+import usfmjs from "usfm-js";
 // helpers
 import * as WordAlignmentHelpers from '../helpers/WordAlignmentHelpers';
 import * as stringHelpers from '../helpers/stringHelpers';
@@ -151,6 +152,7 @@ export const generateBlankAlignments = (verseData) => {
  * @return {Array} alignmentObjects from verse text
  */
 export const generateWordBank = (verseText) => {
+  verseText = removeUsfmMarkers(verseText);
   const verseWords = stringHelpers.tokenize(verseText);
   // TODO: remove once occurrencesInString uses tokenizer, can't do that until bug is addressed with Greek
   const _verseText = verseWords.join(' ');
@@ -164,4 +166,15 @@ export const generateWordBank = (verseText) => {
     };
   });
   return wordBank;
+};
+
+/**
+ * Method to filter usfm markers from a string
+ * @param {String} verseText - The string to remove markers from
+ * @return {String}
+ */
+export const removeUsfmMarkers = (verseText) => {
+  const cleaned = usfmjs.removeMarker(verseText, ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']); // remove these markers, 'f' is predefined
+  // the rest are regex (these will be prefixed with '\\\\')
+  return cleaned;
 };

--- a/src/js/actions/WordAlignmentLoadActions.js
+++ b/src/js/actions/WordAlignmentLoadActions.js
@@ -151,11 +151,11 @@ export const generateBlankAlignments = (verseData) => {
  * @return {Array} alignmentObjects from verse text
  */
 export const generateWordBank = (verseText) => {
-  verseText = WordAlignmentHelpers.removeUsfmMarkers(verseText);
-  const verseWords = stringHelpers.tokenize(verseText);
+  const verseWords = VerseObjectHelpers.getWordList(verseText);
   // TODO: remove once occurrencesInString uses tokenizer, can't do that until bug is addressed with Greek
-  const _verseText = verseWords.join(' ');
-  const wordBank = verseWords.map((word, index) => {
+  const _verseText = verseWords.map(object => object.text || '').join(' ');
+  const wordBank = verseWords.map((object, index) => {
+    const word = object.text;
     let occurrences = stringHelpers.occurrencesInString(_verseText, word);
     let occurrence = stringHelpers.occurrenceInString(_verseText, index, word);
     return {

--- a/src/js/helpers/VerseObjectHelpers.js
+++ b/src/js/helpers/VerseObjectHelpers.js
@@ -193,7 +193,7 @@ export const getWordListFromVerseObjectArray = function (verseObjects) {
  * @return {Array}
  */
 export const getWordList = (verseObjects) => {
-  let output = null;
+  let wordList = [];
   if (typeof verseObjects === 'string') {
     verseObjects = verseObjectsFromString(verseObjects);
   }
@@ -202,7 +202,7 @@ export const getWordList = (verseObjects) => {
   }
 
   if (verseObjects) {
-    output = getWordListFromVerseObjectArray(verseObjects);
+    wordList = getWordListFromVerseObjectArray(verseObjects);
   }
-  return output;
+  return wordList;
 };

--- a/src/js/helpers/VerseObjectHelpers.js
+++ b/src/js/helpers/VerseObjectHelpers.js
@@ -186,3 +186,23 @@ export const getWordListFromVerseObjectArray = function (verseObjects) {
   }
   return wordList;
 };
+
+/**
+ * Method to filter usfm markers from a string or verseObjects array
+ * @param {String|Array|Object} verseObjects - The string to remove markers from
+ * @return {Array}
+ */
+export const getWordList = (verseObjects) => {
+  let output = null;
+  if (typeof verseObjects === 'string') {
+    verseObjects = verseObjectsFromString(verseObjects);
+  }
+  if (verseObjects && verseObjects.verseObjects) {
+    verseObjects = verseObjects.verseObjects;
+  }
+
+  if (verseObjects) {
+    output = getWordListFromVerseObjectArray(verseObjects);
+  }
+  return output;
+};

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -253,3 +253,14 @@ export const convertAlignmentDataToUSFM = (wordAlignmentDataPath, projectTargetL
     resolve(usfmjs.toUSFM(usfmToJSONObject));
   });
 };
+
+/**
+ * Method to filter usfm markers from a string
+ * @param {String} verseText - The string to remove markers from
+ * @return {String}
+ */
+export const removeUsfmMarkers = (verseText) => {
+  const cleaned = usfmjs.removeMarker(verseText, ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']); // remove these markers, 'f' is predefined
+  // the rest are regex (these will be prefixed with '\\\\')
+  return cleaned;
+};

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -253,14 +253,3 @@ export const convertAlignmentDataToUSFM = (wordAlignmentDataPath, projectTargetL
     resolve(usfmjs.toUSFM(usfmToJSONObject));
   });
 };
-
-/**
- * Method to filter usfm markers from a string
- * @param {String} verseText - The string to remove markers from
- * @return {String}
- */
-export const removeUsfmMarkers = (verseText) => {
-  const cleaned = usfmjs.removeMarker(verseText, ['f', 'q(\\d)?', 's(\\d)?', 'p(\\d)?']); // remove these markers, 'f' is predefined
-  // the rest are regex (these will be prefixed with '\\\\')
-  return cleaned;
-};


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Add filtering of USFM tags before generating word bank.

#### Please include detailed Test instructions for your pull request:
-  Import project at end of https://github.com/unfoldingWord-dev/translationCore/issues/3209.  Should not see footnote marker and words in wordBank

#### Standard Test Instructions for PR Review Process:

- [x] Double check unit tests that have been written
- [x] Check for documentation for code changes
- [x] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [x] Checkout the branch locally and ensure that app runs as expected
  - [x] Ensure tests pass
  - [x] Open and watch the console for errors
  - [x] Make sure all actions perform as expected
  - [x] Import and Load a new Project
  - [x] Load a tool and perform basic actions
  - [x] Switch tools and perform basic actions
  - [x] Switch project to an existing project
  - [x] Load a tool and perform basic actions
  - [x] Switch tools and perform basic actions
  - [x] Next time reverse the order of importing after loading an existing project
- [x] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/3909)
<!-- Reviewable:end -->
