### PR TITLE
Fixed hyphenated word bug with usfm3 project imports

### DIFF
--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -133,7 +133,6 @@ export const generateTargetLanguageBibleFromUsfm = async (usfmData, manifest, se
         verses.forEach((verse) => {
           const verseParts = chaptersObject[chapter][verse];
           bibleChapter[verse] = getUsfmForVerseContent(verseParts).trim();
-
           if (alignmentData && bibleData && bibleData[chapter]) {
             const bibleVerse = bibleData[chapter][verse];
             const object = AlignmentHelpers.unmerge(verseParts, bibleVerse);
@@ -225,7 +224,7 @@ export const getUsfmForVerseContent = (verseData) => {
         wordSpacing = ' ';
         if (verseObject.type === 'text') {
           const lastChar = verseObject.text.substr(-1);
-          if ((lastChar === "'") || (lastChar === '"')) { // special case: no extra spacing after quotes or apostrophes before words
+          if ((lastChar === "'") || (lastChar === '"') || (lastChar === '-')) { // special case: no extra spacing after quotes or apostrophes before words
             wordSpacing = '';
           }
         }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixed hyphenated word bug with usfm3 project imports

#### Please include detailed Test instructions for your pull request:
- Load [en_tit.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/1862241/en_tit.usfm.zip)
- Go to the check **Discipline Titus 1:8** and the word `self-control` should render without an extra space after the hyphen.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4187)
<!-- Reviewable:end -->
