### PR TITLE
Standardize Language Icon Styling and Position

### DIFF
--- a/__tests__/__snapshots__/MyProjects.test.js.snap
+++ b/__tests__/__snapshots__/MyProjects.test.js.snap
@@ -140,8 +140,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -154,15 +154,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       }
                                     }
                                   />
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   5 days ago
                                 </td>
                               </tr>
@@ -189,8 +181,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -203,15 +195,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       }
                                     }
                                   />
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   <span>
                                      
                                     (1co) 1 Corinthians
@@ -241,8 +225,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -255,8 +239,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                         "display": "inline-block",
                                         "fill": "currentColor",
                                         "height": "20px",
+                                        "marginBottom": "5px",
                                         "marginRight": "5px",
-                                        "marginTop": "6px",
                                         "muiPrepared": true,
                                         "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                                         "userSelect": "none",
@@ -269,15 +253,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"
                                     />
                                   </svg>
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   <span>
                                      
                                     (en) English
@@ -473,8 +449,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -487,15 +463,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       }
                                     }
                                   />
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   6 days ago
                                 </td>
                               </tr>
@@ -522,8 +490,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -536,15 +504,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       }
                                     }
                                   />
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   <span>
                                      
                                     (tit) Titus
@@ -574,8 +534,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                 <td
                                   style={
                                     Object {
-                                      "verticalAlign": "top",
-                                      "width": "1px",
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     }
                                   }
                                 >
@@ -588,8 +548,8 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                         "display": "inline-block",
                                         "fill": "currentColor",
                                         "height": "20px",
+                                        "marginBottom": "5px",
                                         "marginRight": "5px",
-                                        "marginTop": "6px",
                                         "muiPrepared": true,
                                         "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                                         "userSelect": "none",
@@ -602,15 +562,7 @@ exports[`MyProjects component renders correctly MyProjects component render shou
                                       d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"
                                     />
                                   </svg>
-                                </td>
-                                <td
-                                  style={
-                                    Object {
-                                      "paddingRight": "3px",
-                                      "verticalAlign": "top",
-                                    }
-                                  }
-                                >
+                                   
                                   <span>
                                      
                                     (hi) Hindi

--- a/__tests__/__snapshots__/ProjectCard.test.js.snap
+++ b/__tests__/__snapshots__/ProjectCard.test.js.snap
@@ -123,8 +123,8 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                             <td
                               style={
                                 Object {
-                                  "verticalAlign": "top",
-                                  "width": "1px",
+                                  "alignItems": "center",
+                                  "display": "flex",
                                 }
                               }
                             >
@@ -137,15 +137,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                                   }
                                 }
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "paddingRight": "3px",
-                                  "verticalAlign": "top",
-                                }
-                              }
-                            >
+                               
                               5 days ago
                             </td>
                           </tr>
@@ -172,8 +164,8 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                             <td
                               style={
                                 Object {
-                                  "verticalAlign": "top",
-                                  "width": "1px",
+                                  "alignItems": "center",
+                                  "display": "flex",
                                 }
                               }
                             >
@@ -186,15 +178,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                                   }
                                 }
                               />
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "paddingRight": "3px",
-                                  "verticalAlign": "top",
-                                }
-                              }
-                            >
+                               
                               <span>
                                  
                                 (1co) 1 Corinthians
@@ -224,8 +208,8 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                             <td
                               style={
                                 Object {
-                                  "verticalAlign": "top",
-                                  "width": "1px",
+                                  "alignItems": "center",
+                                  "display": "flex",
                                 }
                               }
                             >
@@ -238,8 +222,8 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                                     "display": "inline-block",
                                     "fill": "currentColor",
                                     "height": "20px",
+                                    "marginBottom": "5px",
                                     "marginRight": "5px",
-                                    "marginTop": "6px",
                                     "muiPrepared": true,
                                     "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
                                     "userSelect": "none",
@@ -252,15 +236,7 @@ exports[`Test ProjectCard component Comparing ProjectCard Component render shoul
                                   d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"
                                 />
                               </svg>
-                            </td>
-                            <td
-                              style={
-                                Object {
-                                  "paddingRight": "3px",
-                                  "verticalAlign": "top",
-                                }
-                              }
-                            >
+                               
                               <span>
                                  
                                 (en) English

--- a/src/js/components/home/projectsManagement/ProjectCard.js
+++ b/src/js/components/home/projectsManagement/ProjectCard.js
@@ -62,25 +62,22 @@ let ProjectCard = (props) => {
                   }
                   return (
                     <td style={{width: width, verticalAlign: 'top'}} key={index}>
-                      <table style={{width: '100%'}}>
-                        <tbody>
-                          <tr>
-                            <td style={{width: '1px', verticalAlign: 'top'}}>
-                              { cardDetail.translateIcon ?
-                                  <TranslateIcon style={{ height: '20px', width: '20px', color: '#000000', marginRight: '5px', marginTop: '6px' }} />
-                                :
+                        <table style={{ width: '100%' }}>
+                          <tbody>
+                            <tr>
+                              <td style={{ display:'flex', alignItems:'center'}}>
+                                {cardDetail.translateIcon ?
+                                  <TranslateIcon style={{ height: '20px', width: '20px', color: '#000000', marginRight: '5px', marginBottom: '5px' }} />
+                                  :
                                   <Glyphicon glyph={cardDetail.glyph} style={{ marginRight: '5px', top: '2px' }} />
-                              }
-                            </td>
-                            <td style={{verticalAlign: 'top', paddingRight: '3px'}}>
-                              {cardDetail.text}
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </td>
-                  );
-                })
+                                }&nbsp;{cardDetail.text}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    );
+                  })
               }
               </tr>
             </tbody>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR makes the project cards styling for the language icon the same as the ones in the online search modal

#### Please include detailed Test instructions for your pull request:
- Open the app and ensure the styling on the online import project cards is the same as the local projects cards (in terms of the language icon position)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4271)
<!-- Reviewable:end -->
