### PR TITLE
bugfix #3963/Fix word typo by migration

### DIFF
--- a/__tests__/ImportMigrationHelpersV4.test.js
+++ b/__tests__/ImportMigrationHelpersV4.test.js
@@ -1,0 +1,141 @@
+import path from 'path';
+import * as fs from 'fs-extra';
+/* eslint-env jest */
+/* eslint-disable no-console */
+'use strict';
+import migrateToVersion4 from "../src/js/helpers/ProjectMigration/migrateToVersion4";
+import * as MigrateToVersion4 from "../src/js/helpers/ProjectMigration/migrateToVersion4";
+import * as Version from "../src/js/helpers/ProjectMigration/VersionUtils";
+jest.mock('fs-extra');
+import migrateToVersion3 from "../src/js/helpers/ProjectMigration/migrateToVersion3";
+
+const manifest = {
+  "project": {"id": "mat", "name": ""},
+  "type": {"id": "text", "name": "Text"},
+  "generator": {"name": "ts-android", "build": 175},
+  "package_version": 7,
+  "target_language": {
+    "name": "ગુજરાતી",
+    "direction": "ltr",
+    "anglicized_name": "Gujarati",
+    "region": "Asia",
+    "is_gateway_language": false,
+    "id": "gu"
+  },
+  "format": "usfm",
+  "resource": {"id": "reg"},
+  "translators": ["qa99"],
+  "parent_draft": {"resource_id": "ulb", "checking_level": "3", "version": "1"},
+  "source_translations": [{
+    "language_id": "gu",
+    "resource_id": "ulb",
+    "checking_level": "3",
+    "date_modified": 20161008,
+    "version": "1"
+  }]
+};
+const PROJECT_PATH = '__tests__/fixtures/project/migration/v1_project';
+
+describe('migrateToVersion4', () => {
+  beforeEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+    // Set up mocked out filePath and data in mock filesystem before each test
+    fs.__setMockFS({
+      [PROJECT_PATH]:[],
+      [path.join(PROJECT_PATH, 'manifest.json')]: manifest
+    });
+  });
+  afterEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+  });
+
+  it('with no tc_version expect to set', () => {
+    migrateToVersion4(PROJECT_PATH);
+    const version = Version.getVersionFromManifest(PROJECT_PATH);
+
+    expect(MigrateToVersion4.MIGRATE_MANIFEST_VERSION).toBe(4); // this shouldn't change
+    expect(version).toBe(MigrateToVersion4.MIGRATE_MANIFEST_VERSION);
+  });
+
+  it('with lower tc_version expect to update version', () => {
+    Version.setVersionInManifest(PROJECT_PATH, MigrateToVersion4.MIGRATE_MANIFEST_VERSION - 1);
+    migrateToVersion4(PROJECT_PATH);
+    const version = Version.getVersionFromManifest(PROJECT_PATH);
+
+    expect(version).toBe(MigrateToVersion4.MIGRATE_MANIFEST_VERSION);
+  });
+
+  it('with higher tc_version expect to leave alone', () => {
+    const manifestVersion = MigrateToVersion4.MIGRATE_MANIFEST_VERSION + 1;
+    Version.setVersionInManifest(PROJECT_PATH, manifestVersion);
+    migrateToVersion4(PROJECT_PATH);
+    const version = Version.getVersionFromManifest(PROJECT_PATH);
+
+    expect(version).toBe(manifestVersion);
+  });
+
+  it('with lower tc_version expect to update alignment data and fix the typo in migration 3', () => {
+
+    // given
+    const match = "ἐgκρατῆ";
+    const replace3 = "ἐνκρατῆ";
+    const replace4 = "ἐγκρατῆ";
+    const sourcePath = "__tests__/fixtures/project/";
+    const book_id = 'tit';
+    const project_id = 'en_' + book_id;
+    const copyFiles = [project_id];
+    fs.__loadFilesIntoMockFs(copyFiles, sourcePath, PROJECT_PATH);
+    const projectPath = path.join(PROJECT_PATH, project_id);
+    const projectAlignmentDataPath = path.join(projectPath, '.apps', 'translationCore');
+    fs.outputFileSync(path.join(projectAlignmentDataPath, 'alignmentData','ignoreMe'), ''); // this file should be ignored
+    fs.ensureDirSync(path.join(projectAlignmentDataPath, 'alignmentData',".DS_Store")); // this folder should be ignored
+    const chapter1_alignment_path = path.join(projectAlignmentDataPath, 'alignmentData', book_id, '1.json');
+    const disciplineWords = path.join(projectAlignmentDataPath, 'index', 'translationWords', book_id, 'discipline.json');
+    const believeWords = path.join(projectAlignmentDataPath, 'index', 'translationWords', book_id, 'believe.json');
+
+    Version.setVersionInManifest(projectPath, 2);
+    migrateToVersion3(projectPath); // setup migration 3 data
+
+    // make sure test data set up correctly
+    expect(isStringInData(chapter1_alignment_path, match)).not.toBeTruthy();
+    expect(isStringInData(chapter1_alignment_path, replace3)).toBeTruthy();
+    expect(isStringInData(chapter1_alignment_path, replace4)).not.toBeTruthy();
+    expect(isStringInData(disciplineWords, match)).not.toBeTruthy();
+    expect(isStringInData(disciplineWords, replace3)).toBeTruthy();
+    expect(isStringInData(disciplineWords, replace4)).not.toBeTruthy();
+    expect(isStringInData(believeWords, match)).not.toBeTruthy();
+
+    // when
+    migrateToVersion4(projectPath);
+
+    // then
+    const version = Version.getVersionFromManifest(projectPath);
+    expect(version).toBe(MigrateToVersion4.MIGRATE_MANIFEST_VERSION);
+
+    expect(isStringInData(chapter1_alignment_path, match)).not.toBeTruthy();
+    expect(isStringInData(chapter1_alignment_path, replace3)).not.toBeTruthy();
+    expect(isStringInData(chapter1_alignment_path, replace4)).toBeTruthy();
+    expect(isStringInData(disciplineWords, match)).not.toBeTruthy();
+    expect(isStringInData(disciplineWords, replace3)).not.toBeTruthy();
+    expect(isStringInData(disciplineWords, replace4)).toBeTruthy();
+    expect(isStringInData(believeWords, match)).not.toBeTruthy();
+    expect(isStringInData(believeWords, replace3)).not.toBeTruthy();
+  });
+});
+
+//
+// helpers
+//
+
+let getChapterData = function (alignment_file) {
+  return fs.readJsonSync(alignment_file);
+};
+
+const isStringInData = function (filePath, match) {
+  const chapterData = getChapterData(filePath);
+  const json = JSON.stringify(chapterData);
+  const index = json.indexOf(match);
+  return index >= 0;
+};

--- a/__tests__/ImportMigrationHelpersV4.test.js
+++ b/__tests__/ImportMigrationHelpersV4.test.js
@@ -79,9 +79,9 @@ describe('migrateToVersion4', () => {
   it('with lower tc_version expect to update alignment data and fix the typo in migration 3', () => {
 
     // given
-    const match = "ἐgκρατῆ";
-    const replace3 = "ἐνκρατῆ";
-    const replace4 = "ἐγκρατῆ";
+    const match = "ἐgκρατ";
+    const replace3 = "ἐνκρατ";
+    const replace4 = "ἐγκρατ";
     const sourcePath = "__tests__/fixtures/project/";
     const book_id = 'tit';
     const project_id = 'en_' + book_id;
@@ -101,7 +101,6 @@ describe('migrateToVersion4', () => {
     // make sure test data set up correctly
     expect(isStringInData(chapter1_alignment_path, match)).not.toBeTruthy();
     expect(isStringInData(chapter1_alignment_path, replace3)).toBeTruthy();
-    expect(isStringInData(chapter1_alignment_path, replace4)).not.toBeTruthy();
     expect(isStringInData(disciplineWords, match)).not.toBeTruthy();
     expect(isStringInData(disciplineWords, replace3)).toBeTruthy();
     expect(isStringInData(disciplineWords, replace4)).not.toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "translationCore",
-  "version": "0.8.1-alpha.21",
+  "version": "0.8.1-alpha.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "translationCore",
   "productName": "translationCore",
-  "version": "0.8.1-alpha.21",
-  "manifestVersion": "3",
+  "version": "0.8.1-alpha.22",
+  "manifestVersion": "4",
   "description": "A bridge between TS and TM",
   "main": "src/main.js",
   "scripts": {

--- a/src/js/helpers/ProjectMigration/index.js
+++ b/src/js/helpers/ProjectMigration/index.js
@@ -2,6 +2,7 @@ import migrateAppsToDotApps from './migrateAppsToDotApps';
 import migrateToVersion1 from './migrateToVersion1';
 import migrateToVersion2 from './migrateToVersion2';
 import migrateToVersion3 from './migrateToVersion3';
+import migrateToVersion4 from './migrateToVersion4';
 
 /**
  * @Description:
@@ -15,4 +16,5 @@ export default (projectSaveLocation, link) => {
   migrateToVersion1(projectSaveLocation, link);
   migrateToVersion2(projectSaveLocation, link);
   migrateToVersion3(projectSaveLocation, link);
+  migrateToVersion4(projectSaveLocation, link);
 };

--- a/src/js/helpers/ProjectMigration/migrateToVersion4.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion4.js
@@ -2,7 +2,7 @@ import path from 'path';
 import * as fs from 'fs-extra';
 import * as Version from './VersionUtils';
 
-export const MIGRATE_MANIFEST_VERSION = 3;
+export const MIGRATE_MANIFEST_VERSION = 4;
 
 /**
  * @description
@@ -37,8 +37,8 @@ const run = (projectPath) => {
 };
 
 /**
- * reads the alignment files and updates them to tc manifest version 3.  Includes fixing typos in old alignment:
- *        convert "ἐgκρατῆ" to "ἐνκρατῆ"
+ * reads the alignment files and updates them to tc manifest version 4.  Includes fixing typos in old alignment:
+ *        convert "ἐνκρατῆ" to "ἐγκρατῆ"
  * @param projectPath
  */
 export const updateAlignments = function (projectPath) {
@@ -74,12 +74,12 @@ export const updateAlignments = function (projectPath) {
 };
 
 /**
- * updates file to tc manifest version 3.  Fixes spelling in translationWords from "ἐgκρατῆ" to "ἐνκρατῆ"
+ * updates file to tc manifest version 4.  Fixes spelling in translationWords from "ἐνκρατῆ" to "ἐγκρατῆ".
  * @param filePath
  */
 export const fix_tWords = function (filePath) {
-  const match = "ἐgκρατῆ";
-  const replace = "ἐνκρατῆ";
+  const match = "ἐνκρατῆ";
+  const replace = "ἐγκρατῆ";
   let modified = false;
   try {
     const items = fs.readJsonSync(filePath);
@@ -98,12 +98,12 @@ export const fix_tWords = function (filePath) {
 };
 
 /**
- * updates file to tc manifest version 3.  Fixes spelling of alignment top words from "ἐgκρατῆ" to "ἐνκρατῆ"
+ * updates file to tc manifest version 4.  Fixes spelling of alignment top words from "ἐνκρατῆ" to "ἐγκρατῆ".
  * @param filePath
  */
 export const fixProjectAlignmentTopWords = function (filePath) {
-  const match = "ἐgκρατῆ";
-  const replace = "ἐνκρατῆ";
+  const match = "ἐνκρατῆ";
+  const replace = "ἐγκρατῆ";
   let modified = false;
   try {
     const chapter_alignments = fs.readJsonSync(filePath);

--- a/src/js/helpers/ProjectMigration/migrateToVersion4.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion4.js
@@ -104,6 +104,9 @@ export const fix_tWords = function (filePath) {
 export const fixProjectAlignmentTopWords = function (filePath) {
   const match = "ἐνκρατῆ";
   const replace = "ἐγκρατῆ";
+  // To clean up lemma:
+  const match2 = "ἐνκρατής";
+  const replace2 = "ἐγκρατής";
   let modified = false;
   try {
     const chapter_alignments = fs.readJsonSync(filePath);
@@ -114,6 +117,9 @@ export const fixProjectAlignmentTopWords = function (filePath) {
           if (word.word === match) {
             word.word = replace;
             modified = true;
+            if (word.lemma === match2) {
+              word.lemma =replace2;
+            }
           }
         }
       }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Added migration of greek typo for word from "ἐνκρατῆ" to "ἐγκρατῆ".  And change lemma from convert "ἐνκρατής" to "ἐγκρατής"

#### Please include detailed Test instructions for your pull request:
- depends on https://github.com/translationCoreApps/tC_Resources/pull/32
- Should see highlighting for self-control in Titus 1:8 in tW under discipline.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4000)
<!-- Reviewable:end -->
