### PR TITLE
Bugfix 4086/Fix USFM3 import #2

### DIFF
--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -179,6 +179,49 @@ describe('UsfmFileConversionHelpers', () => {
     // test quotes
     expect(chapter1_data[5]).toEqual("For to which of the angels did God ever say, \"You are my son, today I have become your father\"? Or to which of the angels did God ever say, \"I will be a father to him, and he will be a son to me\"?");
   });
+
+  test('generateTargetLanguageBibleFromUsfm with aligned USFM and UGNT with milestones should succeed', async () => {
+    // given
+    fs.__setMockFS({
+    });
+    let mockManifest = {
+      project: {
+        id: 'tit'
+      },
+      target_language: {
+        id: "en"
+      }
+    };
+    const newUsfmProjectImportsPath = path.join(IMPORTS_PATH, 'project_folder_name', 'tit');
+    const testDataPath = path.join('__tests__','fixtures','project','alignmentUsfmImport','57-TIT.usfm');
+    const validUsfmString = fs.__actual.readFileSync(testDataPath).toString();
+    const RESOURCE_PATH = path.join(ospath.home(), 'translationCore', 'resources');
+    const resourcePath = "__tests__/fixtures/resources/";
+    const copyFiles = ['grc/bibles/ugnt/v0'];
+    fs.__loadFilesIntoMockFs(copyFiles, resourcePath, RESOURCE_PATH);
+
+    //when
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+
+    //then
+    expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
+
+    const chapter1_data = fs.readJSONSync(path.join(newUsfmProjectImportsPath, '1.json'));
+    expect(Object.keys(chapter1_data).length).toEqual(16);
+    expect(chapter1_data[1]).toEqual("Pablo, un siervo de Dios y apóstol de Jesucristo, por la fe del pueblo escogido de Dios y el conocimiento de la verdad que concuerda con la piedad. TEST");
+
+    // test alignments
+    const wordAlignmentDataPath = path.join(IMPORTS_PATH, 'project_folder_name', '.apps', 'translationCore', 'alignmentData', 'tit');
+    const chapter1_alignment = fs.readJSONSync(path.join(wordAlignmentDataPath, '1.json'));
+    expect(Object.keys(chapter1_alignment).length).toEqual(16);
+
+    const verse1_alignment = chapter1_alignment[1];
+    expect(verse1_alignment.alignments.length).toEqual(14);
+
+    const firstAlignment = verse1_alignment.alignments[0];
+    expect(firstAlignment.topWords[0].word).toEqual("Παῦλος");
+    expect(firstAlignment.bottomWords[0].word).toEqual("Pablo");
+  });
 });
 
 //

--- a/__tests__/fixtures/project/alignmentUsfmImport/57-TIT.usfm
+++ b/__tests__/fixtures/project/alignmentUsfmImport/57-TIT.usfm
@@ -1,0 +1,1138 @@
+\id TIT EN_ULB es-419_Español⋅Latin⋅America_ltr Tue Mar 20 2018 07:12:08 GMT-0400 (EDT) tc
+\h Titus
+\c 1
+\v 1
+\zaln-s | x-strong="G39720" x-lemma="Παῦλος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="Παῦλος"
+\w Pablo|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\zaln-s | x-strong="G14010" x-lemma="δοῦλος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="δοῦλος"
+\w un|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="2" x-content="Θεοῦ"
+\zaln-s | x-strong="G06520" x-lemma="ἀπόστολος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="ἀπόστολος"
+\w siervo|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G11610" x-lemma="δέ" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="δὲ"
+\w Dios|x-occurrence="1" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G24240" x-lemma="Ἰησοῦς" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="Ἰησοῦ"
+\w y|x-occurrence="1" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G55470" x-lemma="χριστός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="Χριστοῦ"
+\w apóstol|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G25960" x-lemma="κατά" x-morph="Gr,P,,,,,A,,," x-occurrence="1" x-occurrences="1" x-content="κατὰ"
+\w de|x-occurrence="2" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-s | x-strong="G41020" x-lemma="πίστις" x-morph="Gr,N,,,,,AFS," x-occurrence="1" x-occurrences="1" x-content="πίστιν"
+\w Jesucristo|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\zaln-s | x-strong="G15880" x-lemma="ἐκλεκτός" x-morph="Gr,NS,,,,GMP," x-occurrence="1" x-occurrences="1" x-content="ἐκλεκτῶν"
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="2" x-occurrences="2" x-content="Θεοῦ"
+\w la|x-occurrence="1" x-occurrences="3"\w*
+\zaln-e\*
+\zaln-s | x-strong="G25320" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="καὶ"
+\w fe|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G19220" x-lemma="ἐπίγνωσις" x-morph="Gr,N,,,,,AFS," x-occurrence="1" x-occurrences="1" x-content="ἐπίγνωσιν"
+\zaln-s | x-strong="G02250" x-lemma="ἀλήθεια" x-morph="Gr,N,,,,,GFS," x-occurrence="1" x-occurrences="1" x-content="ἀληθείας"
+\w del|x-occurrence="1" x-occurrences="1"\w*
+\w pueblo|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G35880" x-lemma="ὁ" x-morph="Gr,RR,,,,GFS," x-occurrence="1" x-occurrences="1" x-content="τῆς"
+\zaln-s | x-strong="G25960" x-lemma="κατά" x-morph="Gr,P,,,,,A,,," x-occurrence="1" x-occurrences="1" x-content="κατ’"
+\w escogido|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="3" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G21500" x-lemma="εὐσέβεια" x-morph="Gr,N,,,,,AFS," x-occurrence="1" x-occurrences="1" x-content="εὐσέβειαν"
+\w Dios|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G39720" x-lemma="Παῦλος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="Παῦλος"
+\w y|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*
+\zaln-s | x-strong="G14010" x-lemma="δοῦλος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="δοῦλος"
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w conocimiento|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="2" x-content="Θεοῦ"
+\zaln-s | x-strong="G06520" x-lemma="ἀπόστολος" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-content="ἀπόστολος"
+\w de|x-occurrence="4" x-occurrences="4"\w*
+\zaln-e\*
+\zaln-e\*
+\zaln-s | x-strong="G24240" x-lemma="Ἰησοῦς" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="Ἰησοῦ"
+\w la|x-occurrence="2" x-occurrences="3"\w*
+\zaln-e\*
+\zaln-s | x-strong="G55470" x-lemma="χριστός" x-morph="Gr,N,,,,,GMS," x-occurrence="1" x-occurrences="1" x-content="Χριστοῦ"
+\w verdad|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G25960" x-lemma="κατά" x-morph="Gr,P,,,,,A,,," x-occurrence="1" x-occurrences="1" x-content="κατὰ"
+\w concuerda|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-strong="G41020" x-lemma="πίστις" x-morph="Gr,N,,,,,AFS," x-occurrence="1" x-occurrences="1" x-content="πίστιν"
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="3" x-occurrences="3"\w*
+\zaln-e\*
+\zaln-s | x-strong="G23160" x-lemma="θεός" x-morph="Gr,N,,,,,GMS," x-occurrence="2" x-occurrences="2" x-content="Θεοῦ"
+\w piedad|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*.
+\zaln-s | x-strong="G25320" x-lemma="καί" x-morph="Gr,CC,,,,,,,," x-occurrence="1" x-occurrences="1" x-content="καὶ"
+\w TEST|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\v 2
+\zaln-s | x-lemma="ἐπί" x-morph="Gr,P,,,,,D,,," x-occurrence="1" x-occurrences="1" x-strong="G19090" x-content="ἐπ’"
+\w Estos|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-lemma="ἐλπίς" x-morph="Gr,N,,,,,DFS," x-occurrence="1" x-occurrences="1" x-strong="G16800" x-content="ἐλπίδι"
+\w son|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="2"\w*
+\w confianza|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w la|x-occurrence="2" x-occurrences="2"\w*
+\zaln-s | x-lemma="ζωή" x-morph="Gr,N,,,,,GFS," x-occurrence="1" x-occurrences="1" x-strong="G22220" x-content="ζωῆς"
+\w vida|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-lemma="αἰώνιος" x-morph="Gr,AA,,,,GFS," x-occurrence="1" x-occurrences="1" x-strong="G01660" x-content="αἰωνίου"
+\w eterna|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\zaln-s | x-lemma="θεός" x-morph="Gr,N,,,,,NMS," x-occurrence="1" x-occurrences="1" x-strong="G23160" x-content="Θεὸς"
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\zaln-s | x-lemma="ὅς" x-morph="Gr,RR,,,,AFS," x-occurrence="1" x-occurrences="1" x-alignmentIndex="3" x-strong="G37390" x-content="ἣν"
+\w Quien|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-lemma="ἀψευδής" x-morph="Gr,AA,,,,NMS," x-occurrence="1" x-occurrences="1" x-strong="G08930" x-content="ἀψευδὴς"
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w miente|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*,
+\zaln-s | x-lemma="ἐπαγγέλλω" x-morph="Gr,VTIAM3,,S," x-occurrence="1" x-occurrences="1" x-strong="G18610" x-content="ἐπηγγείλατο"
+\w prometida|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\w desde|x-occurrence="1" x-occurrences="1"\w*
+\zaln-s | x-lemma="πρό" x-morph="Gr,P,,,,,G,,," x-occurrence="1" x-occurrences="1" x-strong="G42530" x-content="πρὸ"
+\w antes|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-s | x-lemma="ὁ" x-morph="Gr,EA,,,,NMS," x-occurrence="1" x-occurrences="1" x-strong="G35880" x-content="ὁ"
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\zaln-e\*
+\w todos|x-occurrence="1" x-occurrences="1"\w*
+\w los|x-occurrence="1" x-occurrences="1"\w*
+\zaln-s | x-lemma="χρόνος" x-morph="Gr,N,,,,,GMP," x-occurrence="1" x-occurrences="1" x-strong="G55500" x-content="χρόνων"
+\zaln-s | x-lemma="αἰώνιος" x-morph="Gr,AA,,,,GMP," x-occurrence="1" x-occurrences="1" x-strong="G01660" x-content="αἰωνίων"
+\w tiempos|x-occurrence="1" x-occurrences="1"\w*
+\zaln-e\*
+\zaln-e\*. 
+\v 3
+\w En|x-occurrence="1" x-occurrences="1"\w*
+\w el|x-occurrence="1" x-occurrences="2"\w*
+\w momento|x-occurrence="1" x-occurrences="1"\w*
+\w adecuado|x-occurrence="1" x-occurrences="1"\w*,
+\w Él|x-occurrence="1" x-occurrences="2"\w*
+\w reveló|x-occurrence="1" x-occurrences="1"\w*
+\w Su|x-occurrence="1" x-occurrences="1"\w*
+\w palabra|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w el|x-occurrence="2" x-occurrences="2"\w*
+\w mensaje|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w Él|x-occurrence="2" x-occurrences="2"\w*
+\w confió|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w yo|x-occurrence="1" x-occurrences="1"\w*
+\w llevara|x-occurrence="1" x-occurrences="1"\w*.
+\w Yo|x-occurrence="1" x-occurrences="1"\w*
+\w habría|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w hacer|x-occurrence="1" x-occurrences="1"\w*
+\w esto|x-occurrence="1" x-occurrences="1"\w*
+\w según|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w orden|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*. 
+\v 4
+\w A|x-occurrence="1" x-occurrences="1"\w*
+\w Tito|x-occurrence="1" x-occurrences="1"\w*,
+\w un|x-occurrence="1" x-occurrences="1"\w*
+\w verdadero|x-occurrence="1" x-occurrences="1"\w*
+\w hijo|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w nuestra|x-occurrence="1" x-occurrences="1"\w*
+\w fe|x-occurrence="1" x-occurrences="1"\w*
+\w común|x-occurrence="1" x-occurrences="1"\w*.
+\w Gracia|x-occurrence="1" x-occurrences="1"\w*,
+\w misericordia|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="2"\w*
+\w paz|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w Padre|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="2" x-occurrences="2"\w*
+\w Cristo|x-occurrence="1" x-occurrences="1"\w*
+\w Jesús|x-occurrence="1" x-occurrences="1"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*. 
+\v 5
+\w Para|x-occurrence="1" x-occurrences="1"\w*
+\w este|x-occurrence="1" x-occurrences="1"\w*
+\w propósito|x-occurrence="1" x-occurrences="1"\w*
+\w te|x-occurrence="1" x-occurrences="2"\w*
+\w dejé|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="3"\w*
+\w Creta|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w pusieras|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="2" x-occurrences="3"\w*
+\w orden|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w han|x-occurrence="1" x-occurrences="1"\w*
+\w sido|x-occurrence="1" x-occurrences="1"\w*
+\w completadas|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w nombres|x-occurrence="1" x-occurrences="1"\w*
+\w ancianos|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="3" x-occurrences="3"\w*
+\w cada|x-occurrence="1" x-occurrences="1"\w*
+\w ciudad|x-occurrence="1" x-occurrences="1"\w*
+\w como|x-occurrence="1" x-occurrences="1"\w*
+\w te|x-occurrence="2" x-occurrences="2"\w*
+\w instruí|x-occurrence="1" x-occurrences="1"\w*. 
+\v 6
+\w El|x-occurrence="1" x-occurrences="1"\w*
+\w anciano|x-occurrence="1" x-occurrences="1"\w*
+\w debe|x-occurrence="1" x-occurrences="1"\w*
+\w ser|x-occurrence="1" x-occurrences="2"\w*
+\w irreprensible|x-occurrence="1" x-occurrences="1"\w*,
+\w esposo|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w una|x-occurrence="1" x-occurrences="1"\w*
+\w sola|x-occurrence="1" x-occurrences="1"\w*
+\w mujer|x-occurrence="1" x-occurrences="1"\w*,
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w hijos|x-occurrence="1" x-occurrences="1"\w*
+\w fieles|x-occurrence="1" x-occurrences="1"\w*,
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w sean|x-occurrence="1" x-occurrences="1"\w*
+\w acusados|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w ser|x-occurrence="2" x-occurrences="2"\w*
+\w malos|x-occurrence="1" x-occurrences="1"\w*
+\w o|x-occurrence="1" x-occurrences="1"\w*
+\w indisciplinados|x-occurrence="1" x-occurrences="1"\w*. 
+\v 7
+\w Es|x-occurrence="1" x-occurrences="1"\w*
+\w necesario|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w obispo|x-occurrence="1" x-occurrences="1"\w*,
+\w como|x-occurrence="1" x-occurrences="1"\w*
+\w administrador|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w casa|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*,
+\w sea|x-occurrence="1" x-occurrences="1"\w*
+\w irreprensible|x-occurrence="1" x-occurrences="1"\w*.
+\w No|x-occurrence="1" x-occurrences="2"\w*
+\w debe|x-occurrence="1" x-occurrences="2"\w*
+\w ser|x-occurrence="1" x-occurrences="2"\w*
+\w escandaloso|x-occurrence="1" x-occurrences="1"\w*
+\w o|x-occurrence="1" x-occurrences="1"\w*
+\w desenfrenado|x-occurrence="1" x-occurrences="1"\w*.
+\w No|x-occurrence="2" x-occurrences="2"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w debe|x-occurrence="2" x-occurrences="2"\w*
+\w enojar|x-occurrence="1" x-occurrences="1"\w*
+\w fácilmente|x-occurrence="1" x-occurrences="1"\w*,
+\w ni|x-occurrence="1" x-occurrences="2"\w*
+\w ser|x-occurrence="2" x-occurrences="2"\w*
+\w adicto|x-occurrence="1" x-occurrences="1"\w*
+\w al|x-occurrence="1" x-occurrences="1"\w*
+\w vino|x-occurrence="1" x-occurrences="1"\w*,
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w violento|x-occurrence="1" x-occurrences="1"\w*,
+\w ni|x-occurrence="2" x-occurrences="2"\w*
+\w avaro|x-occurrence="1" x-occurrences="1"\w*. 
+\v 8
+\w En|x-occurrence="1" x-occurrences="1"\w*
+\w su|x-occurrence="1" x-occurrences="1"\w*
+\w lugar|x-occurrence="1" x-occurrences="1"\w*,
+\w debe|x-occurrence="1" x-occurrences="1"\w*
+\w ser|x-occurrence="1" x-occurrences="2"\w*
+\w hospitalario|x-occurrence="1" x-occurrences="1"\w*,
+\w amigo|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w lo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w es|x-occurrence="1" x-occurrences="1"\w*
+\w bueno|x-occurrence="1" x-occurrences="1"\w*.
+\w Debe|x-occurrence="1" x-occurrences="1"\w*
+\w ser|x-occurrence="2" x-occurrences="2"\w*
+\w sensible|x-occurrence="1" x-occurrences="1"\w*,
+\w justo|x-occurrence="1" x-occurrences="1"\w*,
+\w piadoso|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w tener|x-occurrence="1" x-occurrences="1"\w*
+\w dominio|x-occurrence="1" x-occurrences="1"\w*
+\w propio|x-occurrence="1" x-occurrences="1"\w*. 
+\v 9
+\w Debe|x-occurrence="1" x-occurrences="1"\w*
+\w aferrarse|x-occurrence="1" x-occurrences="1"\w*
+\w fuertemente|x-occurrence="1" x-occurrences="1"\w*
+\w al|x-occurrence="1" x-occurrences="1"\w*
+\w mensaje|x-occurrence="1" x-occurrences="1"\w*
+\w confiable|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="3"\w*
+\w fue|x-occurrence="1" x-occurrences="1"\w*
+\w enseñado|x-occurrence="1" x-occurrences="1"\w*,
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w modo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="3"\w*
+\w él|x-occurrence="1" x-occurrences="1"\w*
+\w pueda|x-occurrence="1" x-occurrences="1"\w*
+\w motivar|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w otros|x-occurrence="1" x-occurrences="1"\w*
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w sana|x-occurrence="1" x-occurrences="1"\w*
+\w enseñanza|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w corregir|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w aquellos|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="3" x-occurrences="3"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w le|x-occurrence="1" x-occurrences="1"\w*
+\w oponen|x-occurrence="1" x-occurrences="1"\w*. 
+\v 10
+\w Porque|x-occurrence="1" x-occurrences="1"\w*
+\w hay|x-occurrence="1" x-occurrences="1"\w*
+\w muchas|x-occurrence="1" x-occurrences="1"\w*
+\w personas|x-occurrence="1" x-occurrences="2"\w*
+\w rebeldes|x-occurrence="1" x-occurrences="1"\w*,
+\w especialmente|x-occurrence="1" x-occurrences="1"\w*
+\w aquellos|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="2"\w*
+\w circuncisión|x-occurrence="1" x-occurrences="1"\w*.
+\w Sus|x-occurrence="1" x-occurrences="1"\w*
+\w palabras|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w tienen|x-occurrence="1" x-occurrences="1"\w*
+\w valor|x-occurrence="1" x-occurrences="1"\w*.
+\w Ellos|x-occurrence="1" x-occurrences="1"\w*
+\w engañan|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w guían|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w personas|x-occurrence="2" x-occurrences="2"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="2" x-occurrences="2"\w*
+\w dirección|x-occurrence="1" x-occurrences="1"\w*
+\w equivocada|x-occurrence="1" x-occurrences="1"\w*. 
+\v 11
+\w Es|x-occurrence="1" x-occurrences="1"\w*
+\w necesario|x-occurrence="1" x-occurrences="1"\w*
+\w detenerlos|x-occurrence="1" x-occurrences="1"\w*.
+\w Ellos|x-occurrence="1" x-occurrences="1"\w*
+\w enseñan|x-occurrence="1" x-occurrences="1"\w*
+\w lo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w deberían|x-occurrence="1" x-occurrences="1"\w*
+\w enseñar|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w ganancias|x-occurrence="1" x-occurrences="1"\w*
+\w deshonestas|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w corrompen|x-occurrence="1" x-occurrences="1"\w*
+\w familias|x-occurrence="1" x-occurrences="1"\w*
+\w enteras|x-occurrence="1" x-occurrences="1"\w*. 
+\v 12
+\w Uno|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w ellos|x-occurrence="1" x-occurrences="1"\w*,
+\w uno|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w hombres|x-occurrence="1" x-occurrences="1"\w*
+\w sabios|x-occurrence="1" x-occurrences="1"\w*,
+\w dijo|x-occurrence="1" x-occurrences="1"\w*:"\w Los|x-occurrence="1" x-occurrences="1"\w*
+\w Cretenses|x-occurrence="1" x-occurrences="1"\w*
+\w son|x-occurrence="1" x-occurrences="1"\w*
+\w incesantes|x-occurrence="1" x-occurrences="1"\w*
+\w mentirosos|x-occurrence="1" x-occurrences="1"\w*,
+\w animales|x-occurrence="1" x-occurrences="1"\w*
+\w malos|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w peligrosos|x-occurrence="1" x-occurrences="1"\w*,
+\w glotones|x-occurrence="1" x-occurrences="1"\w*
+\w ociosos|x-occurrence="1" x-occurrences="1"\w*." 
+\v 13
+\w Esta|x-occurrence="1" x-occurrences="1"\w*
+\w declaración|x-occurrence="1" x-occurrences="1"\w*
+\w es|x-occurrence="1" x-occurrences="1"\w*
+\w verdadera|x-occurrence="1" x-occurrences="1"\w*,
+\w así|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w corríjanlos|x-occurrence="1" x-occurrences="1"\w*
+\w severamente|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w puedan|x-occurrence="1" x-occurrences="1"\w*
+\w estar|x-occurrence="1" x-occurrences="1"\w*
+\w firmes|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w fe|x-occurrence="1" x-occurrences="1"\w*. 
+\v 14
+\w No|x-occurrence="1" x-occurrences="1"\w*
+\w le|x-occurrence="1" x-occurrences="1"\w*
+\w presten|x-occurrence="1" x-occurrences="1"\w*
+\w atención|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w mitos|x-occurrence="1" x-occurrences="1"\w*
+\w Judíos|x-occurrence="1" x-occurrences="1"\w*
+\w o|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w mandamientos|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w hombres|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w desvían|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w verdad|x-occurrence="1" x-occurrences="1"\w*. 
+\v 15
+\w Para|x-occurrence="1" x-occurrences="1"\w*
+\w aquellos|x-occurrence="1" x-occurrences="2"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w son|x-occurrence="1" x-occurrences="2"\w*
+\w puros|x-occurrence="1" x-occurrences="1"\w*,
+\w todas|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w son|x-occurrence="2" x-occurrences="2"\w*
+\w puras|x-occurrence="1" x-occurrences="1"\w*.
+\w Pero|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w aquellos|x-occurrence="2" x-occurrences="2"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w están|x-occurrence="1" x-occurrences="1"\w*
+\w manchados|x-occurrence="1" x-occurrences="1"\w*
+\w e|x-occurrence="1" x-occurrences="1"\w*
+\w incrédulos|x-occurrence="1" x-occurrences="1"\w*,
+\w nada|x-occurrence="1" x-occurrences="1"\w*
+\w es|x-occurrence="1" x-occurrences="1"\w*
+\w puro|x-occurrence="1" x-occurrences="1"\w*.
+\w Porque|x-occurrence="1" x-occurrences="1"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w mentes|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w conciencias|x-occurrence="1" x-occurrences="1"\w*
+\w han|x-occurrence="1" x-occurrences="1"\w*
+\w sido|x-occurrence="1" x-occurrences="1"\w*
+\w manchadas|x-occurrence="1" x-occurrences="1"\w*. 
+\v 16
+\w Ellos|x-occurrence="1" x-occurrences="1"\w*
+\w profesan|x-occurrence="1" x-occurrences="1"\w*
+\w conocer|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*,
+\w pero|x-occurrence="1" x-occurrences="1"\w*
+\w Lo|x-occurrence="1" x-occurrences="1"\w*
+\w niegan|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w acciones|x-occurrence="1" x-occurrences="1"\w*.
+\w Son|x-occurrence="1" x-occurrences="1"\w*
+\w detestables|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w desobedientes|x-occurrence="1" x-occurrences="1"\w*.
+\w Están|x-occurrence="1" x-occurrences="1"\w*
+\w desaprobados|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w cualquier|x-occurrence="1" x-occurrences="1"\w*
+\w buena|x-occurrence="1" x-occurrences="1"\w*
+\w obra|x-occurrence="1" x-occurrences="1"\w*.
+\c 2
+\v 1
+\w Pero|x-occurrence="1" x-occurrences="1"\w*
+\w tú|x-occurrence="1" x-occurrences="1"\w*,
+\w habla|x-occurrence="1" x-occurrences="1"\w*
+\w lo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w esté|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w acuerdo|x-occurrence="1" x-occurrences="1"\w*
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w fiel|x-occurrence="1" x-occurrences="1"\w*
+\w instrucción|x-occurrence="1" x-occurrences="1"\w*. 
+\v 2
+\w Los|x-occurrence="1" x-occurrences="1"\w*
+\w ancianos|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="1" x-occurrences="1"\w*
+\w ser|x-occurrence="1" x-occurrences="1"\w*
+\w moderados|x-occurrence="1" x-occurrences="1"\w*,
+\w dignos|x-occurrence="1" x-occurrences="1"\w*,
+\w sensibles|x-occurrence="1" x-occurrences="1"\w*,
+\w firmes|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="3"\w*
+\w fe|x-occurrence="1" x-occurrences="1"\w*,
+\w en|x-occurrence="2" x-occurrences="3"\w*
+\w amor|x-occurrence="1" x-occurrences="1"\w*,
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="3" x-occurrences="3"\w*
+\w perseverancia|x-occurrence="1" x-occurrences="1"\w*. 
+\v 3
+\w Las|x-occurrence="1" x-occurrences="1"\w*
+\w ancianas|x-occurrence="1" x-occurrences="1"\w*
+\w también|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="1" x-occurrences="2"\w*
+\w presentarse|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w sí|x-occurrence="1" x-occurrences="1"\w*
+\w mismas|x-occurrence="1" x-occurrences="1"\w*
+\w como|x-occurrence="1" x-occurrences="1"\w*
+\w reverentes|x-occurrence="1" x-occurrences="1"\w*,
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w chismosas|x-occurrence="1" x-occurrences="1"\w*.
+\w No|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="2" x-occurrences="2"\w*
+\w ser|x-occurrence="1" x-occurrences="1"\w*
+\w esclavas|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w mucho|x-occurrence="1" x-occurrences="1"\w*
+\w vino|x-occurrence="1" x-occurrences="1"\w*.
+\w Deben|x-occurrence="1" x-occurrences="1"\w*
+\w enseñar|x-occurrence="1" x-occurrences="1"\w*
+\w lo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w es|x-occurrence="1" x-occurrences="1"\w*
+\w bueno|x-occurrence="1" x-occurrences="1"\w* 
+\v 4
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w exhortar|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="3"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w mujeres|x-occurrence="1" x-occurrences="1"\w*
+\w más|x-occurrence="1" x-occurrences="1"\w*
+\w jóvenes|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="3"\w*
+\w amar|x-occurrence="1" x-occurrences="1"\w*
+\w sensiblemente|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="3" x-occurrences="3"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w propios|x-occurrence="1" x-occurrences="1"\w*
+\w esposos|x-occurrence="1" x-occurrences="1"\w*
+\w e|x-occurrence="1" x-occurrences="1"\w*
+\w hijos|x-occurrence="1" x-occurrences="1"\w*. 
+\v 5
+\w Deben|x-occurrence="1" x-occurrences="1"\w*
+\w enseñarles|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w ser|x-occurrence="1" x-occurrences="1"\w*
+\w sensibles|x-occurrence="1" x-occurrences="1"\w*,
+\w puras|x-occurrence="1" x-occurrences="1"\w*,
+\w buenas|x-occurrence="1" x-occurrences="1"\w*
+\w amas|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w casa|x-occurrence="1" x-occurrences="1"\w*,
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w obedientes|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w propios|x-occurrence="1" x-occurrences="1"\w*
+\w esposos|x-occurrence="1" x-occurrences="1"\w*.
+\w Ellas|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="1" x-occurrences="1"\w*
+\w hacer|x-occurrence="1" x-occurrences="1"\w*
+\w estas|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w palabra|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w sea|x-occurrence="1" x-occurrences="1"\w*
+\w insultada|x-occurrence="1" x-occurrences="1"\w*. 
+\v 6
+\w De|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w misma|x-occurrence="1" x-occurrences="1"\w*
+\w manera|x-occurrence="1" x-occurrences="1"\w*,
+\w exhorta|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w los|x-occurrence="1" x-occurrences="1"\w*
+\w hombres|x-occurrence="1" x-occurrences="1"\w*
+\w más|x-occurrence="1" x-occurrences="1"\w*
+\w jóvenes|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w ser|x-occurrence="1" x-occurrences="1"\w*
+\w sensibles|x-occurrence="1" x-occurrences="1"\w*. 
+\v 7
+\w En|x-occurrence="1" x-occurrences="1"\w*
+\w todas|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w preséntate|x-occurrence="1" x-occurrences="1"\w*
+\w como|x-occurrence="1" x-occurrences="1"\w*
+\w un|x-occurrence="1" x-occurrences="1"\w*
+\w modelo|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w buenas|x-occurrence="1" x-occurrences="1"\w*
+\w obras|x-occurrence="1" x-occurrences="1"\w*;
+\w y|x-occurrence="1" x-occurrences="2"\w*
+\w cuando|x-occurrence="1" x-occurrences="1"\w*
+\w enseñes|x-occurrence="1" x-occurrences="1"\w*,
+\w muestra|x-occurrence="1" x-occurrences="1"\w*
+\w integridad|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="2" x-occurrences="2"\w*
+\w dignidad|x-occurrence="1" x-occurrences="1"\w*. 
+\v 8
+\w Habla|x-occurrence="1" x-occurrences="1"\w*
+\w un|x-occurrence="1" x-occurrences="1"\w*
+\w mensaje|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="4"\w*
+\w sea|x-occurrence="1" x-occurrences="2"\w*
+\w saludable|x-occurrence="1" x-occurrences="1"\w*
+\w e|x-occurrence="1" x-occurrences="1"\w*
+\w irreprensible|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="4"\w*
+\w cualquiera|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="3" x-occurrences="4"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w oponga|x-occurrence="1" x-occurrences="1"\w*
+\w sea|x-occurrence="2" x-occurrences="2"\w*
+\w puesto|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w vergüenza|x-occurrence="1" x-occurrences="1"\w*,
+\w porque|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w tiene|x-occurrence="1" x-occurrences="1"\w*
+\w nada|x-occurrence="1" x-occurrences="1"\w*
+\w malo|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="4" x-occurrences="4"\w*
+\w decir|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w nosotros|x-occurrence="1" x-occurrences="1"\w*. 
+\v 9
+\w Los|x-occurrence="1" x-occurrences="1"\w*
+\w esclavos|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="1" x-occurrences="1"\w*
+\w obedecer|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w sus|x-occurrence="1" x-occurrences="1"\w*
+\w amos|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w todas|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*.
+\w Deben|x-occurrence="1" x-occurrences="1"\w*
+\w complacerlos|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w discutir|x-occurrence="1" x-occurrences="1"\w*
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w ellos|x-occurrence="1" x-occurrences="1"\w*. 
+\v 10
+\w Ellos|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w deben|x-occurrence="1" x-occurrences="2"\w*
+\w robar|x-occurrence="1" x-occurrences="1"\w*.
+\w En|x-occurrence="1" x-occurrences="1"\w*
+\w su|x-occurrence="1" x-occurrences="1"\w*
+\w lugar|x-occurrence="1" x-occurrences="1"\w*,
+\w deben|x-occurrence="2" x-occurrences="2"\w*
+\w mostrar|x-occurrence="1" x-occurrences="1"\w*
+\w toda|x-occurrence="1" x-occurrences="2"\w*
+\w buena|x-occurrence="1" x-occurrences="1"\w*
+\w fe|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w toda|x-occurrence="2" x-occurrences="2"\w*
+\w manera|x-occurrence="1" x-occurrences="1"\w*
+\w puedan|x-occurrence="1" x-occurrences="1"\w*
+\w adornar|x-occurrence="1" x-occurrences="1"\w*
+\w nuestra|x-occurrence="1" x-occurrences="1"\w*
+\w enseñanza|x-occurrence="1" x-occurrences="1"\w*
+\w acerca|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*. 
+\v 11
+\w Porque|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w gracia|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w aparecido|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w todas|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w personas|x-occurrence="1" x-occurrences="1"\w*. 
+\v 12
+\w Ella|x-occurrence="1" x-occurrences="1"\w*
+\w nos|x-occurrence="1" x-occurrences="1"\w*
+\w enseña|x-occurrence="1" x-occurrences="2"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w rechazar|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w impiedad|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="2"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w pasiones|x-occurrence="1" x-occurrences="1"\w*
+\w mundanas|x-occurrence="1" x-occurrences="1"\w*.
+\w Nos|x-occurrence="1" x-occurrences="1"\w*
+\w enseña|x-occurrence="2" x-occurrences="2"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w vivir|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w forma|x-occurrence="1" x-occurrences="1"\w*
+\w sensible|x-occurrence="1" x-occurrences="1"\w*,
+\w justa|x-occurrence="1" x-occurrences="1"\w*,
+\w y|x-occurrence="2" x-occurrences="2"\w*
+\w piadosa|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w esta|x-occurrence="1" x-occurrences="1"\w*
+\w edad|x-occurrence="1" x-occurrences="1"\w* 
+\v 13
+\w mientras|x-occurrence="1" x-occurrences="1"\w*
+\w esperamos|x-occurrence="1" x-occurrences="1"\w*
+\w recibir|x-occurrence="1" x-occurrences="1"\w*
+\w nuestra|x-occurrence="1" x-occurrences="1"\w*
+\w bendita|x-occurrence="1" x-occurrences="1"\w*
+\w esperanza|x-occurrence="1" x-occurrences="1"\w*,
+\w la|x-occurrence="1" x-occurrences="2"\w*
+\w aparición|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w la|x-occurrence="2" x-occurrences="2"\w*
+\w gloria|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w gran|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*
+\w Jesucristo|x-occurrence="1" x-occurrences="1"\w*. 
+\v 14
+\w Jesús|x-occurrence="1" x-occurrences="1"\w*
+\w se|x-occurrence="1" x-occurrences="1"\w*
+\w entregó|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w Sí|x-occurrence="1" x-occurrences="2"\w*
+\w mismo|x-occurrence="1" x-occurrences="2"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w nosotros|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="2"\w*
+\w redimirnos|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w todo|x-occurrence="1" x-occurrences="1"\w*
+\w desorden|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w hacer|x-occurrence="1" x-occurrences="2"\w*
+\w puras|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="2" x-occurrences="2"\w*
+\w Sí|x-occurrence="2" x-occurrences="2"\w*
+\w mismo|x-occurrence="2" x-occurrences="2"\w*,
+\w personas|x-occurrence="1" x-occurrences="1"\w*
+\w especiales|x-occurrence="1" x-occurrences="1"\w*
+\w quienes|x-occurrence="1" x-occurrences="1"\w*
+\w estén|x-occurrence="1" x-occurrences="1"\w*
+\w deseosas|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w hacer|x-occurrence="2" x-occurrences="2"\w*
+\w buenas|x-occurrence="1" x-occurrences="1"\w*
+\w obras|x-occurrence="1" x-occurrences="1"\w*. 
+\v 15
+\w Habla|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w exhorta|x-occurrence="1" x-occurrences="1"\w*
+\w estas|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*.
+\w Corrige|x-occurrence="1" x-occurrences="1"\w*
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w toda|x-occurrence="1" x-occurrences="1"\w*
+\w autoridad|x-occurrence="1" x-occurrences="1"\w*.
+\w No|x-occurrence="1" x-occurrences="1"\w*
+\w permitas|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w nadie|x-occurrence="1" x-occurrences="1"\w*
+\w te|x-occurrence="1" x-occurrences="1"\w*
+\w menosprecie|x-occurrence="1" x-occurrences="1"\w*.
+\c 3
+\v 1
+\w Recuérdales|x-occurrence="1" x-occurrences="1"\w*
+\w someterse|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w los|x-occurrence="1" x-occurrences="1"\w*
+\w gobernantes|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w autoridades|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="1" x-occurrences="3"\w*
+\w obedecerles|x-occurrence="1" x-occurrences="1"\w*,
+\w para|x-occurrence="2" x-occurrences="3"\w*
+\w estar|x-occurrence="1" x-occurrences="1"\w*
+\w listos|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="3" x-occurrences="3"\w*
+\w toda|x-occurrence="1" x-occurrences="1"\w*
+\w buena|x-occurrence="1" x-occurrences="1"\w*
+\w obra|x-occurrence="1" x-occurrences="1"\w*, 
+\v 2
+\w Recuérdales|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w injuriar|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="4"\w*
+\w nadie|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w evitar|x-occurrence="1" x-occurrences="1"\w*
+\w discusiones|x-occurrence="1" x-occurrences="1"\w*,
+\w permitir|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="4"\w*
+\w las|x-occurrence="1" x-occurrences="3"\w*
+\w demás|x-occurrence="1" x-occurrences="1"\w*
+\w personas|x-occurrence="1" x-occurrences="2"\w*
+\w hacer|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="2" x-occurrences="3"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="3" x-occurrences="4"\w*
+\w su|x-occurrence="1" x-occurrences="1"\w*
+\w manera|x-occurrence="1" x-occurrences="1"\w*,
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w mostrar|x-occurrence="1" x-occurrences="1"\w*
+\w humildad|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="4" x-occurrences="4"\w*
+\w todas|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="3" x-occurrences="3"\w*
+\w personas|x-occurrence="2" x-occurrences="2"\w*. 
+\v 3
+\w Porque|x-occurrence="1" x-occurrences="1"\w*
+\w una|x-occurrence="1" x-occurrences="1"\w*
+\w vez|x-occurrence="1" x-occurrences="1"\w*
+\w nosotros|x-occurrence="1" x-occurrences="1"\w*
+\w mismos|x-occurrence="1" x-occurrences="1"\w*
+\w fuimos|x-occurrence="1" x-occurrences="1"\w*
+\w desconsiderados|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="5"\w*
+\w desobedientes|x-occurrence="1" x-occurrences="1"\w*.
+\w Fuimos|x-occurrence="1" x-occurrences="1"\w*
+\w extraviados|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="2" x-occurrences="5"\w*
+\w esclavizados|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w varias|x-occurrence="1" x-occurrences="1"\w*
+\w pasiones|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="3" x-occurrences="5"\w*
+\w placeres|x-occurrence="1" x-occurrences="1"\w*.
+\w Vivimos|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w maldad|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="4" x-occurrences="5"\w*
+\w envidia|x-occurrence="1" x-occurrences="1"\w*.
+\w Éramos|x-occurrence="1" x-occurrences="1"\w*
+\w detestables|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="5" x-occurrences="5"\w*
+\w nos|x-occurrence="1" x-occurrences="1"\w*
+\w odiábamos|x-occurrence="1" x-occurrences="1"\w*
+\w unos|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w otros|x-occurrence="1" x-occurrences="1"\w*. 
+\v 4
+\w Pero|x-occurrence="1" x-occurrences="1"\w*
+\w cuando|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="2"\w*
+\w bondad|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w Su|x-occurrence="1" x-occurrences="1"\w*
+\w amor|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="2" x-occurrences="2"\w*
+\w humanidad|x-occurrence="1" x-occurrences="1"\w*
+\w apareció|x-occurrence="1" x-occurrences="1"\w*, 
+\v 5
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w fue|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="3"\w*
+\w obras|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w justicia|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w nosotros|x-occurrence="1" x-occurrences="1"\w*
+\w hicimos|x-occurrence="1" x-occurrences="1"\w*,
+\w sino|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="2" x-occurrences="3"\w*
+\w su|x-occurrence="1" x-occurrences="1"\w*
+\w misericordia|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w Él|x-occurrence="1" x-occurrences="1"\w*
+\w nos|x-occurrence="1" x-occurrences="1"\w*
+\w salvó|x-occurrence="1" x-occurrences="2"\w*.
+\w Nos|x-occurrence="1" x-occurrences="1"\w*
+\w salvó|x-occurrence="2" x-occurrences="2"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w través|x-occurrence="1" x-occurrences="1"\w*
+\w del|x-occurrence="1" x-occurrences="2"\w*
+\w lavado|x-occurrence="1" x-occurrences="1"\w*
+\w del|x-occurrence="2" x-occurrences="2"\w*
+\w nuevo|x-occurrence="1" x-occurrences="1"\w*
+\w nacimiento|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w renovación|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="3" x-occurrences="3"\w*
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w Espíritu|x-occurrence="1" x-occurrences="1"\w*
+\w Santo|x-occurrence="1" x-occurrences="1"\w*. 
+\v 6
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w derramó|x-occurrence="1" x-occurrences="1"\w*
+\w abundantemente|x-occurrence="1" x-occurrences="1"\w*
+\w su|x-occurrence="1" x-occurrences="1"\w*
+\w Espíritu|x-occurrence="1" x-occurrences="1"\w*
+\w Santo|x-occurrence="1" x-occurrences="1"\w*
+\w sobre|x-occurrence="1" x-occurrences="1"\w*
+\w nosotros|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="1" x-occurrences="2"\w*
+\w medio|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="2"\w*
+\w nuestro|x-occurrence="1" x-occurrences="1"\w*
+\w Salvador|x-occurrence="1" x-occurrences="1"\w*
+\w Jesucristo|x-occurrence="1" x-occurrences="1"\w*.
+\w Él|x-occurrence="1" x-occurrences="1"\w*
+\w hizo|x-occurrence="1" x-occurrences="1"\w*
+\w esto|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*,
+\w habiendo|x-occurrence="1" x-occurrences="1"\w*
+\w sido|x-occurrence="1" x-occurrences="1"\w*
+\w justificados|x-occurrence="1" x-occurrences="1"\w*
+\w por|x-occurrence="2" x-occurrences="2"\w*
+\w Su|x-occurrence="1" x-occurrences="1"\w*
+\w gracia|x-occurrence="1" x-occurrences="1"\w*,
+\w pudiéramos|x-occurrence="1" x-occurrences="1"\w*
+\w ser|x-occurrence="1" x-occurrences="1"\w*
+\w participantes|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="2"\w*
+\w confianza|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="2" x-occurrences="2"\w*
+\w la|x-occurrence="2" x-occurrences="2"\w*
+\w vida|x-occurrence="1" x-occurrences="1"\w*
+\w eterna|x-occurrence="1" x-occurrences="1"\w*. 
+\v 7 
+\v 8
+\w Este|x-occurrence="1" x-occurrences="1"\w*
+\w mensaje|x-occurrence="1" x-occurrences="1"\w*
+\w es|x-occurrence="1" x-occurrences="1"\w*
+\w confiable|x-occurrence="1" x-occurrences="1"\w*.
+\w Quiero|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="4"\w*
+\w hables|x-occurrence="1" x-occurrences="1"\w*
+\w confiadamente|x-occurrence="1" x-occurrences="1"\w*
+\w sobre|x-occurrence="1" x-occurrences="1"\w*
+\w estas|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="2"\w*,
+\w para|x-occurrence="1" x-occurrences="2"\w*
+\w que|x-occurrence="2" x-occurrences="4"\w*
+\w aquéllos|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="3" x-occurrences="4"\w*
+\w confían|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="2"\w*
+\w Dios|x-occurrence="1" x-occurrences="1"\w*
+\w puedan|x-occurrence="1" x-occurrences="1"\w*
+\w mantenerse|x-occurrence="1" x-occurrences="1"\w*
+\w dispuestos|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="2" x-occurrences="2"\w*
+\w las|x-occurrence="1" x-occurrences="2"\w*
+\w buenas|x-occurrence="1" x-occurrences="2"\w*
+\w obras|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="4" x-occurrences="4"\w*
+\w Él|x-occurrence="1" x-occurrences="1"\w*
+\w puso|x-occurrence="1" x-occurrences="1"\w*
+\w ante|x-occurrence="1" x-occurrences="1"\w*
+\w ellos|x-occurrence="1" x-occurrences="1"\w*.
+\w Estas|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="2" x-occurrences="2"\w*
+\w son|x-occurrence="1" x-occurrences="1"\w*
+\w buenas|x-occurrence="2" x-occurrences="2"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w beneficiosas|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="2" x-occurrences="2"\w*
+\w toda|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="2" x-occurrences="2"\w*
+\w personas|x-occurrence="1" x-occurrences="1"\w*. 
+\v 9
+\w Pero|x-occurrence="1" x-occurrences="1"\w*
+\w evita|x-occurrence="1" x-occurrences="1"\w*
+\w debates|x-occurrence="1" x-occurrences="1"\w*
+\w necios|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="3"\w*
+\w genealogías|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="2" x-occurrences="3"\w*
+\w contiendas|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="3" x-occurrences="3"\w*
+\w conflictos|x-occurrence="1" x-occurrences="1"\w*
+\w sobre|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w ley|x-occurrence="1" x-occurrences="1"\w*.
+\w Esas|x-occurrence="1" x-occurrences="1"\w*
+\w cosas|x-occurrence="1" x-occurrences="1"\w*
+\w son|x-occurrence="1" x-occurrences="1"\w*
+\w sin|x-occurrence="1" x-occurrences="1"\w*
+\w valor|x-occurrence="1" x-occurrences="1"\w*
+\w ni|x-occurrence="1" x-occurrences="1"\w*
+\w provecho|x-occurrence="1" x-occurrences="1"\w*. 
+\v 10
+\w Rechaza|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w cualquiera|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w esté|x-occurrence="1" x-occurrences="1"\w*
+\w causando|x-occurrence="1" x-occurrences="1"\w*
+\w divisiones|x-occurrence="1" x-occurrences="1"\w*
+\w entre|x-occurrence="1" x-occurrences="1"\w*
+\w ustedes|x-occurrence="1" x-occurrences="1"\w*,
+\w después|x-occurrence="1" x-occurrences="1"\w*
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w una|x-occurrence="1" x-occurrences="1"\w*
+\w o|x-occurrence="1" x-occurrences="1"\w*
+\w dos|x-occurrence="1" x-occurrences="1"\w*
+\w advertencias|x-occurrence="1" x-occurrences="1"\w*, 
+\v 11
+\w y|x-occurrence="1" x-occurrences="3"\w*
+\w conoce|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w uno|x-occurrence="1" x-occurrences="1"\w*
+\w como|x-occurrence="1" x-occurrences="1"\w*
+\w ese|x-occurrence="1" x-occurrences="1"\w*
+\w se|x-occurrence="1" x-occurrences="2"\w*
+\w ha|x-occurrence="1" x-occurrences="1"\w*
+\w desviado|x-occurrence="1" x-occurrences="1"\w*
+\w del|x-occurrence="1" x-occurrences="1"\w*
+\w buen|x-occurrence="1" x-occurrences="1"\w*
+\w camino|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="2" x-occurrences="3"\w*
+\w está|x-occurrence="1" x-occurrences="1"\w*
+\w pecando|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="3" x-occurrences="3"\w*
+\w se|x-occurrence="2" x-occurrences="2"\w*
+\w condena|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w sí|x-occurrence="1" x-occurrences="1"\w*
+\w mismo|x-occurrence="1" x-occurrences="1"\w*. 
+\v 12
+\w Cuando|x-occurrence="1" x-occurrences="1"\w*
+\w yo|x-occurrence="1" x-occurrences="1"\w*
+\w te|x-occurrence="1" x-occurrences="1"\w*
+\w envíe|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="2"\w*
+\w Artemas|x-occurrence="1" x-occurrences="1"\w*
+\w o|x-occurrence="1" x-occurrences="1"\w*
+\w Tíquico|x-occurrence="1" x-occurrences="1"\w*,
+\w apresúrate|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="1"\w*
+\w ven|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="2" x-occurrences="2"\w*
+\w mí|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w Nicópolis|x-occurrence="1" x-occurrences="1"\w*,
+\w donde|x-occurrence="1" x-occurrences="1"\w*
+\w he|x-occurrence="1" x-occurrences="1"\w*
+\w decidido|x-occurrence="1" x-occurrences="1"\w*
+\w pasar|x-occurrence="1" x-occurrences="1"\w*
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w invierno|x-occurrence="1" x-occurrences="1"\w*. 
+\v 13
+\w Apresúrate|x-occurrence="1" x-occurrences="1"\w*
+\w y|x-occurrence="1" x-occurrences="2"\w*
+\w envía|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w Zenas|x-occurrence="1" x-occurrences="1"\w*,
+\w el|x-occurrence="1" x-occurrences="1"\w*
+\w experto|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w ley|x-occurrence="1" x-occurrences="1"\w*,
+\w y|x-occurrence="2" x-occurrences="2"\w*
+\w Apolos|x-occurrence="1" x-occurrences="1"\w*,
+\w de|x-occurrence="1" x-occurrences="1"\w*
+\w manera|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="1"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w les|x-occurrence="1" x-occurrences="1"\w*
+\w falte|x-occurrence="1" x-occurrences="1"\w*
+\w nada|x-occurrence="1" x-occurrences="1"\w*. 
+\v 14
+\w Nuestra|x-occurrence="1" x-occurrences="1"\w*
+\w gente|x-occurrence="1" x-occurrences="1"\w*
+\w debe|x-occurrence="1" x-occurrences="1"\w*
+\w aprender|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w ocuparse|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w buenas|x-occurrence="1" x-occurrences="1"\w*
+\w obras|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w atiendan|x-occurrence="1" x-occurrences="1"\w*
+\w las|x-occurrence="1" x-occurrences="1"\w*
+\w necesidades|x-occurrence="1" x-occurrences="1"\w*
+\w apremiantes|x-occurrence="1" x-occurrences="1"\w*
+\w para|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w no|x-occurrence="1" x-occurrences="1"\w*
+\w sean|x-occurrence="1" x-occurrences="1"\w*
+\w infructíferos|x-occurrence="1" x-occurrences="1"\w*. 
+\v 15
+\w Todos|x-occurrence="1" x-occurrences="1"\w*
+\w esos|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="1" x-occurrences="2"\w*
+\w están|x-occurrence="1" x-occurrences="1"\w*
+\w conmigo|x-occurrence="1" x-occurrences="1"\w*
+\w te|x-occurrence="1" x-occurrences="1"\w*
+\w saludan|x-occurrence="1" x-occurrences="1"\w*.
+\w Saluda|x-occurrence="1" x-occurrences="1"\w*
+\w a|x-occurrence="1" x-occurrences="1"\w*
+\w los|x-occurrence="1" x-occurrences="1"\w*
+\w que|x-occurrence="2" x-occurrences="2"\w*
+\w nos|x-occurrence="1" x-occurrences="1"\w*
+\w aman|x-occurrence="1" x-occurrences="1"\w*
+\w en|x-occurrence="1" x-occurrences="1"\w*
+\w la|x-occurrence="1" x-occurrences="1"\w*
+\w fe|x-occurrence="1" x-occurrences="1"\w*.
+\w La|x-occurrence="1" x-occurrences="1"\w*
+\w gracia|x-occurrence="1" x-occurrences="1"\w*
+\w sea|x-occurrence="1" x-occurrences="1"\w*
+\w con|x-occurrence="1" x-occurrences="1"\w*
+\w todos|x-occurrence="1" x-occurrences="1"\w*
+\w ustedes|x-occurrence="1" x-occurrences="1"\w*.

--- a/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/1.json
+++ b/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/1.json
@@ -1,0 +1,2512 @@
+{
+  "1": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "Παῦλος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Παῦλος",
+        "strong": "G39720",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/names/paul"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "δοῦλος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δοῦλος",
+        "strong": "G14010",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/other/servant"
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀπόστολος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπόστολος",
+        "strong": "G06520",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/apostle"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/jesus",
+        "children": [
+          {
+            "text": "Ἰησοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "Ἰησοῦς",
+            "strong": "G24240",
+            "morph": "Gr,N,,,,,GMS,"
+          },
+          {
+            "text": "Χριστοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "χριστός",
+            "strong": "G55470",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/christ"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κατὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πίστιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "text": "ἐκλεκτῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκλεκτός",
+        "strong": "G15880",
+        "morph": "Gr,NS,,,,GMP,",
+        "tw": "rc://*/tw/dict/bible/kt/elect"
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἐπίγνωσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπίγνωσις",
+        "strong": "G19220",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/other/know"
+      },
+      {
+        "text": "ἀληθείας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλήθεια",
+        "strong": "G02250",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/true"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RR,,,,GFS,"
+      },
+      {
+        "text": "κατ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "εὐσέβειαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εὐσέβεια",
+        "strong": "G21500",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/godly"
+      },
+      {
+        "type": "text",
+        "text": "\n\n"
+      }
+    ]
+  },
+  "2": {
+    "verseObjects": [
+      {
+        "text": "ἐπ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπί",
+        "strong": "G19090",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "ἐλπίδι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλπίς",
+        "strong": "G16800",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/hope"
+      },
+      {
+        "text": "ζωῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ζωή",
+        "strong": "G22220",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/life"
+      },
+      {
+        "text": "αἰωνίου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰώνιος",
+        "strong": "G01660",
+        "morph": "Gr,AA,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/eternity"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἣν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RR,,,,AFS,"
+      },
+      {
+        "text": "ἐπηγγείλατο",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπαγγέλλω",
+        "strong": "G18610",
+        "morph": "Gr,V,IAM3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/promise"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMS,"
+      },
+      {
+        "text": "ἀψευδὴς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀψευδής",
+        "strong": "G08930",
+        "morph": "Gr,AA,,,,NMS,"
+      },
+      {
+        "text": "Θεὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "text": "πρὸ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρό",
+        "strong": "G42530",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "χρόνων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χρόνος",
+        "strong": "G55500",
+        "morph": "Gr,N,,,,,GMP,",
+        "tw": "rc://*/tw/dict/bible/other/time"
+      },
+      {
+        "text": "αἰωνίων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰώνιος",
+        "strong": "G01660",
+        "morph": "Gr,AA,,,,GMP,",
+        "tw": "rc://*/tw/dict/bible/kt/eternity"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "3": {
+    "verseObjects": [
+      {
+        "text": "ἐφανέρωσεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φανερόω",
+        "strong": "G53190",
+        "morph": "Gr,V,IAA3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/reveal"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "καιροῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καιρός",
+        "strong": "G25400",
+        "morph": "Gr,N,,,,,DMP,",
+        "tw": "rc://*/tw/dict/bible/other/time"
+      },
+      {
+        "text": "ἰδίοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἴδιος",
+        "strong": "G23980",
+        "morph": "Gr,EF,,,,DMP,"
+      },
+      {
+        "text": "τὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AMS,"
+      },
+      {
+        "text": "λόγον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λόγος",
+        "strong": "G30560",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/wordofgod"
+      },
+      {
+        "text": "αὐτοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3GMS,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "κηρύγματι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κήρυγμα",
+        "strong": "G27820",
+        "morph": "Gr,N,,,,,DNS,",
+        "tw": "rc://*/tw/dict/bible/other/preach"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RR,,,,ANS,"
+      },
+      {
+        "text": "ἐπιστεύθην",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πιστεύω",
+        "strong": "G41000",
+        "morph": "Gr,V,IAP1,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/trust"
+      },
+      {
+        "text": "ἐγὼ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1N,S,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κατ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "ἐπιταγὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιταγή",
+        "strong": "G20030",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/command"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "4": {
+    "verseObjects": [
+      {
+        "text": "Τίτῳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Τίτος",
+        "strong": "G51030",
+        "morph": "Gr,N,,,,,DMS,",
+        "tw": "rc://*/tw/dict/bible/names/titus"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "γνησίῳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γνήσιος",
+        "strong": "G11030",
+        "morph": "Gr,AA,,,,DNS,",
+        "tw": "rc://*/tw/dict/bible/kt/true"
+      },
+      {
+        "text": "τέκνῳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τέκνον",
+        "strong": "G50430",
+        "morph": "Gr,N,,,,,DNS,",
+        "tw": "rc://*/tw/dict/bible/kt/son"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κατὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "κοινὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κοινός",
+        "strong": "G28390",
+        "morph": "Gr,AA,,,,AFS,"
+      },
+      {
+        "text": "πίστιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "type": "text",
+        "text": ":"
+      },
+      {
+        "text": "χάρις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάρις",
+        "strong": "G54850",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/grace"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "εἰρήνη",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰρήνη",
+        "strong": "G15150",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/other/peace"
+      },
+      {
+        "text": "ἀπὸ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπό",
+        "strong": "G05750",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/godthefather",
+        "children": [
+          {
+            "text": "Θεοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "θεός",
+            "strong": "G23160",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/god"
+          },
+          {
+            "text": "Πατρὸς",
+            "tag": "w",
+            "type": "word",
+            "lemma": "πατήρ",
+            "strong": "G39620",
+            "morph": "Gr,N,,,,,GMS,"
+          }
+        ]
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/jesus",
+        "children": [
+          {
+            "text": "Χριστοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "χριστός",
+            "strong": "G55470",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/christ"
+          },
+          {
+            "text": "Ἰησοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "Ἰησοῦς",
+            "strong": "G24240",
+            "morph": "Gr,N,,,,,GMS,"
+          }
+        ]
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "5": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "τούτου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὗτος",
+        "strong": "G37780",
+        "morph": "Gr,RD,,,,GNS,"
+      },
+      {
+        "text": "χάριν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάριν",
+        "strong": "G54840",
+        "morph": "Gr,PI,,,,G,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀπέλιπόν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπολίπω",
+        "strong": "G06200",
+        "morph": "Gr,V,IAA1,,S,"
+      },
+      {
+        "text": "σε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2A,S,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "Κρήτῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Κρήτη",
+        "strong": "G29140",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/names/crete"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "τὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,ANP,"
+      },
+      {
+        "text": "λείποντα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λείπω",
+        "strong": "G30070",
+        "morph": "Gr,V,PPA,ANP,"
+      },
+      {
+        "text": "ἐπιδιορθώσῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιδιορθόω",
+        "strong": "G19300",
+        "morph": "Gr,V,SAM2,,S,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "καταστήσῃς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καθίστημι",
+        "strong": "G25250",
+        "morph": "Gr,V,SAA2,,S,",
+        "tw": "rc://*/tw/dict/bible/other/ordain"
+      },
+      {
+        "text": "κατὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πόλιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πόλις",
+        "strong": "G41720",
+        "morph": "Gr,N,,,,,AFS,"
+      },
+      {
+        "text": "πρεσβυτέρους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρεσβύτερος",
+        "strong": "G42450",
+        "morph": "Gr,NS,,,,AMPC",
+        "tw": "rc://*/tw/dict/bible/other/elder"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὡς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὡς",
+        "strong": "G56130",
+        "morph": "Gr,CS,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/like"
+      },
+      {
+        "text": "ἐγώ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1N,S,"
+      },
+      {
+        "text": "σοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2D,S,"
+      },
+      {
+        "text": "διεταξάμην",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διατάσσω",
+        "strong": "G12990",
+        "morph": "Gr,V,IAM1,,S,",
+        "tw": "rc://*/tw/dict/bible/other/ordain"
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "6": {
+    "verseObjects": [
+      {
+        "text": "εἴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰ",
+        "strong": "G14870",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "τίς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τις",
+        "strong": "G51000",
+        "morph": "Gr,RI,,,,NMS,"
+      },
+      {
+        "text": "ἐστιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "ἀνέγκλητος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνέγκλητος",
+        "strong": "G04100",
+        "morph": "Gr,NP,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/blameless"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μιᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἷς",
+        "strong": "G15200",
+        "morph": "Gr,EN,,,,GFS,"
+      },
+      {
+        "text": "γυναικὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γυνή",
+        "strong": "G11350",
+        "morph": "Gr,N,,,,,GFS,"
+      },
+      {
+        "text": "ἀνήρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνήρ",
+        "strong": "G04350",
+        "morph": "Gr,N,,,,,NMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τέκνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τέκνον",
+        "strong": "G50430",
+        "morph": "Gr,N,,,,,ANP,",
+        "tw": "rc://*/tw/dict/bible/kt/children"
+      },
+      {
+        "text": "ἔχων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔχω",
+        "strong": "G21920",
+        "morph": "Gr,V,PPA,NMS,"
+      },
+      {
+        "text": "πιστά",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πιστός",
+        "strong": "G41030",
+        "morph": "Gr,NS,,,,ANP,",
+        "tw": "rc://*/tw/dict/bible/kt/faithful"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "κατηγορίᾳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατηγορία",
+        "strong": "G27240",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/other/accuse"
+      },
+      {
+        "text": "ἀσωτίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀσωτία",
+        "strong": "G08100",
+        "morph": "Gr,N,,,,,GFS,"
+      },
+      {
+        "text": "ἢ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἤ",
+        "strong": "G22280",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἀνυπότακτα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνυπότακτος",
+        "strong": "G05060",
+        "morph": "Gr,NP,,,,ANP,",
+        "tw": "rc://*/tw/dict/bible/other/rebel"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "7": {
+    "verseObjects": [
+      {
+        "text": "δεῖ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέω",
+        "strong": "G12100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "γὰρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "τὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AMS,"
+      },
+      {
+        "text": "ἐπίσκοπον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπίσκοπος",
+        "strong": "G19850",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/overseer"
+      },
+      {
+        "text": "ἀνέγκλητον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνέγκλητος",
+        "strong": "G04100",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/blameless"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὡς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὡς",
+        "strong": "G56130",
+        "morph": "Gr,CS,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/like"
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "text": "οἰκονόμον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οἰκονόμος",
+        "strong": "G36230",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/manager"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "αὐθάδη",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐθάδης",
+        "strong": "G08290",
+        "morph": "Gr,NS,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ὀργίλον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὀργίλος",
+        "strong": "G37110",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/angry"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "πάροινον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πάροινος",
+        "strong": "G39430",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/wine"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "πλήκτην",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πλήκτης",
+        "strong": "G41310",
+        "morph": "Gr,N,,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "αἰσχροκερδῆ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰσχροκερδής",
+        "strong": "G01460",
+        "morph": "Gr,NS,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "8": {
+    "verseObjects": [
+      {
+        "text": "ἀλλὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλλά",
+        "strong": "G02350",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "φιλόξενον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φιλόξενος",
+        "strong": "G53820",
+        "morph": "Gr,NS,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "φιλάγαθον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φιλάγαθος",
+        "strong": "G53580",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σώφρονα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σώφρων",
+        "strong": "G49980",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/selfcontrol"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "δίκαιον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δίκαιος",
+        "strong": "G13420",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/righteous"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὅσιον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅσιος",
+        "strong": "G37410",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/holy"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἐγκρατῆ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγκρατής",
+        "strong": "G14680",
+        "morph": "Gr,NS,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/discipline"
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "9": {
+    "verseObjects": [
+      {
+        "text": "ἀντεχόμενον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀντέχω",
+        "strong": "G04720",
+        "morph": "Gr,V,PPM,AMS,"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "κατὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFS,"
+      },
+      {
+        "text": "διδαχὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδαχή",
+        "strong": "G13220",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/other/teach"
+      },
+      {
+        "text": "πιστοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πιστός",
+        "strong": "G41030",
+        "morph": "Gr,AA,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/faithful"
+      },
+      {
+        "text": "λόγου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λόγος",
+        "strong": "G30560",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/other/word"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "δυνατὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δυνατός",
+        "strong": "G14150",
+        "morph": "Gr,NS,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/power"
+      },
+      {
+        "text": "ᾖ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,SPA3,,S,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,DO,,,,,,,,"
+      },
+      {
+        "text": "παρακαλεῖν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παρακαλέω",
+        "strong": "G38700",
+        "morph": "Gr,V,NPA,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/courage"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "διδασκαλίᾳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδασκαλία",
+        "strong": "G13190",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/other/doctrine"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,DFS,"
+      },
+      {
+        "text": "ὑγιαινούσῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑγιαίνω",
+        "strong": "G51980",
+        "morph": "Gr,V,PPA,DFS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CO,,,,,,,,"
+      },
+      {
+        "text": "τοὺς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,AMP,"
+      },
+      {
+        "text": "ἀντιλέγοντας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀντιλέγω",
+        "strong": "G04830",
+        "morph": "Gr,V,PPA,AMP,"
+      },
+      {
+        "text": "ἐλέγχειν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλέγχω",
+        "strong": "G16510",
+        "morph": "Gr,V,NPA,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/rebuke"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "10": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "εἰσὶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IPA3,,P,"
+      },
+      {
+        "text": "γὰρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "πολλοὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πολλός",
+        "strong": "G41830",
+        "morph": "Gr,RI,,,,NMP,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ἀνυπότακτοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνυπότακτος",
+        "strong": "G05060",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/rebel"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ματαιολόγοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ματαιολόγος",
+        "strong": "G31510",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/vain"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "φρεναπάται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φρεναπάτης",
+        "strong": "G54230",
+        "morph": "Gr,N,,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/deceive"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μάλιστα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μάλιστα",
+        "strong": "G31220",
+        "morph": "Gr,D,,,,,,,,S"
+      },
+      {
+        "text": "οἱ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,NMP,"
+      },
+      {
+        "text": "ἐκ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκ",
+        "strong": "G15370",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "τῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GFS,"
+      },
+      {
+        "text": "περιτομῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περιτομή",
+        "strong": "G40610",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/circumcise"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "11": {
+    "verseObjects": [
+      {
+        "text": "οὓς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RR,,,,AMP,"
+      },
+      {
+        "text": "δεῖ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέω",
+        "strong": "G12100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "ἐπιστομίζειν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιστομίζω",
+        "strong": "G19930",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "οἵτινες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅστις",
+        "strong": "G37480",
+        "morph": "Gr,RR,,,,NMP,"
+      },
+      {
+        "text": "ὅλους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅλος",
+        "strong": "G36500",
+        "morph": "Gr,EQ,,,,AMP,"
+      },
+      {
+        "text": "οἴκους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οἶκος",
+        "strong": "G36240",
+        "morph": "Gr,N,,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/other/household"
+      },
+      {
+        "text": "ἀνατρέπουσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνατρέπω",
+        "strong": "G03960",
+        "morph": "Gr,V,IPA3,,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "διδάσκοντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδάσκω",
+        "strong": "G13210",
+        "morph": "Gr,V,PPA,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/teach"
+      },
+      {
+        "text": "ἃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RD,,,,ANP,"
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "δεῖ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέω",
+        "strong": "G12100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "αἰσχροῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰσχρός",
+        "strong": "G01500",
+        "morph": "Gr,AA,,,,GNS,",
+        "tw": "rc://*/tw/dict/bible/other/shame"
+      },
+      {
+        "text": "κέρδους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κέρδος",
+        "strong": "G27710",
+        "morph": "Gr,N,,,,,GNS,",
+        "tw": "rc://*/tw/dict/bible/other/profit"
+      },
+      {
+        "text": "χάριν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάριν",
+        "strong": "G54840",
+        "morph": "Gr,PI,,,,G,,,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "12": {
+    "verseObjects": [
+      {
+        "text": "εἶπέν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λέγω",
+        "strong": "G30040",
+        "morph": "Gr,V,IAA3,,S,"
+      },
+      {
+        "text": "τις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τις",
+        "strong": "G51000",
+        "morph": "Gr,RI,,,,NMS,"
+      },
+      {
+        "text": "ἐξ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκ",
+        "strong": "G15370",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "αὐτῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3GMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἴδιος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἴδιος",
+        "strong": "G23980",
+        "morph": "Gr,RD,,,,NMS,"
+      },
+      {
+        "text": "αὐτῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3GMP,"
+      },
+      {
+        "text": "προφήτης",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προφήτης",
+        "strong": "G43960",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/prophet"
+      },
+      {
+        "type": "text",
+        "text": ",\n“"
+      },
+      {
+        "text": "Κρῆτες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Κρής",
+        "strong": "G29120",
+        "morph": "Gr,N,,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/names/crete"
+      },
+      {
+        "text": "ἀεὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀεί",
+        "strong": "G01040",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ψεῦσται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ψεύστης",
+        "strong": "G55830",
+        "morph": "Gr,N,,,,,NMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κακὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κακός",
+        "strong": "G25560",
+        "morph": "Gr,AA,,,,NNP,",
+        "tw": "rc://*/tw/dict/bible/kt/evil"
+      },
+      {
+        "text": "θηρία",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θηρίον",
+        "strong": "G23420",
+        "morph": "Gr,N,,,,,NNP,",
+        "tw": "rc://*/tw/dict/bible/other/beast"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "γαστέρες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γαστήρ",
+        "strong": "G10640",
+        "morph": "Gr,N,,,,,NFP,",
+        "tw": "rc://*/tw/dict/bible/other/womb"
+      },
+      {
+        "text": "ἀργαί",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀργός",
+        "strong": "G06920",
+        "morph": "Gr,AA,,,,NFP,"
+      },
+      {
+        "type": "text",
+        "text": ".”\n\n"
+      }
+    ]
+  },
+  "13": {
+    "verseObjects": [
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "μαρτυρία",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μαρτυρία",
+        "strong": "G31410",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/testimony"
+      },
+      {
+        "text": "αὕτη",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὗτος",
+        "strong": "G37780",
+        "morph": "Gr,ED,,,,NFS,"
+      },
+      {
+        "text": "ἐστὶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "ἀληθής",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀληθής",
+        "strong": "G02270",
+        "morph": "Gr,NP,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/true"
+      },
+      {
+        "type": "text",
+        "text": "."
+      },
+      {
+        "text": "δι’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διά",
+        "strong": "G12230",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "ἣν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,ER,,,,AFS,"
+      },
+      {
+        "text": "αἰτίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰτία",
+        "strong": "G01560",
+        "morph": "Gr,N,,,,,AFS,"
+      },
+      {
+        "text": "ἔλεγχε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλέγχω",
+        "strong": "G16510",
+        "morph": "Gr,V,MPA2,,S,",
+        "tw": "rc://*/tw/dict/bible/other/rebuke"
+      },
+      {
+        "text": "αὐτοὺς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3AMP,"
+      },
+      {
+        "text": "ἀποτόμως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀποτόμως",
+        "strong": "G06640",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "ὑγιαίνωσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑγιαίνω",
+        "strong": "G51980",
+        "morph": "Gr,V,SPA3,,P,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "πίστει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "14": {
+    "verseObjects": [
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "προσέχοντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προσέχω",
+        "strong": "G43370",
+        "morph": "Gr,V,PPA,NMP,"
+      },
+      {
+        "text": "Ἰουδαϊκοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Ἰουδαϊκός",
+        "strong": "G24510",
+        "morph": "Gr,AA,,,,DMP,",
+        "tw": "rc://*/tw/dict/bible/kt/jew"
+      },
+      {
+        "text": "μύθοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μῦθος",
+        "strong": "G34540",
+        "morph": "Gr,N,,,,,DMP,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἐντολαῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐντολή",
+        "strong": "G17850",
+        "morph": "Gr,N,,,,,DFP,",
+        "tw": "rc://*/tw/dict/bible/kt/command"
+      },
+      {
+        "text": "ἀνθρώπων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄνθρωπος",
+        "strong": "G04440",
+        "morph": "Gr,N,,,,,GMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀποστρεφομένων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀποστρέφω",
+        "strong": "G06540",
+        "morph": "Gr,V,PPM,GMP,",
+        "tw": "rc://*/tw/dict/bible/other/turn"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFS,"
+      },
+      {
+        "text": "ἀλήθειαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλήθεια",
+        "strong": "G02250",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/true"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "15": {
+    "verseObjects": [
+      {
+        "text": "πάντα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,NNP,"
+      },
+      {
+        "text": "καθαρὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καθαρός",
+        "strong": "G25130",
+        "morph": "Gr,NP,,,,NNP,",
+        "tw": "rc://*/tw/dict/bible/kt/purify"
+      },
+      {
+        "text": "τοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DMP,"
+      },
+      {
+        "text": "καθαροῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καθαρός",
+        "strong": "G25130",
+        "morph": "Gr,NS,,,,DMP,",
+        "tw": "rc://*/tw/dict/bible/kt/purify"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "τοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,DMP,"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "μεμιαμμένοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μιαίνω",
+        "strong": "G33920",
+        "morph": "Gr,V,PEP,DMP,",
+        "tw": "rc://*/tw/dict/bible/other/defile"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἀπίστοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄπιστος",
+        "strong": "G05710",
+        "morph": "Gr,NS,,,,DMP,",
+        "tw": "rc://*/tw/dict/bible/kt/believe"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "οὐδὲν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὐδείς",
+        "strong": "G37620",
+        "morph": "Gr,RI,,,,NNS,"
+      },
+      {
+        "text": "καθαρόν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καθαρός",
+        "strong": "G25130",
+        "morph": "Gr,NP,,,,NNS,",
+        "tw": "rc://*/tw/dict/bible/kt/purify"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "ἀλλὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλλά",
+        "strong": "G02350",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "μεμίανται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μιαίνω",
+        "strong": "G33920",
+        "morph": "Gr,V,IEP3,,S,",
+        "tw": "rc://*/tw/dict/bible/other/defile"
+      },
+      {
+        "text": "αὐτῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3GMP,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,DO,,,,,,,,"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMS,"
+      },
+      {
+        "text": "νοῦς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νοῦς",
+        "strong": "G35630",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/other/mind"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CO,,,,,,,,"
+      },
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "συνείδησις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "συνείδησις",
+        "strong": "G48930",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/conscience"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "16": {
+    "verseObjects": [
+      {
+        "text": "Θεὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "text": "ὁμολογοῦσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁμολογέω",
+        "strong": "G36700",
+        "morph": "Gr,V,IPA3,,P,",
+        "tw": "rc://*/tw/dict/bible/kt/confess"
+      },
+      {
+        "text": "εἰδέναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἴδω",
+        "strong": "G14920",
+        "morph": "Gr,V,NEA,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/know"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EP,,,,DNP,"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἔργοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,DNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "text": "ἀρνοῦνται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀρνέομαι",
+        "strong": "G07200",
+        "morph": "Gr,V,IPM3,,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "βδελυκτοὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "βδελυκτός",
+        "strong": "G09470",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/detestable"
+      },
+      {
+        "text": "ὄντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,PPA,NMP,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἀπειθεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπειθής",
+        "strong": "G05450",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/disobey"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "πρὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρός",
+        "strong": "G43140",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πᾶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,ANS,"
+      },
+      {
+        "text": "ἔργον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "text": "ἀγαθὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀγαθός",
+        "strong": "G00180",
+        "morph": "Gr,AA,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἀδόκιμοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀδόκιμος",
+        "strong": "G00960",
+        "morph": "Gr,NS,,,,NMP,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "front": {
+    "verseObjects": [
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "type": "text",
+        "text": "\n"
+      }
+    ]
+  }
+}

--- a/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/2.json
+++ b/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/2.json
@@ -1,0 +1,1947 @@
+{
+  "1": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "σὺ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2N,S,"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "λάλει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λαλέω",
+        "strong": "G29800",
+        "morph": "Gr,V,MPA2,,S,"
+      },
+      {
+        "text": "ἃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RD,,,,ANP,"
+      },
+      {
+        "text": "πρέπει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρέπω",
+        "strong": "G42410",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,DFS,"
+      },
+      {
+        "text": "ὑγιαινούσῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑγιαίνω",
+        "strong": "G51980",
+        "morph": "Gr,V,PPA,DFS,"
+      },
+      {
+        "text": "διδασκαλίᾳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδασκαλία",
+        "strong": "G13190",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/other/doctrine"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "2": {
+    "verseObjects": [
+      {
+        "text": "πρεσβύτας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρεσβύτης",
+        "strong": "G42460",
+        "morph": "Gr,N,,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/other/elder"
+      },
+      {
+        "text": "νηφαλίους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νηφάλιος",
+        "strong": "G35240",
+        "morph": "Gr,NS,,,,AMP,"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σεμνούς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σεμνός",
+        "strong": "G45860",
+        "morph": "Gr,NP,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/kt/honor"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σώφρονας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σώφρων",
+        "strong": "G49980",
+        "morph": "Gr,NS,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/other/selfcontrol"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὑγιαίνοντας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑγιαίνω",
+        "strong": "G51980",
+        "morph": "Gr,V,PPA,AMP,"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "πίστει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "ἀγάπῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀγάπη",
+        "strong": "G00260",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/love"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "ὑπομονῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑπομονή",
+        "strong": "G52810",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/other/perseverance"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "3": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "πρεσβύτιδας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρεσβῦτις",
+        "strong": "G42470",
+        "morph": "Gr,N,,,,,AFP,"
+      },
+      {
+        "text": "ὡσαύτως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὡσαύτως",
+        "strong": "G56150",
+        "morph": "Gr,D,,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/like"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "καταστήματι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατάστημα",
+        "strong": "G26880",
+        "morph": "Gr,N,,,,,DNS,"
+      },
+      {
+        "text": "ἱεροπρεπεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἱεροπρεπής",
+        "strong": "G24120",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/reverence"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "διαβόλους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διάβολος",
+        "strong": "G12280",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/slander"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μηδὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μηδέ",
+        "strong": "G33660",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "οἴνῳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οἶνος",
+        "strong": "G36310",
+        "morph": "Gr,N,,,,,DMS,",
+        "tw": "rc://*/tw/dict/bible/other/wine"
+      },
+      {
+        "text": "πολλῷ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πολλός",
+        "strong": "G41830",
+        "morph": "Gr,EQ,,,,DMS,"
+      },
+      {
+        "text": "δεδουλωμένας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δουλόω",
+        "strong": "G14020",
+        "morph": "Gr,V,PEP,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/enslave"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καλοδιδασκάλους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλοδιδάσκαλος",
+        "strong": "G25670",
+        "morph": "Gr,NS,,,,AFP,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "4": {
+    "verseObjects": [
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "σωφρονίζωσι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωφρονίζω",
+        "strong": "G49940",
+        "morph": "Gr,V,SPA3,,P,"
+      },
+      {
+        "text": "τὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFP,"
+      },
+      {
+        "text": "νέας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νέος",
+        "strong": "G35010",
+        "morph": "Gr,NS,,,,AFP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "φιλάνδρους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φίλανδρος",
+        "strong": "G53620",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/love"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "φιλοτέκνους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φιλότεκνος",
+        "strong": "G53880",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/love"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "5": {
+    "verseObjects": [
+      {
+        "text": "σώφρονας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σώφρων",
+        "strong": "G49980",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/selfcontrol"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἁγνάς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἁγνός",
+        "strong": "G00530",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/purify"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "οἰκουργούς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οἰκουργός",
+        "strong": "G36260",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/household"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀγαθάς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀγαθός",
+        "strong": "G00180",
+        "morph": "Gr,NS,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὑποτασσομένας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑποτάσσω",
+        "strong": "G52930",
+        "morph": "Gr,V,PPP,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/subject"
+      },
+      {
+        "text": "τοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EP,,,,DMP,"
+      },
+      {
+        "text": "ἰδίοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἴδιος",
+        "strong": "G23980",
+        "morph": "Gr,EF,,,,DMP,"
+      },
+      {
+        "text": "ἀνδράσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνήρ",
+        "strong": "G04350",
+        "morph": "Gr,N,,,,,DMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMS,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/wordofgod",
+        "children": [
+          {
+            "text": "λόγος",
+            "tag": "w",
+            "type": "word",
+            "lemma": "λόγος",
+            "strong": "G30560",
+            "morph": "Gr,N,,,,,NMS,"
+          },
+          {
+            "text": "τοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "ὁ",
+            "strong": "G35880",
+            "morph": "Gr,EA,,,,GMS,"
+          },
+          {
+            "text": "Θεοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "θεός",
+            "strong": "G23160",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/god"
+          }
+        ]
+      },
+      {
+        "text": "βλασφημῆται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "βλασφημέω",
+        "strong": "G09870",
+        "morph": "Gr,V,SPP3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/blasphemy"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "6": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "τοὺς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AMP,"
+      },
+      {
+        "text": "νεωτέρους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νεώτερος",
+        "strong": "G35125",
+        "morph": "Gr,AA,,,,AMPC"
+      },
+      {
+        "text": "ὡσαύτως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὡσαύτως",
+        "strong": "G56150",
+        "morph": "Gr,D,,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/like"
+      },
+      {
+        "text": "παρακάλει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παρακαλέω",
+        "strong": "G38700",
+        "morph": "Gr,V,MPA2,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/exhort"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σωφρονεῖν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωφρονέω",
+        "strong": "G49930",
+        "morph": "Gr,V,NPA,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/selfcontrol"
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "7": {
+    "verseObjects": [
+      {
+        "text": "περὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περί",
+        "strong": "G40120",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πάντα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,ANP,"
+      },
+      {
+        "text": "σεαυτὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σεαυτοῦ",
+        "strong": "G45720",
+        "morph": "Gr,RE,,,2AMS,"
+      },
+      {
+        "text": "παρεχόμενος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παρέχω",
+        "strong": "G39300",
+        "morph": "Gr,V,PPM,NMS,"
+      },
+      {
+        "text": "τύπον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τύπος",
+        "strong": "G51790",
+        "morph": "Gr,N,,,,,AMS,"
+      },
+      {
+        "text": "καλῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλός",
+        "strong": "G25700",
+        "morph": "Gr,AA,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἔργων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EP,,,,DFS,"
+      },
+      {
+        "text": "διδασκαλίᾳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδασκαλία",
+        "strong": "G13190",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/other/doctrine"
+      },
+      {
+        "text": "ἀφθορίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀφθορία",
+        "strong": "G08627",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/other/integrity"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σεμνότητα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σεμνότης",
+        "strong": "G45870",
+        "morph": "Gr,N,,,,,AFS,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "8": {
+    "verseObjects": [
+      {
+        "text": "λόγον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λόγος",
+        "strong": "G30560",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/word"
+      },
+      {
+        "text": "ὑγιῆ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑγιής",
+        "strong": "G51990",
+        "morph": "Gr,AA,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀκατάγνωστον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀκατάγνωστος",
+        "strong": "G01760",
+        "morph": "Gr,NS,,,,AMS,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,NMS,"
+      },
+      {
+        "text": "ἐξ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκ",
+        "strong": "G15370",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "ἐναντίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐναντίος",
+        "strong": "G17270",
+        "morph": "Gr,NS,,,,GFS,"
+      },
+      {
+        "text": "ἐντραπῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐντρέπω",
+        "strong": "G17880",
+        "morph": "Gr,V,SAP3,,S,",
+        "tw": "rc://*/tw/dict/bible/other/shame"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μηδὲν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μηδείς",
+        "strong": "G33670",
+        "morph": "Gr,RI,,,,ANS,"
+      },
+      {
+        "text": "ἔχων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔχω",
+        "strong": "G21920",
+        "morph": "Gr,V,PPA,NMS,"
+      },
+      {
+        "text": "λέγειν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λέγω",
+        "strong": "G30040",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "text": "περὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περί",
+        "strong": "G40120",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "text": "φαῦλον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φαῦλος",
+        "strong": "G53370",
+        "morph": "Gr,NS,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/evil"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "9": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "δούλους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δοῦλος",
+        "strong": "G14010",
+        "morph": "Gr,N,,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/other/servant"
+      },
+      {
+        "text": "ἰδίοις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἴδιος",
+        "strong": "G23980",
+        "morph": "Gr,EF,,,,DMP,"
+      },
+      {
+        "text": "δεσπόταις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δεσπότης",
+        "strong": "G12030",
+        "morph": "Gr,N,,,,,DMP,",
+        "tw": "rc://*/tw/dict/bible/kt/lord"
+      },
+      {
+        "text": "ὑποτάσσεσθαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑποτάσσω",
+        "strong": "G52930",
+        "morph": "Gr,V,NPM,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/subject"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "πᾶσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,DNP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "εὐαρέστους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εὐάρεστος",
+        "strong": "G21010",
+        "morph": "Gr,NP,,,,AMP,"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ἀντιλέγοντας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀντιλέγω",
+        "strong": "G04830",
+        "morph": "Gr,V,PPA,AMP,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "10": {
+    "verseObjects": [
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "νοσφιζομένους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νοσφίζω",
+        "strong": "G35570",
+        "morph": "Gr,V,PPM,AMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀλλὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλλά",
+        "strong": "G02350",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "πᾶσαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,AFS,"
+      },
+      {
+        "text": "πίστιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "text": "ἐνδεικνυμένους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐνδείκνυμι",
+        "strong": "G17310",
+        "morph": "Gr,V,PPM,AMP,"
+      },
+      {
+        "text": "ἀγαθήν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀγαθός",
+        "strong": "G00180",
+        "morph": "Gr,NS,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFS,"
+      },
+      {
+        "text": "διδασκαλίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διδασκαλία",
+        "strong": "G13190",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/other/doctrine"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,AFS,"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κοσμῶσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κοσμέω",
+        "strong": "G28850",
+        "morph": "Gr,V,SPA3,,P,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "πᾶσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,DNP,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "11": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "ἐπεφάνη",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιφαίνω",
+        "strong": "G20140",
+        "morph": "Gr,V,IAP3,,S,"
+      },
+      {
+        "text": "γὰρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "χάρις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάρις",
+        "strong": "G54850",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/grace"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σωτήριος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήριος",
+        "strong": "G49920",
+        "morph": "Gr,NS,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/save"
+      },
+      {
+        "text": "πᾶσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,DMP,"
+      },
+      {
+        "text": "ἀνθρώποις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄνθρωπος",
+        "strong": "G04440",
+        "morph": "Gr,N,,,,,DMP,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "12": {
+    "verseObjects": [
+      {
+        "text": "παιδεύουσα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παιδεύω",
+        "strong": "G38110",
+        "morph": "Gr,V,PPA,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/discipline"
+      },
+      {
+        "text": "ἡμᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "ἀρνησάμενοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀρνέομαι",
+        "strong": "G07200",
+        "morph": "Gr,V,PAM,NMP,"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFS,"
+      },
+      {
+        "text": "ἀσέβειαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀσέβεια",
+        "strong": "G07630",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/godly"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "τὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFP,"
+      },
+      {
+        "text": "κοσμικὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κοσμικός",
+        "strong": "G28860",
+        "morph": "Gr,AA,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/world"
+      },
+      {
+        "text": "ἐπιθυμίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιθυμία",
+        "strong": "G19390",
+        "morph": "Gr,N,,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/lust"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σωφρόνως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωφρόνως",
+        "strong": "G49960",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "δικαίως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δικαίως",
+        "strong": "G13460",
+        "morph": "Gr,D,,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/kt/righteous"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "εὐσεβῶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εὐσεβῶς",
+        "strong": "G21530",
+        "morph": "Gr,D,,,,,,,,,",
+        "tw": "rc://*/tw/dict/bible/kt/godly"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ζήσωμεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ζάω",
+        "strong": "G21980",
+        "morph": "Gr,V,SAA1,,P,",
+        "tw": "rc://*/tw/dict/bible/kt/life"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "τῷ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DMS,"
+      },
+      {
+        "text": "νῦν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νῦν",
+        "strong": "G35680",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "αἰῶνι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰών",
+        "strong": "G01650",
+        "morph": "Gr,N,,,,,DMS,",
+        "tw": "rc://*/tw/dict/bible/other/age"
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "13": {
+    "verseObjects": [
+      {
+        "text": "προσδεχόμενοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προσδέχομαι",
+        "strong": "G43270",
+        "morph": "Gr,V,PPM,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/receive"
+      },
+      {
+        "text": "τὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFS,"
+      },
+      {
+        "text": "μακαρίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μακάριος",
+        "strong": "G31070",
+        "morph": "Gr,AA,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/bless"
+      },
+      {
+        "text": "ἐλπίδα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλπίς",
+        "strong": "G16800",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/hope"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἐπιφάνειαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιφάνεια",
+        "strong": "G20150",
+        "morph": "Gr,N,,,,,AFS,"
+      },
+      {
+        "text": "τῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GFS,"
+      },
+      {
+        "text": "δόξης",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δόξα",
+        "strong": "G13910",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/glory"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "μεγάλου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μέγας",
+        "strong": "G31730",
+        "morph": "Gr,AA,,,,GMS,"
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/jesus",
+        "children": [
+          {
+            "text": "Ἰησοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "Ἰησοῦς",
+            "strong": "G24240",
+            "morph": "Gr,N,,,,,GMS,"
+          },
+          {
+            "text": "Χριστοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "χριστός",
+            "strong": "G55470",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/christ"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ";\n\n"
+      }
+    ]
+  },
+  "14": {
+    "verseObjects": [
+      {
+        "text": "ὃς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RR,,,,NMS,"
+      },
+      {
+        "text": "ἔδωκεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δίδωμι",
+        "strong": "G13250",
+        "morph": "Gr,V,IAA3,,S,"
+      },
+      {
+        "text": "ἑαυτὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἑαυτοῦ",
+        "strong": "G14380",
+        "morph": "Gr,RE,,,3AMS,"
+      },
+      {
+        "text": "ὑπὲρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑπέρ",
+        "strong": "G52280",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "λυτρώσηται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λυτρόω",
+        "strong": "G30840",
+        "morph": "Gr,V,SAM3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/redeem"
+      },
+      {
+        "text": "ἡμᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,P,"
+      },
+      {
+        "text": "ἀπὸ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπό",
+        "strong": "G05750",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "πάσης",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,GFS,"
+      },
+      {
+        "text": "ἀνομίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνομία",
+        "strong": "G04580",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/other/lawful"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "καθαρίσῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καθαρίζω",
+        "strong": "G25110",
+        "morph": "Gr,V,SAA3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/clean"
+      },
+      {
+        "text": "ἑαυτῷ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἑαυτοῦ",
+        "strong": "G14380",
+        "morph": "Gr,RE,,,3DMS,"
+      },
+      {
+        "text": "λαὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λαός",
+        "strong": "G29920",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/peoplegroup"
+      },
+      {
+        "text": "περιούσιον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περιούσιος",
+        "strong": "G40410",
+        "morph": "Gr,AA,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/possess"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ζηλωτὴν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ζηλωτής",
+        "strong": "G22070",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/kt/zealous"
+      },
+      {
+        "text": "καλῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλός",
+        "strong": "G25700",
+        "morph": "Gr,AA,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἔργων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "15": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "ταῦτα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὗτος",
+        "strong": "G37780",
+        "morph": "Gr,RD,,,,ANP,"
+      },
+      {
+        "text": "λάλει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λαλέω",
+        "strong": "G29800",
+        "morph": "Gr,V,MPA2,,S,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "παρακάλει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παρακαλέω",
+        "strong": "G38700",
+        "morph": "Gr,V,MPA2,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/exhort"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἔλεγχε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλέγχω",
+        "strong": "G16510",
+        "morph": "Gr,V,MPA2,,S,",
+        "tw": "rc://*/tw/dict/bible/other/rebuke"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μετὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μετά",
+        "strong": "G33260",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "πάσης",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,GFS,"
+      },
+      {
+        "text": "ἐπιταγῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιταγή",
+        "strong": "G20030",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/authority"
+      },
+      {
+        "type": "text",
+        "text": "."
+      },
+      {
+        "text": "μηδείς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μηδείς",
+        "strong": "G33670",
+        "morph": "Gr,RI,,,,NMS,"
+      },
+      {
+        "text": "σου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2G,S,"
+      },
+      {
+        "text": "περιφρονείτω",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περιφρονέω",
+        "strong": "G40650",
+        "morph": "Gr,V,MPA3,,S,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "front": {
+    "verseObjects": [
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "type": "text",
+        "text": "\n"
+      }
+    ]
+  }
+}

--- a/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/3.json
+++ b/__tests__/fixtures/resources/grc/bibles/ugnt/v0/tit/3.json
@@ -1,0 +1,2157 @@
+{
+  "1": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "ὑπομίμνῃσκε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑπομιμνῄσκω",
+        "strong": "G52790",
+        "morph": "Gr,V,MPA2,,S,"
+      },
+      {
+        "text": "αὐτοὺς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3AMP,"
+      },
+      {
+        "text": "ἀρχαῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀρχή",
+        "strong": "G07460",
+        "morph": "Gr,N,,,,,DFP,",
+        "tw": "rc://*/tw/dict/bible/other/ruler"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἐξουσίαις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐξουσία",
+        "strong": "G18490",
+        "morph": "Gr,N,,,,,DFP,",
+        "tw": "rc://*/tw/dict/bible/kt/authority"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὑποτάσσεσθαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὑποτάσσω",
+        "strong": "G52930",
+        "morph": "Gr,V,NPM,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/subject"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "πειθαρχεῖν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πειθαρχέω",
+        "strong": "G39800",
+        "morph": "Gr,V,NPA,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/obey"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "πρὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρός",
+        "strong": "G43140",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πᾶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,ANS,"
+      },
+      {
+        "text": "ἔργον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "text": "ἀγαθὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀγαθός",
+        "strong": "G00180",
+        "morph": "Gr,AA,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἑτοίμους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἕτοιμος",
+        "strong": "G20920",
+        "morph": "Gr,NP,,,,AMP,"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "2": {
+    "verseObjects": [
+      {
+        "text": "μηδένα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μηδείς",
+        "strong": "G33670",
+        "morph": "Gr,RI,,,,AMS,"
+      },
+      {
+        "text": "βλασφημεῖν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "βλασφημέω",
+        "strong": "G09870",
+        "morph": "Gr,V,NPA,,,,,",
+        "tw": "rc://*/tw/dict/bible/kt/blasphemy"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀμάχους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄμαχος",
+        "strong": "G02690",
+        "morph": "Gr,NP,,,,AMP,",
+        "tw": "rc://*/tw/dict/bible/other/peace"
+      },
+      {
+        "text": "εἶναι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,NPA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἐπιεικεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιεικής",
+        "strong": "G19330",
+        "morph": "Gr,NP,,,,AMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "πᾶσαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,AFS,"
+      },
+      {
+        "text": "ἐνδεικνυμένους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐνδείκνυμι",
+        "strong": "G17310",
+        "morph": "Gr,V,PPM,AMP,"
+      },
+      {
+        "text": "πραΰτητα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πραΰτης",
+        "strong": "G42400",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/humble"
+      },
+      {
+        "text": "πρὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρός",
+        "strong": "G43140",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "πάντας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,EQ,,,,AMP,"
+      },
+      {
+        "text": "ἀνθρώπους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄνθρωπος",
+        "strong": "G04440",
+        "morph": "Gr,N,,,,,AMP,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "3": {
+    "verseObjects": [
+      {
+        "text": "ἦμεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IIA1,,P,"
+      },
+      {
+        "text": "γάρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ποτε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ποτέ",
+        "strong": "G42180",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ἡμεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1N,P,"
+      },
+      {
+        "text": "ἀνόητοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνόητος",
+        "strong": "G04530",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/kt/foolish"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀπειθεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀπειθής",
+        "strong": "G05450",
+        "morph": "Gr,NS,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/disobey"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "πλανώμενοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πλανάω",
+        "strong": "G41050",
+        "morph": "Gr,V,PPP,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/astray"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "δουλεύοντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δουλεύω",
+        "strong": "G13980",
+        "morph": "Gr,V,PPA,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/enslave"
+      },
+      {
+        "text": "ἐπιθυμίαις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιθυμία",
+        "strong": "G19390",
+        "morph": "Gr,N,,,,,DFP,",
+        "tw": "rc://*/tw/dict/bible/other/lust"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἡδοναῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἡδονή",
+        "strong": "G22370",
+        "morph": "Gr,N,,,,,DFP,"
+      },
+      {
+        "text": "ποικίλαις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ποικίλος",
+        "strong": "G41640",
+        "morph": "Gr,AA,,,,DFP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "κακίᾳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κακία",
+        "strong": "G25490",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/evil"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "φθόνῳ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φθόνος",
+        "strong": "G53550",
+        "morph": "Gr,N,,,,,DMS,",
+        "tw": "rc://*/tw/dict/bible/other/envy"
+      },
+      {
+        "text": "διάγοντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διάγω",
+        "strong": "G12360",
+        "morph": "Gr,V,PPA,NMP,",
+        "tw": "rc://*/tw/dict/bible/kt/live"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "στυγητοί",
+        "tag": "w",
+        "type": "word",
+        "lemma": "στυγητός",
+        "strong": "G47670",
+        "morph": "Gr,NS,,,,NMP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "μισοῦντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μισέω",
+        "strong": "G34040",
+        "morph": "Gr,V,PPA,NMP,"
+      },
+      {
+        "text": "ἀλλήλους",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλλήλων",
+        "strong": "G02400",
+        "morph": "Gr,RC,,,,AMP,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "4": {
+    "verseObjects": [
+      {
+        "text": "ὅτε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅτε",
+        "strong": "G37530",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "χρηστότης",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χρηστότης",
+        "strong": "G55440",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/other/kind"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "φιλανθρωπία",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φιλανθρωπία",
+        "strong": "G53630",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/love"
+      },
+      {
+        "text": "ἐπεφάνη",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπιφαίνω",
+        "strong": "G20140",
+        "morph": "Gr,V,IAP3,,S,"
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "Θεοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "5": {
+    "verseObjects": [
+      {
+        "text": "οὐκ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὐ",
+        "strong": "G37560",
+        "morph": "Gr,DO,,,,,,,,"
+      },
+      {
+        "text": "ἐξ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκ",
+        "strong": "G15370",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "ἔργων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "text": "τῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,GNP,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "δικαιοσύνῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δικαιοσύνη",
+        "strong": "G13430",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/righteous"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RD,,,,ANP,"
+      },
+      {
+        "text": "ἐποιήσαμεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ποιέω",
+        "strong": "G41600",
+        "morph": "Gr,V,IAA1,,P,"
+      },
+      {
+        "text": "ἡμεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1N,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἀλλὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀλλά",
+        "strong": "G02350",
+        "morph": "Gr,CO,,,,,,,,"
+      },
+      {
+        "text": "κατὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "τὸ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,ANS,"
+      },
+      {
+        "text": "αὐτοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3GMS,"
+      },
+      {
+        "text": "ἔλεος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔλεος",
+        "strong": "G16560",
+        "morph": "Gr,N,,,,,ANS,",
+        "tw": "rc://*/tw/dict/bible/kt/mercy"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἔσωσεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σῴζω",
+        "strong": "G49820",
+        "morph": "Gr,V,IAA3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/save"
+      },
+      {
+        "text": "ἡμᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "διὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διά",
+        "strong": "G12230",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "λουτροῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λουτρόν",
+        "strong": "G30670",
+        "morph": "Gr,N,,,,,GNS,",
+        "tw": "rc://*/tw/dict/bible/kt/clean"
+      },
+      {
+        "text": "παλινγενεσίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παλινγενεσία",
+        "strong": "G38240",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/bornagain"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἀνακαινώσεως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνακαίνωσις",
+        "strong": "G03420",
+        "morph": "Gr,N,,,,,GFS,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/holyspirit",
+        "children": [
+          {
+            "text": "Πνεύματος",
+            "tag": "w",
+            "type": "word",
+            "lemma": "πνεῦμα",
+            "strong": "G41510",
+            "morph": "Gr,N,,,,,GNS,"
+          },
+          {
+            "text": "Ἁγίου",
+            "tag": "w",
+            "type": "word",
+            "lemma": "ἅγιος",
+            "strong": "G00400",
+            "morph": "Gr,AA,,,,GNS,",
+            "tw": "rc://*/tw/dict/bible/kt/holy"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "6": {
+    "verseObjects": [
+      {
+        "text": "οὗ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅς",
+        "strong": "G37390",
+        "morph": "Gr,RR,,,,GNS,"
+      },
+      {
+        "text": "ἐξέχεεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκχέω",
+        "strong": "G16320",
+        "morph": "Gr,V,IAA3,,S,"
+      },
+      {
+        "text": "ἐφ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐπί",
+        "strong": "G19090",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "ἡμᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,P,"
+      },
+      {
+        "text": "πλουσίως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πλουσίως",
+        "strong": "G41460",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "διὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διά",
+        "strong": "G12230",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "tag": "k",
+        "type": "milestone",
+        "tw": "rc://*/tw/dict/bible/kt/jesus",
+        "children": [
+          {
+            "text": "Ἰησοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "Ἰησοῦς",
+            "strong": "G24240",
+            "morph": "Gr,N,,,,,GMS,"
+          },
+          {
+            "text": "Χριστοῦ",
+            "tag": "w",
+            "type": "word",
+            "lemma": "χριστός",
+            "strong": "G55470",
+            "morph": "Gr,N,,,,,GMS,",
+            "tw": "rc://*/tw/dict/bible/kt/christ"
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "τοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,GMS,"
+      },
+      {
+        "text": "Σωτῆρος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σωτήρ",
+        "strong": "G49900",
+        "morph": "Gr,N,,,,,GMS,",
+        "tw": "rc://*/tw/dict/bible/kt/savior"
+      },
+      {
+        "text": "ἡμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,P,"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "7": {
+    "verseObjects": [
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "δικαιωθέντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δικαιόω",
+        "strong": "G13440",
+        "morph": "Gr,V,PAP,NMP,",
+        "tw": "rc://*/tw/dict/bible/kt/justice"
+      },
+      {
+        "text": "τῇ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DFS,"
+      },
+      {
+        "text": "ἐκείνου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκεῖνος",
+        "strong": "G15650",
+        "morph": "Gr,RD,,,,GMS,"
+      },
+      {
+        "text": "χάριτι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάρις",
+        "strong": "G54850",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/grace"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κληρονόμοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κληρονόμος",
+        "strong": "G28180",
+        "morph": "Gr,N,,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/heir"
+      },
+      {
+        "text": "γενηθῶμεν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γίνομαι",
+        "strong": "G10960",
+        "morph": "Gr,V,SAP1,,P,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "κατ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κατά",
+        "strong": "G25960",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "ἐλπίδα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐλπίς",
+        "strong": "G16800",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/kt/hope"
+      },
+      {
+        "text": "ζωῆς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ζωή",
+        "strong": "G22220",
+        "morph": "Gr,N,,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/life"
+      },
+      {
+        "text": "αἰωνίου",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἰώνιος",
+        "strong": "G01660",
+        "morph": "Gr,AA,,,,GFS,",
+        "tw": "rc://*/tw/dict/bible/kt/eternity"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "8": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "πιστὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πιστός",
+        "strong": "G41030",
+        "morph": "Gr,NP,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/faithful"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMS,"
+      },
+      {
+        "text": "λόγος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λόγος",
+        "strong": "G30560",
+        "morph": "Gr,N,,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/other/word"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "περὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περί",
+        "strong": "G40120",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "τούτων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὗτος",
+        "strong": "G37780",
+        "morph": "Gr,RD,,,,GNP,"
+      },
+      {
+        "text": "βούλομαί",
+        "tag": "w",
+        "type": "word",
+        "lemma": "βούλομαι",
+        "strong": "G10140",
+        "morph": "Gr,V,IPM1,,S,"
+      },
+      {
+        "text": "σε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2A,S,"
+      },
+      {
+        "text": "διαβεβαιοῦσθαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "διαβεβαιόομαι",
+        "strong": "G12260",
+        "morph": "Gr,V,NPM,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ",\n“"
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "φροντίζωσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φροντίζω",
+        "strong": "G54310",
+        "morph": "Gr,V,SPA3,,P,"
+      },
+      {
+        "text": "καλῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλός",
+        "strong": "G25700",
+        "morph": "Gr,AA,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἔργων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "προΐστασθαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προΐστημι",
+        "strong": "G42910",
+        "morph": "Gr,V,NPM,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/manager"
+      },
+      {
+        "text": "οἱ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,NMP,"
+      },
+      {
+        "text": "πεπιστευκότες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πιστεύω",
+        "strong": "G41000",
+        "morph": "Gr,V,PEA,NMP,",
+        "tw": "rc://*/tw/dict/bible/kt/believe"
+      },
+      {
+        "text": "Θεῷ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "θεός",
+        "strong": "G23160",
+        "morph": "Gr,N,,,,,DMS,",
+        "tw": "rc://*/tw/dict/bible/kt/god"
+      },
+      {
+        "type": "text",
+        "text": ".”"
+      },
+      {
+        "text": "ταῦτά",
+        "tag": "w",
+        "type": "word",
+        "lemma": "οὗτος",
+        "strong": "G37780",
+        "morph": "Gr,RD,,,,NNP,"
+      },
+      {
+        "text": "ἐστιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IPA3,,S,"
+      },
+      {
+        "text": "καλὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλός",
+        "strong": "G25700",
+        "morph": "Gr,NP,,,,NNP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ὠφέλιμα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὠφέλιμος",
+        "strong": "G56240",
+        "morph": "Gr,NP,,,,NNP,",
+        "tw": "rc://*/tw/dict/bible/other/profit"
+      },
+      {
+        "text": "τοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,DMP,"
+      },
+      {
+        "text": "ἀνθρώποις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄνθρωπος",
+        "strong": "G04440",
+        "morph": "Gr,N,,,,,DMP,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "9": {
+    "verseObjects": [
+      {
+        "text": "μωρὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μωρός",
+        "strong": "G34740",
+        "morph": "Gr,AA,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/foolish"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ζητήσεις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ζήτησις",
+        "strong": "G22140",
+        "morph": "Gr,N,,,,,AFP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "γενεαλογίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γενεαλογία",
+        "strong": "G10760",
+        "morph": "Gr,N,,,,,AFP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἔρεις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔρις",
+        "strong": "G20540",
+        "morph": "Gr,N,,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/strife"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "μάχας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μάχη",
+        "strong": "G31630",
+        "morph": "Gr,N,,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/other/strife"
+      },
+      {
+        "text": "νομικὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νομικός",
+        "strong": "G35440",
+        "morph": "Gr,AA,,,,AFP,",
+        "tw": "rc://*/tw/dict/bible/kt/lawofmoses"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "περιΐστασο",
+        "tag": "w",
+        "type": "word",
+        "lemma": "περιΐστημι",
+        "strong": "G40260",
+        "morph": "Gr,V,MPM2,,S,"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "εἰσὶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,IPA3,,P,"
+      },
+      {
+        "text": "γὰρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἀνωφελεῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀνωφελής",
+        "strong": "G05120",
+        "morph": "Gr,NS,,,,NFP,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "μάταιοι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μάταιος",
+        "strong": "G31520",
+        "morph": "Gr,NS,,,,NFP,",
+        "tw": "rc://*/tw/dict/bible/other/vain"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "10": {
+    "verseObjects": [
+      {
+        "text": "αἱρετικὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αἱρετικός",
+        "strong": "G01410",
+        "morph": "Gr,AA,,,,AMS,"
+      },
+      {
+        "text": "ἄνθρωπον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄνθρωπος",
+        "strong": "G04440",
+        "morph": "Gr,N,,,,,AMS,"
+      },
+      {
+        "text": "μετὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μετά",
+        "strong": "G33260",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "μίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἷς",
+        "strong": "G15200",
+        "morph": "Gr,EN,,,,AFS,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "δευτέραν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δεύτερος",
+        "strong": "G12080",
+        "morph": "Gr,EO,,,,AFS,"
+      },
+      {
+        "text": "νουθεσίαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νουθεσία",
+        "strong": "G35590",
+        "morph": "Gr,N,,,,,AFS,",
+        "tw": "rc://*/tw/dict/bible/other/admonish"
+      },
+      {
+        "text": "παραιτοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παραιτέομαι",
+        "strong": "G38680",
+        "morph": "Gr,V,MPM2,,S,",
+        "tw": "rc://*/tw/dict/bible/other/reject"
+      },
+      {
+        "type": "text",
+        "text": ",\n\n"
+      }
+    ]
+  },
+  "11": {
+    "verseObjects": [
+      {
+        "text": "εἰδὼς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἴδω",
+        "strong": "G14920",
+        "morph": "Gr,V,PEA,NMS,",
+        "tw": "rc://*/tw/dict/bible/other/know"
+      },
+      {
+        "text": "ὅτι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅτι",
+        "strong": "G37540",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "ἐξέστραπται",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκστρέφω",
+        "strong": "G16120",
+        "morph": "Gr,V,IEP3,,S,",
+        "tw": "rc://*/tw/dict/bible/other/perverse"
+      },
+      {
+        "text": "ὁ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMS,"
+      },
+      {
+        "text": "τοιοῦτος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "τοιοῦτος",
+        "strong": "G51080",
+        "morph": "Gr,RD,,,,NMS,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "ἁμαρτάνει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἁμαρτάνω",
+        "strong": "G02640",
+        "morph": "Gr,V,IPA3,,S,",
+        "tw": "rc://*/tw/dict/bible/kt/sin"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ὢν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,PPA,NMS,"
+      },
+      {
+        "text": "αὐτοκατάκριτος",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτοκατάκριτος",
+        "strong": "G08430",
+        "morph": "Gr,NP,,,,NMS,",
+        "tw": "rc://*/tw/dict/bible/kt/condemn"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "12": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "ὅταν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὅταν",
+        "strong": "G37520",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "πέμψω",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πέμπω",
+        "strong": "G39920",
+        "morph": "Gr,V,SAA1,,S,",
+        "tw": "rc://*/tw/dict/bible/other/send"
+      },
+      {
+        "text": "Ἀρτεμᾶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Ἀρτεμᾶς",
+        "strong": "G07340",
+        "morph": "Gr,N,,,,,AMS,"
+      },
+      {
+        "text": "πρὸς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρός",
+        "strong": "G43140",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "σὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2A,S,"
+      },
+      {
+        "text": "ἢ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἤ",
+        "strong": "G22280",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "Τυχικόν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Τυχικός",
+        "strong": "G51900",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/names/tychicus"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "σπούδασον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σπουδάζω",
+        "strong": "G47040",
+        "morph": "Gr,V,MAA2,,S,"
+      },
+      {
+        "text": "ἐλθεῖν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔρχομαι",
+        "strong": "G20640",
+        "morph": "Gr,V,NAA,,,,,"
+      },
+      {
+        "text": "πρός",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πρός",
+        "strong": "G43140",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "με",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,S,"
+      },
+      {
+        "text": "εἰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰς",
+        "strong": "G15190",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "Νικόπολιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Νικόπολις",
+        "strong": "G35330",
+        "morph": "Gr,N,,,,,AFS,"
+      },
+      {
+        "type": "text",
+        "text": ";"
+      },
+      {
+        "text": "ἐκεῖ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐκεῖ",
+        "strong": "G15630",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "γὰρ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "γάρ",
+        "strong": "G10630",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "κέκρικα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "κρίνω",
+        "strong": "G29190",
+        "morph": "Gr,V,IEA1,,S,"
+      },
+      {
+        "text": "παραχειμάσαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "παραχειμάζω",
+        "strong": "G39140",
+        "morph": "Gr,V,NAA,,,,,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "13": {
+    "verseObjects": [
+      {
+        "text": "Ζηνᾶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Ζηνᾶς",
+        "strong": "G22110",
+        "morph": "Gr,N,,,,,AMS,"
+      },
+      {
+        "text": "τὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AMS,"
+      },
+      {
+        "text": "νομικὸν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "νομικός",
+        "strong": "G35440",
+        "morph": "Gr,AR,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/other/law"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "Ἀπολλῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "Ἀπολλῶς",
+        "strong": "G06250",
+        "morph": "Gr,N,,,,,AMS,",
+        "tw": "rc://*/tw/dict/bible/names/apollos"
+      },
+      {
+        "text": "σπουδαίως",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σπουδαίως",
+        "strong": "G47090",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "πρόπεμψον",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προπέμπω",
+        "strong": "G43110",
+        "morph": "Gr,V,MAA2,,S,",
+        "tw": "rc://*/tw/dict/bible/other/send"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "μηδὲν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μηδείς",
+        "strong": "G33670",
+        "morph": "Gr,RI,,,,NNS,"
+      },
+      {
+        "text": "αὐτοῖς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "αὐτός",
+        "strong": "G08460",
+        "morph": "Gr,RP,,,3DMP,"
+      },
+      {
+        "text": "λείπῃ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "λείπω",
+        "strong": "G30070",
+        "morph": "Gr,V,SPA3,,S,"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "14": {
+    "verseObjects": [
+      {
+        "text": "μανθανέτωσαν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μανθάνω",
+        "strong": "G31290",
+        "morph": "Gr,V,MPA3,,P,"
+      },
+      {
+        "text": "δὲ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "δέ",
+        "strong": "G11610",
+        "morph": "Gr,CC,,,,,,,,"
+      },
+      {
+        "text": "καὶ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καί",
+        "strong": "G25320",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "οἱ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NMP,"
+      },
+      {
+        "text": "ἡμέτεροι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἡμέτερος",
+        "strong": "G22510",
+        "morph": "Gr,RP,,,1NMP,"
+      },
+      {
+        "text": "καλῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "καλός",
+        "strong": "G25700",
+        "morph": "Gr,AA,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/good"
+      },
+      {
+        "text": "ἔργων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἔργον",
+        "strong": "G20410",
+        "morph": "Gr,N,,,,,GNP,",
+        "tw": "rc://*/tw/dict/bible/kt/works"
+      },
+      {
+        "text": "προΐστασθαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "προΐστημι",
+        "strong": "G42910",
+        "morph": "Gr,V,NPM,,,,,",
+        "tw": "rc://*/tw/dict/bible/other/manager"
+      },
+      {
+        "text": "εἰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰς",
+        "strong": "G15190",
+        "morph": "Gr,P,,,,,A,,,"
+      },
+      {
+        "text": "τὰς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,AFP,"
+      },
+      {
+        "text": "ἀναγκαίας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀναγκαῖος",
+        "strong": "G03160",
+        "morph": "Gr,AA,,,,AFP,"
+      },
+      {
+        "text": "χρείας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χρεία",
+        "strong": "G55320",
+        "morph": "Gr,N,,,,,AFP,"
+      },
+      {
+        "type": "text",
+        "text": ","
+      },
+      {
+        "text": "ἵνα",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἵνα",
+        "strong": "G24430",
+        "morph": "Gr,CS,,,,,,,,"
+      },
+      {
+        "text": "μὴ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μή",
+        "strong": "G33610",
+        "morph": "Gr,D,,,,,,,,,"
+      },
+      {
+        "text": "ὦσιν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "εἰμί",
+        "strong": "G15100",
+        "morph": "Gr,V,SPA3,,P,"
+      },
+      {
+        "text": "ἄκαρποι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἄκαρπος",
+        "strong": "G01750",
+        "morph": "Gr,NP,,,,NMP,",
+        "tw": "rc://*/tw/dict/bible/other/fruit"
+      },
+      {
+        "type": "text",
+        "text": ".\n\n"
+      }
+    ]
+  },
+  "15": {
+    "verseObjects": [
+      {
+        "type": "text",
+        "text": "\n"
+      },
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "text": "ἀσπάζονταί",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀσπάζομαι",
+        "strong": "G07820",
+        "morph": "Gr,V,IPM3,,P,"
+      },
+      {
+        "text": "σε",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2A,S,"
+      },
+      {
+        "text": "οἱ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,NMP,"
+      },
+      {
+        "text": "μετ’",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μετά",
+        "strong": "G33260",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "ἐμοῦ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1G,S,"
+      },
+      {
+        "text": "πάντες",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,NMP,"
+      },
+      {
+        "type": "text",
+        "text": "."
+      },
+      {
+        "text": "ἄσπασαι",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἀσπάζομαι",
+        "strong": "G07820",
+        "morph": "Gr,V,MAM2,,S,"
+      },
+      {
+        "text": "τοὺς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,RD,,,,AMP,"
+      },
+      {
+        "text": "φιλοῦντας",
+        "tag": "w",
+        "type": "word",
+        "lemma": "φιλέω",
+        "strong": "G53680",
+        "morph": "Gr,V,PPA,AMP,",
+        "tw": "rc://*/tw/dict/bible/kt/love"
+      },
+      {
+        "text": "ἡμᾶς",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐγώ",
+        "strong": "G14730",
+        "morph": "Gr,RP,,,1A,P,"
+      },
+      {
+        "text": "ἐν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ἐν",
+        "strong": "G17220",
+        "morph": "Gr,P,,,,,D,,,"
+      },
+      {
+        "text": "πίστει",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πίστις",
+        "strong": "G41020",
+        "morph": "Gr,N,,,,,DFS,",
+        "tw": "rc://*/tw/dict/bible/kt/faith"
+      },
+      {
+        "type": "text",
+        "text": "."
+      },
+      {
+        "text": "ἡ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "ὁ",
+        "strong": "G35880",
+        "morph": "Gr,EA,,,,NFS,"
+      },
+      {
+        "text": "χάρις",
+        "tag": "w",
+        "type": "word",
+        "lemma": "χάρις",
+        "strong": "G54850",
+        "morph": "Gr,N,,,,,NFS,",
+        "tw": "rc://*/tw/dict/bible/kt/grace"
+      },
+      {
+        "text": "μετὰ",
+        "tag": "w",
+        "type": "word",
+        "lemma": "μετά",
+        "strong": "G33260",
+        "morph": "Gr,P,,,,,G,,,"
+      },
+      {
+        "text": "πάντων",
+        "tag": "w",
+        "type": "word",
+        "lemma": "πᾶς",
+        "strong": "G39560",
+        "morph": "Gr,RI,,,,GMP,"
+      },
+      {
+        "text": "ὑμῶν",
+        "tag": "w",
+        "type": "word",
+        "lemma": "σύ",
+        "strong": "G47710",
+        "morph": "Gr,RP,,,2G,P,"
+      },
+      {
+        "type": "text",
+        "text": ".\n"
+      }
+    ]
+  },
+  "front": {
+    "verseObjects": [
+      {
+        "tag": "p",
+        "type": "paragraph",
+        "text": "\n"
+      },
+      {
+        "type": "text",
+        "text": "\n"
+      }
+    ]
+  }
+}

--- a/src/js/helpers/AlignmentHelpers.js
+++ b/src/js/helpers/AlignmentHelpers.js
@@ -103,8 +103,8 @@ export function verseStringWordsContainedInAlignments(alignments, wordBank, vers
 export const unmerge = (verseObjects, alignedVerse) => {
   let baseMilestones = [], wordBank = [];
   let alignments = [];
-  if (verseObjects && verseObjects.verseObject) {
-    verseObjects = verseObjects.verseObject;
+  if (verseObjects && verseObjects.verseObjects) {
+    verseObjects = verseObjects.verseObjects;
   }
   if (typeof alignedVerse !== 'string') {
     alignedVerse = VerseObjectHelpers.getWordList(alignedVerse);

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -245,5 +245,5 @@ export const getUsfmForVerseContent = (verseData) => {
   };
   const USFM = usfmjs.toUSFM(outputData, {chunk: true});
   const split = USFM.split("\\v 1 ");
-  return split.length > 1 ? split[1] : USFM;
+  return split.length > 1 ? split[1] : "";
 };


### PR DESCRIPTION
Replaces: unfoldingword-dev#4093 which was reverted

#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix USFM3 import to flatten UGNT milestones  in greek text before unmerging alignment data.
- fix issue that generateBlankAlignments() would break with punctuation such as `κατ’`
-  migration for fixing of 0 value for occurrence(s) in older alignments

#### Please include detailed Test instructions for your pull request:
- follow steps in https://github.com/unfoldingWord-dev/translationCore/issues/4086 and should be able to import a USFM3 Titus project without getting the alignment reset.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4101)
<!-- Reviewable:end -->
