### PR TITLE
USFM Export Fix For False Positive Merge Conflicts

### DIFF
--- a/__tests__/MergeConflictHelpers.test.js
+++ b/__tests__/MergeConflictHelpers.test.js
@@ -123,3 +123,52 @@ describe('MergeConflictHelpers.getMergeConflicts', () => {
     expect(foundMergeConflicts.length).toEqual(10);
   });
 });
+
+describe('MergeConflictHelpers.parseMergeConflictVersion', () => {
+  test('should parse the version of a merge conflict in the format of the reducer', () => {
+    const verseText = 'This is random verse with a merge conflict';
+    const expectedParsedObject = {"chapter": "1", "text": {"8": verseText}, "verses": "8"};
+    const versionText = `\\v 8 ${verseText}`;
+    let usfmFilePath = ProjectStructureValidationHelpers.isUSFMProject(oneMergeConflictsUSFMPath);
+    let usfmData = MergeConflictHelpers.loadUSFM(usfmFilePath);
+    const parsedMergeConflict = MergeConflictHelpers.parseMergeConflictVersion(versionText, usfmData);
+    expect(parsedMergeConflict).toEqual(expectedParsedObject);
+  });
+
+  test('should parse the version of a merge conflict with two verses in the format of the reducer', () => {
+    const verseText1 = 'El anciano debe ser irreprensible, esposo de una sola mujer, con hijos fieles, que no sean acusados de ser malos o indisciplinados.';
+    const verseText2 = 'Es necesario que el obispo, como administrador de la casa de Dios, sea irreprensible. No debe ser escandaloso o desenfrenado. No se debe enojar fácilmente, ni ser adicto al vino, no violento, ni avaro.';
+    const expectedParsedObject = {
+      "chapter": "1",
+      "text": {
+        "6": "El anciano debe ser irreprensible, esposo de una sola mujer, con hijos fieles, que no sean acusados de ser malos o indisciplinados. ",
+        "7": "Es necesario que el obispo, como administrador de la casa de Dios, sea irreprensible. No debe ser escandaloso o desenfrenado. No se debe enojar fácilmente, ni ser adicto al vino, no violento, ni avaro."
+      },
+      "verses": "6-7"
+    };
+    const versionText = `\\v 6 ${verseText1} \\v 7 ${verseText2}`;
+    let usfmFilePath = ProjectStructureValidationHelpers.isUSFMProject(manyMergeConflictsUSFMPath);
+    let usfmData = MergeConflictHelpers.loadUSFM(usfmFilePath);
+    const parsedMergeConflict = MergeConflictHelpers.parseMergeConflictVersion(versionText, usfmData);
+    expect(parsedMergeConflict).toEqual(expectedParsedObject);
+  });
+});
+
+describe('MergeConflictHelpers.getChapterFromVerseText', () => {
+  test('should fine the chapter from which the verse is from', () => {
+    const verseText = 'Aka mien ọnọ mọn adiuduan oghi efunru, imọin lẹ ọnuan ni.';
+    const expectedChapter = "3";
+    let usfmFilePath = ProjectStructureValidationHelpers.isUSFMProject(oneMergeConflictsUSFMPath);
+    let usfmData = MergeConflictHelpers.loadUSFM(usfmFilePath);
+    const parsedMergeConflict = MergeConflictHelpers.getChapterFromVerseText(verseText, usfmData);
+    expect(parsedMergeConflict).toEqual(expectedChapter);
+  });
+
+  test('should not find the chapter from which the verse is from', () => {
+    const verseText = 'verse that doesnt exist';
+    let usfmFilePath = ProjectStructureValidationHelpers.isUSFMProject(oneMergeConflictsUSFMPath);
+    let usfmData = MergeConflictHelpers.loadUSFM(usfmFilePath);
+    const parsedMergeConflict = MergeConflictHelpers.getChapterFromVerseText(verseText, usfmData);
+    expect(parsedMergeConflict).toBeUndefined();
+  });
+});

--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -164,9 +164,7 @@ describe('USFMExportActions.USFMExportActions', () => {
         conflicts: [true]
       }
     };
-    const expectedActions = [{ "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
-    { "type": "RESET_PROJECT_VALIDATION_REDUCER" },
-    { "type": "VALIDATE" },
+    const expectedActions = [{ "type": "VALIDATE" },
     { "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
     { "type": "RESET_PROJECT_VALIDATION_REDUCER" }];
     const store = mockStore(initialState);
@@ -188,7 +186,7 @@ describe('USFMExportActions.USFMExportActions', () => {
         conflicts: null
       }
     };
-    const expectedActions = [{"type": "CLEAR_MERGE_CONFLICTS_REDUCER"}, {"type": "RESET_PROJECT_VALIDATION_REDUCER"}, {"type": "VALIDATE"}];
+    const expectedActions = [{"type": "VALIDATE"}];
     const store = mockStore(initialState);
     return store.dispatch(USFMExportActions.checkProjectForMergeConflicts(projectSaveLocation)).then((res) => {
       expect(res).toBe();
@@ -362,9 +360,7 @@ describe('USFMExportActions.exportToUSFM', () => {
   });
   it('should get a successfully export a project to usfm3', () => {
     const filePath = `/57-TIT.usfm`;
-    const expectedActions = [{ "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
-    { "type": "RESET_PROJECT_VALIDATION_REDUCER" },
-    { "type": "VALIDATE" },
+    const expectedActions = [{ "type": "VALIDATE" },
     { "type": "OPEN_OPTION_DIALOG" },
     { "type": "CLOSE_ALERT_DIALOG" },
     { "bool": true, "type": "SHOW_DIMMED_SCREEN" },

--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -164,22 +164,11 @@ describe('USFMExportActions.USFMExportActions', () => {
         conflicts: [true]
       }
     };
-    const expectedActions = [{ "type": "VALIDATE" },
-    { type: 'TOGGLE_PROJECT_VALIDATION_STEPPER', showProjectValidationStepper: false },
-    { type: 'RESET_PROJECT_DETAIL' },
-    { type: 'TOGGLE_HOME_VIEW', boolean: true },
-    { type: 'RESET_PROJECT_DETAIL' },
-    { type: 'CLEAR_PREVIOUS_GROUPS_DATA' },
-    { type: 'CLEAR_PREVIOUS_GROUPS_INDEX' },
-    { type: 'CLEAR_CONTEXT_ID' },
-    { type: 'CLEAR_CURRENT_TOOL_DATA' },
-    { type: 'CLEAR_RESOURCES_REDUCER' },
-    { type: 'SET_CURRENT_TOOL_TITLE', currentToolTitle: '' },
-    { type: 'CLEAR_COPYRIGHT_CHECK_REDUCER' },
-    { type: 'CLEAR_PROJECT_INFORMATION_REDUCER' },
-    { type: 'CLEAR_MERGE_CONFLICTS_REDUCER' },
-    { type: 'RESET_PROJECT_VALIDATION_REDUCER' },
-    { type: 'GET_MY_PROJECTS', projects: [] }];
+    const expectedActions = [{ "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
+    { "type": "RESET_PROJECT_VALIDATION_REDUCER" },
+    { "type": "VALIDATE" },
+    { "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
+    { "type": "RESET_PROJECT_VALIDATION_REDUCER" }];
     const store = mockStore(initialState);
     return store.dispatch(USFMExportActions.checkProjectForMergeConflicts(projectSaveLocation)).catch((e) => {
       expect(e).toBe('projects.merge_export_error');
@@ -199,7 +188,7 @@ describe('USFMExportActions.USFMExportActions', () => {
         conflicts: null
       }
     };
-    const expectedActions = [{ "type": "VALIDATE" }];
+    const expectedActions = [{"type": "CLEAR_MERGE_CONFLICTS_REDUCER"}, {"type": "RESET_PROJECT_VALIDATION_REDUCER"}, {"type": "VALIDATE"}];
     const store = mockStore(initialState);
     return store.dispatch(USFMExportActions.checkProjectForMergeConflicts(projectSaveLocation)).then((res) => {
       expect(res).toBe();
@@ -373,23 +362,17 @@ describe('USFMExportActions.exportToUSFM', () => {
   });
   it('should get a successfully export a project to usfm3', () => {
     const filePath = `/57-TIT.usfm`;
-    const expectedActions = [{ type: 'VALIDATE' },
-    { type: 'OPEN_OPTION_DIALOG' },
-    { type: 'CLOSE_ALERT_DIALOG' },
-    { type: 'SHOW_DIMMED_SCREEN', bool: true },
-    {
-      type: 'OPEN_ALERT_DIALOG',
-      alertMessage: 'projects.exporting_file_alert',
-      loading: true
-    },
-    { type: 'SHOW_DIMMED_SCREEN', bool: false },
-    { type: 'CLOSE_ALERT_DIALOG' },
-    { type: 'SET_USFM_SAVE_LOCATION', usfmSaveLocation: '/' },
-    {
-      type: 'OPEN_ALERT_DIALOG',
-      alertMessage: 'projects.exported_alert',
-      loading: false
-    }];
+    const expectedActions = [{ "type": "CLEAR_MERGE_CONFLICTS_REDUCER" },
+    { "type": "RESET_PROJECT_VALIDATION_REDUCER" },
+    { "type": "VALIDATE" },
+    { "type": "OPEN_OPTION_DIALOG" },
+    { "type": "CLOSE_ALERT_DIALOG" },
+    { "bool": true, "type": "SHOW_DIMMED_SCREEN" },
+    { "alertMessage": "projects.exporting_file_alert", "loading": true, "type": "OPEN_ALERT_DIALOG" },
+    { "bool": false, "type": "SHOW_DIMMED_SCREEN" },
+    { "type": "CLOSE_ALERT_DIALOG" },
+    { "type": "SET_USFM_SAVE_LOCATION", "usfmSaveLocation": "/" },
+    { "alertMessage": "projects.exported_alert", "loading": false, "type": "OPEN_ALERT_DIALOG" }];
     const projectSaveLocation = path.join(PROJECTS_PATH, projectName);
     const usfmExportType = 'usfm3';
     const initialState = {

--- a/src/js/actions/MergeConflictActions.js
+++ b/src/js/actions/MergeConflictActions.js
@@ -168,6 +168,7 @@ export function finalize() {
     MergeConflictHelpers.merge(mergeConflictArray.conflicts, mergeConflictArray.filePath);
     TargetLanguageActions.generateTargetBibleFromUSFMPath(mergeConflictArray.filePath, projectSaveLocation, manifest);
     dispatch(ProjectImportStepperActions.removeProjectValidationStep(MERGE_CONFLICT_NAMESPACE));
+    dispatch({ type: consts.CLEAR_MERGE_CONFLICTS_REDUCER });
     dispatch(ProjectImportStepperActions.updateStepperIndex());
   });
 }

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -10,7 +10,6 @@ import * as AlertModalActions from './AlertModalActions';
 import * as TargetLanguageActions from './TargetLanguageActions';
 import * as BodyUIActions from './BodyUIActions';
 import * as MergeConflictActions from '../actions/MergeConflictActions';
-import * as ProjectImportStepperActions from '../actions/ProjectImportStepperActions';
 import * as WordAlignmentActions from './WordAlignmentActions';
 import { setSetting } from '../actions/SettingsActions';
 //helpers
@@ -78,13 +77,16 @@ export function exportToUSFM(projectPath) {
 export function checkProjectForMergeConflicts(projectPath, manifest) {
   return ((dispatch, getState) => {
     return new Promise((resolve, reject) => {
+      dispatch({ type: types.CLEAR_MERGE_CONFLICTS_REDUCER });
+      dispatch({ type: types.RESET_PROJECT_VALIDATION_REDUCER });
       const translate = getTranslate(getState());
       //Using the validate function to run requred processes to check for merge conflicts
       dispatch(MergeConflictActions.validate(projectPath, manifest));
       const { conflicts } = getState().mergeConflictReducer;
       if (conflicts) {
         /** Clearing merge conflicts for future import */
-        dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
+        dispatch({ type: types.CLEAR_MERGE_CONFLICTS_REDUCER });
+        dispatch({ type: types.RESET_PROJECT_VALIDATION_REDUCER });
         /** If project has merge conflicts it cannot be imported */
         reject(translate('projects.merge_export_error'));
       } else resolve();

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -77,8 +77,6 @@ export function exportToUSFM(projectPath) {
 export function checkProjectForMergeConflicts(projectPath, manifest) {
   return ((dispatch, getState) => {
     return new Promise((resolve, reject) => {
-      dispatch({ type: types.CLEAR_MERGE_CONFLICTS_REDUCER });
-      dispatch({ type: types.RESET_PROJECT_VALIDATION_REDUCER });
       const translate = getTranslate(getState());
       //Using the validate function to run requred processes to check for merge conflicts
       dispatch(MergeConflictActions.validate(projectPath, manifest));


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes the behavior of a merge conflict not getting reset in the data and causing usfm export to think there is a conflict even though it is from the last project. 

#### Please include detailed Test instructions for your pull request:
1. Import https://git.door43.org/tc06/en-x-demo1_php_text_ulb
2. Resolve the merge conflicts and open in Word Alignment
3. Go back to the projects page
4. Click on the 3 dot menu on a different project and choose Export to USFM
5. You should not get an alert saying that there were merge conflicts
### Try to break this in similar ways

#### Standard Test Instructions for PR Review Process:

- [x] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [x] Checkout the branch locally and ensure that app runs as expected
  - [x] Ensure tests pass
  - [x] Open and watch the console for errors
  - [x] Make sure all actions perform as expected
  - [x] Import and Load a new Project
  - [x] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4149)
<!-- Reviewable:end -->
