### PR TITLE
Upgraded Projects Export USFM3 Fix

### DIFF
--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -13,6 +13,9 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
 const RESOURCE_PATH = path.join(ospath.home(), 'Development', 'Electron', 'translationCore', 'tC_resources', 'resources');
+jest.mock('../src/js/actions/Import/ProjectMigrationActions', () => ({
+  migrate: ()=>{}
+}));
 jest.mock('../src/js/helpers/exportHelpers', () => ({
   ...require.requireActual('../src/js/helpers/exportHelpers'),
   getFilePath: (projectName, lastSaveLocation, ext) => `/${projectName}.${ext}`


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes an issue with projects used from 0.8 not being able to be exported without first being opened.

#### Please include detailed Test instructions for your pull request:
- Follow the steps on #4361 and you should not be able to reproduce the bug.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4369)
<!-- Reviewable:end -->
