### PR TITLE
Bugfix 4347/Should not warn of Invalid Alignments for edited verses that have no alignment.

### DIFF
--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -133,7 +133,7 @@ const mergeTest = (name = {}) => {
   const json = readJSON(`${name}.json`);
   expect(json).toBeTruthy();
   const {alignment, verseObjects, verseString, wordBank} = json;
-  const output = AlignmentHelpers.merge(alignment, wordBank, verseString);
+  const output = AlignmentHelpers.merge(alignment, wordBank, verseString, true);
   const jsonChunk = {
     "headers": [],
     "chapters": {},

--- a/__tests__/AlignmentHelpers.test.js
+++ b/__tests__/AlignmentHelpers.test.js
@@ -44,6 +44,27 @@ describe("Merge Alignment into Verse Objects", () => {
   it('handles titus 1-1', () => {
     mergeTest('tit1-1');
   });
+  it('handles titus 1-1 unaligned extra word in wordbank', () => {
+    mergeTest('tit1-1_unaligned_extra_in_wordbank');
+  });
+  it('handles titus 1-1 unaligned missing word in wordbank', () => {
+    mergeTest('tit1-1_unaligned_missing_in_wordbank');
+  });
+  it('handles titus 1-1 partial aligned', () => {
+    mergeTest('tit1-1_partial_aligned');
+  });
+  it('handles titus 1-1 partial aligned extra word in wordbank', () => {
+    function test_error() {
+      mergeTest('tit1-1_partial_extra_in_wordbank');
+    }
+    expect(test_error).toThrowErrorMatchingSnapshot();
+  });
+  it('handles titus 1-1 partial aligned missing word in wordbank', () => {
+    function test_error() {
+      mergeTest('tit1-1_partial_missing_in_wordbank');
+    }
+    expect(test_error).toThrowErrorMatchingSnapshot();
+  });
 });
 
 

--- a/__tests__/__snapshots__/AlignmentHelpers.test.js.snap
+++ b/__tests__/__snapshots__/AlignmentHelpers.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Merge Alignment into Verse Objects handles titus 1-1 partial aligned extra word in wordbank 1`] = `"Word \\"extra\\" is in wordBank, but missing from target language verse."`;
+
+exports[`Merge Alignment into Verse Objects handles titus 1-1 partial aligned missing word in wordbank 1`] = `"The words \\"extra\\" from the target language verse are not in the alignment data."`;

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_aligned.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_aligned.json
@@ -1,0 +1,636 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,",
+  "verseObjects": [
+    {
+      "strongs": "G39720",
+      "lemma": "Παῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "Παῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "strongs": "G14010",
+      "lemma": "δοῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "δοῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "type": "text",
+      "text": "'"
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "Παῦλος",
+          "strongs": "G39720",
+          "lemma": "Παῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δοῦλος",
+          "strongs": "G14010",
+          "lemma": "δοῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀπόστολος",
+          "strongs": "G06520",
+          "lemma": "ἀπόστολος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δὲ",
+          "strongs": "G11610",
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Ἰησοῦ",
+          "strongs": "G24240",
+          "lemma": "Ἰησοῦς",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Χριστοῦ",
+          "strongs": "G55470",
+          "lemma": "χριστός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατὰ",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πίστιν",
+          "strongs": "G41020",
+          "lemma": "πίστις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκλεκτῶν",
+          "strongs": "G15880",
+          "lemma": "ἐκλεκτός",
+          "morph": "Gr,NS,,,,GMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strongs": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπίγνωσιν",
+          "strongs": "G19220",
+          "lemma": "ἐπίγνωσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀληθείας",
+          "strongs": "G02250",
+          "lemma": "ἀλήθεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τῆς",
+          "strongs": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,RR,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατ’",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσέβειαν",
+          "strongs": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "word": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "word": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "word": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "word": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "word": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_extra_in_wordbank.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_extra_in_wordbank.json
@@ -1,0 +1,641 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,",
+  "verseObjects": [
+    {
+      "strongs": "G39720",
+      "lemma": "Παῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "Παῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "strongs": "G14010",
+      "lemma": "δοῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "δοῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "type": "text",
+      "text": "'"
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "Παῦλος",
+          "strongs": "G39720",
+          "lemma": "Παῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δοῦλος",
+          "strongs": "G14010",
+          "lemma": "δοῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀπόστολος",
+          "strongs": "G06520",
+          "lemma": "ἀπόστολος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δὲ",
+          "strongs": "G11610",
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Ἰησοῦ",
+          "strongs": "G24240",
+          "lemma": "Ἰησοῦς",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Χριστοῦ",
+          "strongs": "G55470",
+          "lemma": "χριστός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατὰ",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πίστιν",
+          "strongs": "G41020",
+          "lemma": "πίστις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκλεκτῶν",
+          "strongs": "G15880",
+          "lemma": "ἐκλεκτός",
+          "morph": "Gr,NS,,,,GMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strongs": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπίγνωσιν",
+          "strongs": "G19220",
+          "lemma": "ἐπίγνωσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀληθείας",
+          "strongs": "G02250",
+          "lemma": "ἀλήθεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τῆς",
+          "strongs": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,RR,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατ’",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσέβειαν",
+          "strongs": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "word": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "word": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "word": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "word": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "word": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "extra",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_missing_in_wordbank.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_partial_missing_in_wordbank.json
@@ -1,0 +1,636 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness, extra",
+  "verseObjects": [
+    {
+      "strongs": "G39720",
+      "lemma": "Παῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "Παῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "strongs": "G14010",
+      "lemma": "δοῦλος",
+      "morph": "Gr,N,,,,,NMS,",
+      "occurrence": 1,
+      "occurrences": 1,
+      "tag": "zaln",
+      "type": "milestone",
+      "content": "δοῦλος",
+      "children": [
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "tag": "w",
+          "type": "word",
+          "text": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "type": "text",
+      "text": "'"
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "Παῦλος",
+          "strongs": "G39720",
+          "lemma": "Παῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "Paul",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δοῦλος",
+          "strongs": "G14010",
+          "lemma": "δοῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+        {
+          "word": "a",
+          "occurrence": 1,
+          "occurrences": 1
+        },
+        {
+          "word": "servant",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀπόστολος",
+          "strongs": "G06520",
+          "lemma": "ἀπόστολος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δὲ",
+          "strongs": "G11610",
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Ἰησοῦ",
+          "strongs": "G24240",
+          "lemma": "Ἰησοῦς",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Χριστοῦ",
+          "strongs": "G55470",
+          "lemma": "χριστός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατὰ",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πίστιν",
+          "strongs": "G41020",
+          "lemma": "πίστις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκλεκτῶν",
+          "strongs": "G15880",
+          "lemma": "ἐκλεκτός",
+          "morph": "Gr,NS,,,,GMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strongs": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπίγνωσιν",
+          "strongs": "G19220",
+          "lemma": "ἐπίγνωσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀληθείας",
+          "strongs": "G02250",
+          "lemma": "ἀλήθεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τῆς",
+          "strongs": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,RR,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατ’",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσέβειαν",
+          "strongs": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "word": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "word": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "word": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "word": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "word": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_unaligned_extra_in_wordbank.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_unaligned_extra_in_wordbank.json
@@ -1,0 +1,617 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,",
+  "verseObjects": [
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Paul",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "a",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "servant",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "type": "text",
+      "text": "'"
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "Παῦλος",
+          "strongs": "G39720",
+          "lemma": "Παῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δοῦλος",
+          "strongs": "G14010",
+          "lemma": "δοῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀπόστολος",
+          "strongs": "G06520",
+          "lemma": "ἀπόστολος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δὲ",
+          "strongs": "G11610",
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Ἰησοῦ",
+          "strongs": "G24240",
+          "lemma": "Ἰησοῦς",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Χριστοῦ",
+          "strongs": "G55470",
+          "lemma": "χριστός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατὰ",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πίστιν",
+          "strongs": "G41020",
+          "lemma": "πίστις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκλεκτῶν",
+          "strongs": "G15880",
+          "lemma": "ἐκλεκτός",
+          "morph": "Gr,NS,,,,GMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strongs": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπίγνωσιν",
+          "strongs": "G19220",
+          "lemma": "ἐπίγνωσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀληθείας",
+          "strongs": "G02250",
+          "lemma": "ἀλήθεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τῆς",
+          "strongs": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,RR,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατ’",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσέβειαν",
+          "strongs": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "Paul",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "a",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "servant",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "word": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "word": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "word": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "word": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "word": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "extra",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_unaligned_missing_in_wordbank.json
+++ b/__tests__/fixtures/pivotAlignmentVerseObjects/tit1-1_unaligned_missing_in_wordbank.json
@@ -1,0 +1,619 @@
+{
+  "alignedVerseString": "Παῦλος δοῦλος Θεοῦ ἀπόστολος δὲ Ἰησοῦ Χριστοῦ κατὰ πίστιν ἐκλεκτῶν Θεοῦ καὶ ἐπίγνωσιν ἀληθείας τῆς κατ’ εὐσέβειαν",
+  "verseString": "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness, extra",
+  "verseObjects": [
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Paul",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "a",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "servant",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "type": "text",
+      "text": "'"
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "type": "text",
+      "text": ","
+    },
+    {
+      "tag": "w",
+      "type": "word",
+      "text": "extra",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ],
+  "alignment": [
+    {
+      "topWords": [
+        {
+          "word": "Παῦλος",
+          "strongs": "G39720",
+          "lemma": "Παῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δοῦλος",
+          "strongs": "G14010",
+          "lemma": "δοῦλος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀπόστολος",
+          "strongs": "G06520",
+          "lemma": "ἀπόστολος",
+          "morph": "Gr,N,,,,,NMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "δὲ",
+          "strongs": "G11610",
+          "lemma": "δέ",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Ἰησοῦ",
+          "strongs": "G24240",
+          "lemma": "Ἰησοῦς",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Χριστοῦ",
+          "strongs": "G55470",
+          "lemma": "χριστός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατὰ",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "πίστιν",
+          "strongs": "G41020",
+          "lemma": "πίστις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐκλεκτῶν",
+          "strongs": "G15880",
+          "lemma": "ἐκλεκτός",
+          "morph": "Gr,NS,,,,GMP,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "Θεοῦ",
+          "strongs": "G23160",
+          "lemma": "θεός",
+          "morph": "Gr,N,,,,,GMS,",
+          "occurrence": 2,
+          "occurrences": 2
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "καὶ",
+          "strongs": "G25320",
+          "lemma": "καί",
+          "morph": "Gr,CC,,,,,,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἐπίγνωσιν",
+          "strongs": "G19220",
+          "lemma": "ἐπίγνωσις",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "ἀληθείας",
+          "strongs": "G02250",
+          "lemma": "ἀλήθεια",
+          "morph": "Gr,N,,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "τῆς",
+          "strongs": "G35880",
+          "lemma": "ὁ",
+          "morph": "Gr,RR,,,,GFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "κατ’",
+          "strongs": "G25960",
+          "lemma": "κατά",
+          "morph": "Gr,P,,,,,A,,,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    },
+    {
+      "topWords": [
+        {
+          "word": "εὐσέβειαν",
+          "strongs": "G21500",
+          "lemma": "εὐσέβεια",
+          "morph": "Gr,N,,,,,AFS,",
+          "occurrence": 1,
+          "occurrences": 1
+        }
+      ],
+      "bottomWords": [
+      ]
+    }
+  ],
+  "wordBank": [
+    {
+      "word": "Paul",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "a",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "servant",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 1,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "and",
+      "occurrence": 1,
+      "occurrences": 2
+    },
+    {
+      "word": "an",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "apostle",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 2,
+      "occurrences": 4
+    },
+    {
+      "word": "Jesus",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "Christ",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "for",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "the",
+      "occurrence": 1,
+      "occurrences": 3
+    },
+    {
+      "word": "faith",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 3,
+      "occurrences": 4
+    },
+    {
+      "word": "God",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "s",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "chosen",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "people",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "and",
+      "occurrence": 2,
+      "occurrences": 2
+    },
+    {
+      "word": "the",
+      "occurrence": 2,
+      "occurrences": 3
+    },
+    {
+      "word": "knowledge",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "of",
+      "occurrence": 4,
+      "occurrences": 4
+    },
+    {
+      "word": "the",
+      "occurrence": 3,
+      "occurrences": 3
+    },
+    {
+      "word": "truth",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "that",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "agrees",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "with",
+      "occurrence": 1,
+      "occurrences": 1
+    },
+    {
+      "word": "godliness",
+      "occurrence": 1,
+      "occurrences": 1
+    }
+  ]
+}

--- a/src/js/helpers/AlignmentHelpers.js
+++ b/src/js/helpers/AlignmentHelpers.js
@@ -7,9 +7,10 @@ import * as ArrayHelpers from './ArrayHelpers';
  * @param {Array} alignments - array of aligned word objects {bottomWords, topWords}
  * @param {Array} wordBank - array of topWords
  * @param {String} verseString - The string to base the bottomWords sorting
+ * @param {Boolean} useVerseText - if true, then return parsed verse text if unaligned verse has changed, otherwise return null
  * @returns {Array} - sorted array of verseObjects to be used for verseText of targetLanguage
  */
-export const merge = (alignments, wordBank, verseString) => {
+export const merge = (alignments, wordBank, verseString, useVerseText=false) => {
   let verseObjects; // array to return
   // get the definitive list of verseObjects from the verse, unaligned but in order
   const unalignedOrdered = VerseObjectHelpers.getOrderedVerseObjectsFromString(verseString);
@@ -25,7 +26,7 @@ export const merge = (alignments, wordBank, verseString) => {
         type: 'InvalidatedAlignments'
       };
     } else { // if verse had no alignments
-      return verseObjects; // use parsed verse text
+      return useVerseText ? verseObjects : null; // use parsed verse text
     }
   }
   // each wordBank object should result in one verseObject
@@ -39,7 +40,7 @@ export const merge = (alignments, wordBank, verseString) => {
       if (hasAlignments(alignments)) { // if verse has some alignments
         throw {message: `Word "${bottomWord.word}" is in wordBank, but missing from target language verse.`, type: 'InvalidatedAlignments'};
       } else { // if verse had no alignments
-        return verseObjects; // use parsed verse text
+        return useVerseText ? verseObjects : null; // use parsed verse text
       }
     }
   }

--- a/src/js/helpers/AlignmentHelpers.js
+++ b/src/js/helpers/AlignmentHelpers.js
@@ -16,20 +16,33 @@ export const merge = (alignments, wordBank, verseString) => {
   // assign verseObjects with unaligned objects to be replaced with aligned ones
   verseObjects = JSON.parse(JSON.stringify(unalignedOrdered));
   //check each word in the verse string is also in the word bank or alignments
-  const vereseObjectsNotInAlignmentData = verseStringWordsContainedInAlignments(alignments, wordBank, verseObjects);
-  if (vereseObjectsNotInAlignmentData.length > 0) {
-    const verseWordsJoined = vereseObjectsNotInAlignmentData.map(({ text }) => text).join(', ');
-    throw { message: `The words "${verseWordsJoined}" from the target language verse are not in the alignment data.`, type: 'InvalidatedAlignments' };
+  const verseObjectsNotInAlignmentData = verseStringWordsContainedInAlignments(alignments, wordBank, verseObjects);
+  if (verseObjectsNotInAlignmentData.length > 0) {
+    if (hasAlignments(alignments)) { // if verse has some alignments
+      const verseWordsJoined = verseObjectsNotInAlignmentData.map(({text}) => text).join(', ');
+      throw {
+        message: `The words "${verseWordsJoined}" from the target language verse are not in the alignment data.`,
+        type: 'InvalidatedAlignments'
+      };
+    } else { // if verse had no alignments
+      return verseObjects; // use parsed verse text
+    }
   }
   // each wordBank object should result in one verseObject
-  wordBank.forEach(bottomWord => {
+  for (let bottomWord of wordBank) {
     const verseObject = VerseObjectHelpers.wordVerseObjectFromBottomWord(bottomWord);
     const index = VerseObjectHelpers.indexOfVerseObject(unalignedOrdered, verseObject);
-    if (index > -1) verseObjects[index] = verseObject;
-    else {
-      throw { message: `Word: ${bottomWord.word} missing from word bank.`, type: 'InvalidatedAlignments' };
+    if (index > -1) {
+      verseObjects[index] = verseObject;
     }
-  });
+    else {
+      if (hasAlignments(alignments)) { // if verse has some alignments
+        throw {message: `Word "${bottomWord.word}" is in wordBank, but missing from target language verse.`, type: 'InvalidatedAlignments'};
+      } else { // if verse had no alignments
+        return verseObjects; // use parsed verse text
+      }
+    }
+  }
   let indicesToDelete = [];
   // each alignment should result in one verseObject
   alignments.forEach(alignment => {
@@ -71,6 +84,18 @@ export const merge = (alignments, wordBank, verseString) => {
   // deleteIndices that were queued due to consecutive bottomWords in alignments
   verseObjects = ArrayHelpers.deleteIndices(verseObjects, indicesToDelete);
   return verseObjects;
+};
+
+/**
+ * check if there were any alignments
+ * @param {Array} alignments
+ * @return {boolean} true if an alignment was found
+ */
+export const hasAlignments = (alignments) => {
+  const indexFirstAlignment = alignments.findIndex((alignment) => {
+    return alignment.bottomWords.length > 0;
+  });
+  return indexFirstAlignment >= 0;
 };
 
 /**

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -114,7 +114,7 @@ export const sortWordObjectsByString = (wordObjectArray, stringData) => {
 
 /**
  * Helper method to retrieve the greek chapter object according to specified book/chapter
- * 
+ *
  * @param {string} bookId  - Abbreviation of book name
  * @param {number} chapter  - Current chapter from the contextId
  * @returns {{ verseNumber: {verseObjects: Array} }} - Verses in the chapter object
@@ -267,7 +267,7 @@ export const convertAlignmentDataToUSFM = (wordAlignmentDataPath, projectTargetL
         let verseObjects;
         try {
           verseObjects = AlignmentHelpers.merge(
-            verseAlignments.alignments, verseAlignments.wordBank, verseString
+            verseAlignments.alignments, verseAlignments.wordBank, verseString, true
           );
         } catch (e) {
           if (e && e.type && e.type === 'InvalidatedAlignments') {
@@ -379,7 +379,7 @@ export const getCurrentGreekVerseFromAlignments = ({ alignments }) => {
 /**
  * Helper method to parse alignments for target languge words and combine them in order
  *
- * @param {array} alignemnts - array of top words/bottom words
+ * @param {array} alignments - array of top words/bottom words
  * @param {array} wordBank - array of unused topWords for aligning
  * @param {string} verseString - verse from target language, used for aligning greek words
  * in alingment data and extracting words
@@ -395,9 +395,12 @@ export const getCurrentTargetLanguageVerseFromAlignments = ({ alignments, wordBa
       return null;
     }
   }
-  const verseObjects = getWordsFromVerseObjects(verseObjectWithAlignments);
-  const verseObjectsCleaned = verseObjectHelpers.getWordList(verseObjects);
-  return combineVerseArray(verseObjectsCleaned);
+  if (verseObjectWithAlignments) {
+    const verseObjects = getWordsFromVerseObjects(verseObjectWithAlignments);
+    const verseObjectsCleaned = verseObjectHelpers.getWordList(verseObjects);
+    return combineVerseArray(verseObjectsCleaned);
+  }
+  return null;
 };
 
 /**
@@ -518,7 +521,7 @@ export const getEmptyAlignmentData = (alignmentData, ugnt, targetBible, chapter)
   return _alignmentData;
 };
 /**
- * Helper function to get the alignment data from a specified location and return the 
+ * Helper function to get the alignment data from a specified location and return the
  * reset version of it. (Does not change project data)
  * @param {string} projectSaveLocation - Path of the project that is not reset
  * @param {number} chapter - Number of the current chapter
@@ -547,11 +550,11 @@ export function resetAlignmentsForVerse(projectSaveLocation, chapter, verse) {
 
 /**
  * Helper method to check if a word alignment project has alignments
- * 
+ *
  * @param {string} wordAlignmentDataPath - Path to the alignemnt data i.e.
  * projectSaveLocation/.apps/translationCore/alignmentData/project.id
  * @param {Array} chapters - Array of the chapter file paths for easy iterating over
- * @returns {boolean} 
+ * @returns {boolean}
  */
 export function checkProjectForAlignments(wordAlignmentDataPath, chapters) {
   let hasAlignments = false;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- No longer warn about alignment changes if verse was edited, but had no alignments.

#### Please include detailed Test instructions for your pull request:
- start with a new titus project. 
- in wa, partially aligned Titus 1:1 of the project, 
- make sure verse Titus 1:4 has no alignments
- then export as USFM3.
- go into tw, in scripture pane edit verse 4 of the project to add, remove, or change a word(s).
- then export to USFM3 again, should not get warning about alignment changes.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4351)
<!-- Reviewable:end -->
