### PR TITLE
Added Localization For Duplicate Import Dialog

### DIFF
--- a/src/js/actions/Import/ProjectImportFilesystemActions.js
+++ b/src/js/actions/Import/ProjectImportFilesystemActions.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
+import { getTranslate } from '../../selectors';
 // helpers
 import * as ProjectImportFilesystemHelpers from '../../helpers/Import/ProjectImportFilesystemHelpers';
 //actions
@@ -14,6 +15,7 @@ const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
 export const move = () => {
   return ((dispatch, getState) => {
     return new Promise(async(resolve, reject) => {
+      const translate = getTranslate(getState());
       try {
         const projectName = getState().localImportReducer.selectedProjectFilename;
         const projectPath = await ProjectImportFilesystemHelpers.move(projectName);
@@ -21,7 +23,10 @@ export const move = () => {
         fs.removeSync(path.join(IMPORTS_PATH, projectName));
         resolve();
       } catch (error) {
-        reject(error);
+        if (error && error.message && error.data) {
+          reject(translate(error.message, error.data));
+        }
+        else reject(error);
       }
     });
   });

--- a/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
+++ b/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
@@ -22,12 +21,7 @@ export const move = (projectName) => {
     const projectAlreadyExists = projectExistsInProjectsFolder(fromPath);
     if (projectAlreadyExists || fs.existsSync(toPath)) {
       fs.removeSync(path.join(IMPORTS_PATH, projectName));
-      reject(
-        <div>
-          The project you selected ({projectName}) already exists.<br />
-          Reimporting existing projects is not currently supported.
-        </div>
-      );
+      reject({ message: 'home.project.duplicate.already_exists', data: { projectName } });
     } else {
       // copy import to project
       if (fs.existsSync(fromPath)) {
@@ -38,20 +32,10 @@ export const move = (projectName) => {
           fs.removeSync(fromPath);
           resolve(projectPath);
         } else {
-          reject(
-            <div>
-              Error occured while importing your project.<br />
-              Could not move the project from {fromPath} to {toPath}
-            </div>
-          );
+          reject({ message: 'home.project.duplicate.could_not_move', data: { fromPath, toPath } });
         }
       } else {
-        reject(
-          <div>
-            Error occured while importing your project.<br />
-            The project file {projectName} was not found in {fromPath}
-          </div>
-        );
+        reject({ message: 'home.project.duplicate.was_not_found', data: { projectName, fromPath } });
       }
     }
   });

--- a/src/locale/Afrikaans-af_ZA.json
+++ b/src/locale/Afrikaans-af_ZA.json
@@ -99,8 +99,8 @@
     "instructions": "instruksies",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Afrikaans-af_ZA.json
+++ b/src/locale/Afrikaans-af_ZA.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "instruksies",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Arabic-ar_SA.json
+++ b/src/locale/Arabic-ar_SA.json
@@ -99,8 +99,8 @@
     "instructions": "تعليمات",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Arabic-ar_SA.json
+++ b/src/locale/Arabic-ar_SA.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "تعليمات",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Catalan-ca_ES.json
+++ b/src/locale/Catalan-ca_ES.json
@@ -99,8 +99,8 @@
     "instructions": "Instruccions",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Catalan-ca_ES.json
+++ b/src/locale/Catalan-ca_ES.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instruccions",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Chinese Simplified-zh_CN.json
+++ b/src/locale/Chinese Simplified-zh_CN.json
@@ -99,8 +99,8 @@
     "instructions": "说明",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Chinese Simplified-zh_CN.json
+++ b/src/locale/Chinese Simplified-zh_CN.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "说明",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Chinese Traditional-zh_TW.json
+++ b/src/locale/Chinese Traditional-zh_TW.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "說明",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Chinese Traditional-zh_TW.json
+++ b/src/locale/Chinese Traditional-zh_TW.json
@@ -99,8 +99,8 @@
     "instructions": "說明",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Czech-cs_CZ.json
+++ b/src/locale/Czech-cs_CZ.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instrukce",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Czech-cs_CZ.json
+++ b/src/locale/Czech-cs_CZ.json
@@ -99,8 +99,8 @@
     "instructions": "Instrukce",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Danish-da_DK.json
+++ b/src/locale/Danish-da_DK.json
@@ -99,8 +99,8 @@
     "instructions": "Instruktioner",
     "project": {
       "duplicate":{
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Danish-da_DK.json
+++ b/src/locale/Danish-da_DK.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instruktioner",
     "project": {
+      "duplicate":{
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Dutch-nl_NL.json
+++ b/src/locale/Dutch-nl_NL.json
@@ -99,8 +99,8 @@
     "instructions": "Instructions",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Dutch-nl_NL.json
+++ b/src/locale/Dutch-nl_NL.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instructions",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -107,6 +107,11 @@
     "logout": "Log out",
     "instructions": "Instructions",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -108,8 +108,8 @@
     "instructions": "Instructions",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Finnish-fi_FI.json
+++ b/src/locale/Finnish-fi_FI.json
@@ -99,8 +99,8 @@
     "instructions": "Ohjeet",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Finnish-fi_FI.json
+++ b/src/locale/Finnish-fi_FI.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Ohjeet",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/French-fr_FR.json
+++ b/src/locale/French-fr_FR.json
@@ -99,8 +99,8 @@
     "instructions": "Instructions",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/French-fr_FR.json
+++ b/src/locale/French-fr_FR.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instructions",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/German-de_DE.json
+++ b/src/locale/German-de_DE.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Anleitung",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/German-de_DE.json
+++ b/src/locale/German-de_DE.json
@@ -99,8 +99,8 @@
     "instructions": "Anleitung",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Greek-el_GR.json
+++ b/src/locale/Greek-el_GR.json
@@ -99,8 +99,8 @@
     "instructions": "Οδηγίες",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Greek-el_GR.json
+++ b/src/locale/Greek-el_GR.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Οδηγίες",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Hebrew-he_IL.json
+++ b/src/locale/Hebrew-he_IL.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "הוראות",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Hebrew-he_IL.json
+++ b/src/locale/Hebrew-he_IL.json
@@ -99,8 +99,8 @@
     "instructions": "הוראות",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Hungarian-hu_HU.json
+++ b/src/locale/Hungarian-hu_HU.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Utasítás",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Hungarian-hu_HU.json
+++ b/src/locale/Hungarian-hu_HU.json
@@ -99,8 +99,8 @@
     "instructions": "Utasítás",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Italian-it_IT.json
+++ b/src/locale/Italian-it_IT.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Istruzioni",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Italian-it_IT.json
+++ b/src/locale/Italian-it_IT.json
@@ -99,8 +99,8 @@
     "instructions": "Istruzioni",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Japanese-ja_JP.json
+++ b/src/locale/Japanese-ja_JP.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "指示",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Japanese-ja_JP.json
+++ b/src/locale/Japanese-ja_JP.json
@@ -99,8 +99,8 @@
     "instructions": "指示",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Korean-ko_KR.json
+++ b/src/locale/Korean-ko_KR.json
@@ -99,8 +99,8 @@
     "instructions": "명령",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Korean-ko_KR.json
+++ b/src/locale/Korean-ko_KR.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "명령",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Norwegian-no_NO.json
+++ b/src/locale/Norwegian-no_NO.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Bruksanvisning",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Norwegian-no_NO.json
+++ b/src/locale/Norwegian-no_NO.json
@@ -99,8 +99,8 @@
     "instructions": "Bruksanvisning",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Polish-pl_PL.json
+++ b/src/locale/Polish-pl_PL.json
@@ -99,8 +99,8 @@
     "instructions": "Instrukcje",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Polish-pl_PL.json
+++ b/src/locale/Polish-pl_PL.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instrukcje",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Portuguese-pt_PT.json
+++ b/src/locale/Portuguese-pt_PT.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instruções",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Portuguese-pt_PT.json
+++ b/src/locale/Portuguese-pt_PT.json
@@ -99,8 +99,8 @@
     "instructions": "Instruções",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Romanian-ro_RO.json
+++ b/src/locale/Romanian-ro_RO.json
@@ -99,8 +99,8 @@
     "instructions": "Instrucțiuni",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Romanian-ro_RO.json
+++ b/src/locale/Romanian-ro_RO.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instrucțiuni",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Russian-ru_RU.json
+++ b/src/locale/Russian-ru_RU.json
@@ -99,8 +99,8 @@
     "instructions": "инструкции",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Russian-ru_RU.json
+++ b/src/locale/Russian-ru_RU.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "инструкции",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Serbian (Cyrillic)-sr_SP.json
+++ b/src/locale/Serbian (Cyrillic)-sr_SP.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Инструкције",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Serbian (Cyrillic)-sr_SP.json
+++ b/src/locale/Serbian (Cyrillic)-sr_SP.json
@@ -99,8 +99,8 @@
     "instructions": "Инструкције",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Spanish-es_ES.json
+++ b/src/locale/Spanish-es_ES.json
@@ -99,8 +99,8 @@
     "instructions": "Instrucciones",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Spanish-es_ES.json
+++ b/src/locale/Spanish-es_ES.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instrucciones",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Swedish-sv_SE.json
+++ b/src/locale/Swedish-sv_SE.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Instruktioner",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Swedish-sv_SE.json
+++ b/src/locale/Swedish-sv_SE.json
@@ -99,8 +99,8 @@
     "instructions": "Instruktioner",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Turkish-tr_TR.json
+++ b/src/locale/Turkish-tr_TR.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Talimatlar",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Turkish-tr_TR.json
+++ b/src/locale/Turkish-tr_TR.json
@@ -99,8 +99,8 @@
     "instructions": "Talimatlar",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Ukrainian-uk_UA.json
+++ b/src/locale/Ukrainian-uk_UA.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Інструкція",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",

--- a/src/locale/Ukrainian-uk_UA.json
+++ b/src/locale/Ukrainian-uk_UA.json
@@ -99,8 +99,8 @@
     "instructions": "Інструкція",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Vietnamese-vi_VN.json
+++ b/src/locale/Vietnamese-vi_VN.json
@@ -99,8 +99,8 @@
     "instructions": "Hướng dẫn",
     "project": {
       "duplicate": {
-        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
-        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "already_exists": "The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.",
+        "could_not_move": "Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}",
         "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
       },
       "importing_local_project": "Importing local project",

--- a/src/locale/Vietnamese-vi_VN.json
+++ b/src/locale/Vietnamese-vi_VN.json
@@ -98,6 +98,11 @@
     "logout": "Log out",
     "instructions": "Hướng dẫn",
     "project": {
+      "duplicate": {
+        "already_exists": "<div>The project you selected (${projectName}) already exists.<br />Reimporting existing projects is not currently supported.</div>",
+        "could_not_move": "<div>Error occured while importing your project.<br />Could not move the project from ${fromPath} to ${toPath}</div>",
+        "was_not_found": "<div>Error occured while importing your project.<br />The project file ${projectName} was not found in ${fromPath}</div>"
+      },
       "importing_local_project": "Importing local project",
       "importing_file": "Importing ${file} Please wait...",
       "loading": "Loading your project data",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR adds localizes dialogs to the alerts related to duplicate imports

#### Please include detailed Test instructions for your pull request:
- Download and import this [project](https://github.com/unfoldingWord-dev/translationCore/files/1798445/57-TIT.usfm.zip).
- Select a license and language name(remember this for later).
- Go back to the projects tab and import the same project (from local projects)
- Ensure there is an alert saying you cannot import the same project twice including the project name

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4015)
<!-- Reviewable:end -->
