### PR TITLE
Invalid Book Name With Non-Developer Mode Fix

### DIFF
--- a/__tests__/ProjectStructureValidationHelpers.test.js
+++ b/__tests__/ProjectStructureValidationHelpers.test.js
@@ -1,4 +1,4 @@
-jest.unmock('fs-extra');
+import fs from 'fs-extra';
 //helpers
 import * as ProjectStructureValidationHelpers from '../src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers';
 //projects
@@ -15,6 +15,13 @@ const en_tw_project = '__tests__/fixtures/project/projectVerification/en_tw';
 const en_tn_project = '__tests__/fixtures/project/projectVerification/en_tn';
 
 describe('ProjectStructureValidationHelpers.testResourceByType', () => {
+    beforeAll(() => {
+        const sourcePath = '__tests__/fixtures/project/';
+        const destinationPath = '__tests__/fixtures/project/';
+        const copyFiles = ['projectVerification'];
+        fs.__resetMockFS();
+        fs.__loadFilesIntoMockFs(copyFiles, sourcePath, destinationPath);
+    });
     //Testing false negatives for resources (tN, tW, tA) and Open Bible Stories
     test('should detect project as translationNotes', () => {
         let errMessage = ProjectStructureValidationHelpers.testResourceByType(en_tn_project, 'tn');
@@ -111,4 +118,40 @@ describe('projectHasMultipleBooks', () => {
         let result = ProjectStructureValidationHelpers.projectHasMultipleBooks(en_tw_project);
         expect(result).toBeFalsy();
     });
+});
+
+describe('verifyValidBetaProject', () => {
+    var state = {
+        settingsReducer: {
+            currentSettings: {
+                developerMode: true
+            }
+        },
+        projectDetailsReducer: {
+            manifest: {
+                project: {
+                    id: 'tit'
+                }
+            }
+        }
+    };
+    test('valid beta project with developer mode', () => {
+       return expect(ProjectStructureValidationHelpers.verifyValidBetaProject(state)).resolves.toBe();
+    });
+    test('valid beta project without developer mode', () => {
+        state.settingsReducer.currentSettings.developerMode = false;
+        return expect(ProjectStructureValidationHelpers.verifyValidBetaProject(state)).resolves.toBe();
+     });
+     test('valid beta project without developer mode and not old testament', () => {
+        state.projectDetailsReducer.manifest.project.id = 'fakebook';
+        return expect(ProjectStructureValidationHelpers.verifyValidBetaProject(state)).resolves.toBe();
+     });
+     test('not valid beta project without developer mode and old testament', () => {
+        state.projectDetailsReducer.manifest.project.id = '1ki';
+        return expect(ProjectStructureValidationHelpers.verifyValidBetaProject(state)).rejects.toBe('This version of translationCore only supports New Testament projects.');
+     });
+     test('valid beta project with developer mode and old testament', () => {
+        state.settingsReducer.currentSettings.developerMode = true;
+        return expect(ProjectStructureValidationHelpers.verifyValidBetaProject(state)).resolves.toBe();
+     });
 });

--- a/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
@@ -194,7 +194,7 @@ export function verifyValidBetaProject(state) {
     let { currentSettings } = state.settingsReducer;
     let { manifest } = state.projectDetailsReducer;
     if (currentSettings && currentSettings.developerMode) return resolve();
-    else if (manifest && manifest.project && BooksOfTheBible.newTestament[manifest.project.id]) return resolve();
+    else if (manifest && manifest.project && !BooksOfTheBible.oldTestament[manifest.project.id]) return resolve();
     else return reject('This version of translationCore only supports New Testament projects.');
   });
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR allows projects that do not have a valid book id to be loaded in non developer mode.

#### Please include detailed Test instructions for your pull request:
- Download [this](https://github.com/unfoldingWord-dev/translationCore/files/1882010/ITT.usfm.zip) project
- Turn off developer mode
- Import the usfm file
- Choose Titus as the book and English as the language
- Open in Word Alignment
- Everything should work as expected

Note: Any invalid book name projects should work whether in developer mode or not, and any old testament projects should still not work in non developer mode

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4287)
<!-- Reviewable:end -->
