### PR TITLE
BugFix 3302/Fix Occurrence matching

### DIFF
--- a/src/js/helpers/VerseObjectHelpers.js
+++ b/src/js/helpers/VerseObjectHelpers.js
@@ -249,7 +249,7 @@ const addContentAttributeToChildren = (childrens, parentObject, grandParentConte
     if (child.children) {
       child = addContentAttributeToChildren(child.children, child, parentObject.content);
     } else if (!child.content && parentObject.content) {
-      const childrenContent = [parentObject.content];
+      const childrenContent = [parentObject];
       if (grandParentContent) childrenContent.push(grandParentContent);
       child.content = childrenContent;
     }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- in tW, now matches occurrence value for UGNT and ULB in order to fix problem with double highlights of God in Titus 1:1.

#### Please include detailed Test instructions for your pull request:
- depends on https://github.com/translationCoreApps/ScripturePane/pull/102
- in Titus project open tW, go to God, and try both instances of Titus 1:1.  Should see only one selection for each in UGNT and ULB.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4023)
<!-- Reviewable:end -->
