### PR TITLE
Localizing Merge Conflict Resolver 'Version' text

### DIFF
--- a/__tests__/__snapshots__/MergeConflictsCard.test.js.snap
+++ b/__tests__/__snapshots__/MergeConflictsCard.test.js.snap
@@ -115,6 +115,7 @@ ShallowWrapper {
                   "6": "Some other verse",
                 }
               }
+              translate={[Function]}
             />,
             <VersionCard
               checked={true}
@@ -127,6 +128,7 @@ ShallowWrapper {
                   "6": "Some other verse",
                 }
               }
+              translate={[Function]}
             />,
           ],
         ],
@@ -311,6 +313,7 @@ ShallowWrapper {
               "5": "This verse has been changed by another user",
               "6": "Some other verse",
             },
+            "translate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -329,6 +332,7 @@ ShallowWrapper {
               "5": "Some verse",
               "6": "Some other verse",
             },
+            "translate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -411,6 +415,7 @@ ShallowWrapper {
                     "6": "Some other verse",
                   }
                 }
+                translate={[Function]}
               />,
               <VersionCard
                 checked={true}
@@ -423,6 +428,7 @@ ShallowWrapper {
                     "6": "Some other verse",
                   }
                 }
+                translate={[Function]}
               />,
             ],
           ],
@@ -607,6 +613,7 @@ ShallowWrapper {
                 "5": "This verse has been changed by another user",
                 "6": "Some other verse",
               },
+              "translate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -625,6 +632,7 @@ ShallowWrapper {
                 "5": "Some verse",
                 "6": "Some other verse",
               },
+              "translate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -1085,6 +1093,7 @@ ShallowWrapper {
         "5": "This verse has been changed by another user",
         "6": "Some other verse",
       },
+      "translate": [Function],
     },
     "ref": null,
     "rendered": null,
@@ -1104,6 +1113,7 @@ ShallowWrapper {
           "5": "This verse has been changed by another user",
           "6": "Some other verse",
         },
+        "translate": [Function],
       },
       "ref": null,
       "rendered": null,
@@ -1657,6 +1667,7 @@ ShallowWrapper {
                   "6": "Some other verse",
                 }
               }
+              translate={[Function]}
             />,
             <VersionCard
               checked={true}
@@ -1669,6 +1680,7 @@ ShallowWrapper {
                   "6": "Some other verse",
                 }
               }
+              translate={[Function]}
             />,
           ],
         ],
@@ -1853,6 +1865,7 @@ ShallowWrapper {
               "5": "This verse has been changed by another user",
               "6": "Some other verse",
             },
+            "translate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -1871,6 +1884,7 @@ ShallowWrapper {
               "5": "Some verse",
               "6": "Some other verse",
             },
+            "translate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -1953,6 +1967,7 @@ ShallowWrapper {
                     "6": "Some other verse",
                   }
                 }
+                translate={[Function]}
               />,
               <VersionCard
                 checked={true}
@@ -1965,6 +1980,7 @@ ShallowWrapper {
                     "6": "Some other verse",
                   }
                 }
+                translate={[Function]}
               />,
             ],
           ],
@@ -2149,6 +2165,7 @@ ShallowWrapper {
                 "5": "This verse has been changed by another user",
                 "6": "Some other verse",
               },
+              "translate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -2167,6 +2184,7 @@ ShallowWrapper {
                 "5": "Some verse",
                 "6": "Some other verse",
               },
+              "translate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -2627,6 +2645,7 @@ ShallowWrapper {
         "5": "Some verse",
         "6": "Some other verse",
       },
+      "translate": [Function],
     },
     "ref": null,
     "rendered": null,
@@ -2646,6 +2665,7 @@ ShallowWrapper {
           "5": "Some verse",
           "6": "Some other verse",
         },
+        "translate": [Function],
       },
       "ref": null,
       "rendered": null,

--- a/src/js/components/projectValidation/MergeConflictsCheck/MergeConflictsCard.js
+++ b/src/js/components/projectValidation/MergeConflictsCheck/MergeConflictsCard.js
@@ -16,6 +16,7 @@ class MergeConflictsCheck extends Component {
     return versions.map((version) => {
       return (
         <VersionCard
+        translate={this.props.translate}
         key={`${mergeConflictIndex}-${version.index}`}
         onCheck={this.props.onCheck}
         {...version}

--- a/src/js/components/projectValidation/MergeConflictsCheck/VersionCard.js
+++ b/src/js/components/projectValidation/MergeConflictsCheck/VersionCard.js
@@ -15,13 +15,13 @@ class VersionCard extends Component {
   }
 
   render() {
-    let {checked, index, mergeConflictIndex, textData } = this.props;
+    let {checked, index, mergeConflictIndex, textData, translate } = this.props;
     return (
       <div style={{ borderBottom: '1px solid black' }}>
         <div style={{ padding: 15 }}>
           <RadioButton
             checked={checked}
-            label={`Version ${Number(index) + 1}`}
+            label={translate('version', {'version': Number(index) + 1})}
             onCheck={() => this.props.onCheck(mergeConflictIndex, index, true)}
           />
           {this.getTextObjectSection(textData)}
@@ -36,7 +36,8 @@ VersionCard.propTypes = {
   mergeConflictIndex: PropTypes.string.isRequired,
   textData: PropTypes.object.isRequired,
   onCheck: PropTypes.func.isRequired,
-  checked: PropTypes.any
+  checked: PropTypes.any,
+  translate: PropTypes.func.isRequired
 };
 
 export default VersionCard;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR grabs the localized text for the merge conflict version card component

#### Please include detailed Test instructions for your pull request:
- Get a merge conflict project, if you don't have one you can use [this](https://github.com/unfoldingWord-dev/translationCore/files/1872666/ema-x-ora_php_ult.zip) one.
- Change the locale to Hindi, try and load the project and you should be presented with a merge conflict message, when resolving the version ensure you see localized text everywhere on the stepper card. (Especially when pressing the dropdown)


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4219)
<!-- Reviewable:end -->
