### PR TITLE
Bugfix 4285/Fix localization of NT warning

### DIFF
--- a/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
@@ -1,6 +1,7 @@
 import path from 'path-extra';
 import fs from 'fs-extra';
 import React from 'react';
+import {getTranslate} from '../../selectors';
 //helpers
 import * as usfmHelpers from '../usfmHelpers';
 //static
@@ -195,6 +196,9 @@ export function verifyValidBetaProject(state) {
     let { manifest } = state.projectDetailsReducer;
     if (currentSettings && currentSettings.developerMode) return resolve();
     else if (manifest && manifest.project && BooksOfTheBible.newTestament[manifest.project.id]) return resolve();
-    else return reject('This version of translationCore only supports New Testament projects.');
+    else {
+      const translate = getTranslate(state);
+      return reject(translate("project_validation.only_nt_supported"));
+    }
   });
 }

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -198,7 +198,8 @@
     "merge_conflicts": "Merge Conflicts",
     "merge_conflict": "Merge Conflict ${conflict_number}",
     "conflict_reference": "This is a merge conflict for chapter ${chapter}, verse ${verse}.",
-    "missing_verses_instructions": "Some verses are missing from your project. You can fix these in ${tstudio} or ${autographa}."
+    "missing_verses_instructions": "Some verses are missing from your project. You can fix these in ${tstudio} or ${autographa}.",
+    "only_nt_supported": "This version of translationCore only supports New Testament projects."
   },
   "book_list": {
     "nt": {

--- a/src/locale/Hindi-hi_IN.json
+++ b/src/locale/Hindi-hi_IN.json
@@ -198,7 +198,8 @@
     "merge_conflicts": "मर्ज विवाद",
     "merge_conflict": "विलय संघर्ष ${conflict_number}",
     "conflict_reference": "यह अध्याय ${chapter}, कविता ${verse} के लिए एक मर्ज संघर्ष है",
-    "missing_verses_instructions": "आपकी परियोजना से कुछ छंद गायब हैं आप इन को ${tstudio} या ${autographa} में ठीक कर सकते हैं"
+    "missing_verses_instructions": "आपकी परियोजना से कुछ छंद गायब हैं आप इन को ${tstudio} या ${autographa} में ठीक कर सकते हैं",
+    "only_nt_supported": "अनुवाद का यह संस्करण केवल नए नियम परियोजनाओं का समर्थन करता है।"
   },
   "book_list": {
     "nt": {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix localization on New testament warning.

#### Please include detailed Test instructions for your pull request:
- turn off developer mode
- switch to Hindi locale
- try to do USFM import of OT book.
- should see hindi dialog prompt: अनुवाद का यह संस्करण केवल नए नियम परियोजनाओं का समर्थन करता है।

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4286)
<!-- Reviewable:end -->
