### PR TITLE
Fix Missing Verses Check Opening Twice

### DIFF
--- a/__tests__/OnlineImportWorkflowActions.test.js
+++ b/__tests__/OnlineImportWorkflowActions.test.js
@@ -17,8 +17,8 @@ jest.mock('../src/js/actions/Import/ProjectImportFilesystemActions', () => ({
 jest.mock('../src/js/actions/MyProjects/MyProjectsActions', () => ({ getMyProjects: () => ({ type: 'GET_MY_PROJECTS' }) }));
 jest.mock('../src/js/actions/MyProjects/ProjectLoadingActions', () => ({
   clearLastProject: () => ({ type: 'CLEAR_LAST_PROJECT' }),
-  migrateValidateLoadProject: jest.fn(() => ({ type: 'MIGRATE_VALIDATE_LOAD' }))
-    .mockImplementationOnce(() => ({ type: 'MIGRATE_VALIDATE_LOAD' }))
+  displayTools: jest.fn(() => ({ type: 'DISPLAY_TOOLS' }))
+    .mockImplementationOnce(() => ({ type: 'DISPLAY_TOOLS' }))
     .mockImplementationOnce(() => () => Promise.reject('Some error'))
 }));
 jest.mock('../src/js/helpers/TargetLanguageHelpers', ()=> ({
@@ -64,8 +64,10 @@ describe('OnlineImportWorkflowActions.onlineImport', () => {
         selectedProjectFilename: 'es-419_tit_text_ulb'
       },
       { type: 'VALIDATE' },
+      { type: 'VALIDATE' },
       { type: 'MOVE' },
-      { type: 'GET_MY_PROJECTS' }
+      { type: 'GET_MY_PROJECTS' },
+      {type: 'DISPLAY_TOOLS'}
     ];
     const store = mockStore(initialState);
     return store.dispatch(OnlineImportWorkflowActions.onlineImport()).then(() => {
@@ -78,7 +80,7 @@ describe('OnlineImportWorkflowActions.onlineImport', () => {
       { "importLink": "", "type": "IMPORT_LINK" },
       { "alertMessage": "projects.importing_project_alert", "loading": true, "type": "OPEN_ALERT_DIALOG" },
       { "selectedProjectFilename": "es-419_tit_text_ulb", "type": "UPDATE_SELECTED_PROJECT_FILENAME" },
-      { "type": "VALIDATE" }, { "type": "MOVE" }, { "type": "GET_MY_PROJECTS" },
+      { "type": "VALIDATE" }, { type: 'VALIDATE' }, { "type": "MOVE" }, { "type": "GET_MY_PROJECTS" },
       { "type": "CLEAR_LAST_PROJECT" },
       { "alertMessage": "Some error", "loading": undefined, "type": "OPEN_ALERT_DIALOG" },
       { "showProjectValidationStepper": false, "type": "TOGGLE_PROJECT_VALIDATION_STEPPER" },

--- a/__tests__/OnlineImportWorkflowActions.test.js
+++ b/__tests__/OnlineImportWorkflowActions.test.js
@@ -65,8 +65,7 @@ describe('OnlineImportWorkflowActions.onlineImport', () => {
       },
       { type: 'VALIDATE' },
       { type: 'MOVE' },
-      { type: 'GET_MY_PROJECTS' },
-      { type: 'MIGRATE_VALIDATE_LOAD' }
+      { type: 'GET_MY_PROJECTS' }
     ];
     const store = mockStore(initialState);
     return store.dispatch(OnlineImportWorkflowActions.onlineImport()).then(() => {

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import path from 'path-extra';
 import ospath from 'ospath';
-import { ipcRenderer } from 'electron';
+import {ipcRenderer} from 'electron';
 import consts from '../ActionTypes';
 // actions
 import * as BodyUIActions from '../BodyUIActions';
@@ -15,12 +15,12 @@ import * as ProjectLoadingActions from '../MyProjects/ProjectLoadingActions';
 import * as TargetLanguageHelpers from '../../helpers/TargetLanguageHelpers';
 // helpers
 import * as FileConversionHelpers from '../../helpers/FileConversionHelpers';
-import { getTranslate, getProjectManifest, getProjectSaveLocation, getProjectName } from '../../selectors';
+import {getTranslate, getProjectManifest, getProjectSaveLocation} from '../../selectors';
 // constants
 export const ALERT_MESSAGE = (
   <div>
     No file was selected. Please click on the
-    <span style={{ color: 'var(--accent-color-dark)', fontWeight: "bold" }}>
+    <span style={{color: 'var(--accent-color-dark)', fontWeight: "bold"}}>
       &nbsp;Import Local Project&nbsp;
     </span>
     button again and select the project you want to load.
@@ -41,20 +41,20 @@ export const localImport = () => {
     } = getState().localImportReducer;
     const importProjectPath = path.join(IMPORTS_PATH, selectedProjectFilename);
     try {
-       // convert file to tC acceptable project format
+      // convert file to tC acceptable project format
       await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);
       ProjectMigrationActions.migrate(importProjectPath);
-      await dispatch(ProjectValidationActions.validate(importProjectPath, true));
+      await dispatch(ProjectValidationActions.validate(importProjectPath));
       const manifest = getProjectManifest(getState());
       const updatedImportPath = getProjectSaveLocation(getState());
-      if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest))
+      if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest)) {
         TargetLanguageHelpers.generateTargetBibleFromTstudioProjectPath(updatedImportPath, manifest);
+        await delay(400);
+        await dispatch(ProjectValidationActions.validate(updatedImportPath));
+      }
       await dispatch(ProjectImportFilesystemActions.move());
       dispatch(MyProjectsActions.getMyProjects());
-      const currentProjectName = getProjectName(getState());
-      setTimeout(()=>{
-        dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
-      }, 500);
+      await dispatch(ProjectLoadingActions.displayTools());
     } catch (error) {
       const errorMessage = error || translate('projects.import_error', {fromPath: sourceProjectPath, toPath: importProjectPath}); // default warning if exception is not set
       // Catch all errors in nested functions above
@@ -78,38 +78,42 @@ export const localImport = () => {
  */
 export function selectLocalProject(startLocalImport = localImport) {
   return (dispatch, getState) => {
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
       const translate = getTranslate(getState());
       dispatch(BodyUIActions.dimScreen(true));
       dispatch(BodyUIActions.toggleProjectsFAB());
       // TODO: the filter name and dialog text should not be set here.
       // we should instead send generic data and load the text in the react component with localization
       // or at least we could insert the locale keys here.
-      setTimeout(() => {
-        const options = {
-          properties: ['openFile'],
-          filters: [
-            { name: translate('supported_file_types'), extensions: ['usfm', 'sfm', 'txt', 'tstudio', 'tcore'] }
-          ]
-        };
-        let filePaths = ipcRenderer.sendSync('load-local', { options: options });
-        dispatch(BodyUIActions.dimScreen(false));
-        // if import was cancel then show alert indicating that it was cancel
-        if (filePaths && filePaths[0]) {
-          dispatch(AlertModalActions.openAlertDialog(translate('projects.importing_local_alert'), true));
-          const sourceProjectPath = filePaths[0];
-          const selectedProjectFilename = path.parse(sourceProjectPath).base.split('.')[0] || '';
-          setTimeout(async () => {
-            dispatch({ type: consts.UPDATE_SOURCE_PROJECT_PATH, sourceProjectPath });
-            dispatch({ type: consts.UPDATE_SELECTED_PROJECT_FILENAME, selectedProjectFilename });
-            await dispatch(startLocalImport());
-            resolve();
-          }, 100);
-        } else {
-          dispatch(AlertModalActions.closeAlertDialog());
-          resolve();
-        }
-      }, 500);
+      await delay(500);
+      const options = {
+        properties: ['openFile'],
+        filters: [
+          {name: translate('supported_file_types'), extensions: ['usfm', 'sfm', 'txt', 'tstudio', 'tcore']}
+        ]
+      };
+      let filePaths = ipcRenderer.sendSync('load-local', {options: options});
+      dispatch(BodyUIActions.dimScreen(false));
+      // if import was cancel then show alert indicating that it was cancel
+      if (filePaths && filePaths[0]) {
+        dispatch(AlertModalActions.openAlertDialog(translate('projects.importing_local_alert'), true));
+        const sourceProjectPath = filePaths[0];
+        const selectedProjectFilename = path.parse(sourceProjectPath).base.split('.')[0] || '';
+        await delay(100);
+        dispatch({type: consts.UPDATE_SOURCE_PROJECT_PATH, sourceProjectPath});
+        dispatch({type: consts.UPDATE_SELECTED_PROJECT_FILENAME, selectedProjectFilename});
+        await dispatch(startLocalImport());
+        resolve();
+      } else {
+        dispatch(AlertModalActions.closeAlertDialog());
+        resolve();
+      }
     });
   };
+}
+
+function delay(ms) {
+  return new Promise((resolve) =>
+    setTimeout(resolve, ms)
+  );
 }

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -44,7 +44,7 @@ export const localImport = () => {
        // convert file to tC acceptable project format
       await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);
       ProjectMigrationActions.migrate(importProjectPath);
-      await dispatch(ProjectValidationActions.validate(importProjectPath));
+      await dispatch(ProjectValidationActions.validate(importProjectPath, true));
       const manifest = getProjectManifest(getState());
       const updatedImportPath = getProjectSaveLocation(getState());
       if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest))
@@ -52,7 +52,9 @@ export const localImport = () => {
       await dispatch(ProjectImportFilesystemActions.move());
       dispatch(MyProjectsActions.getMyProjects());
       const currentProjectName = getProjectName(getState());
-      dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
+      setTimeout(()=>{
+        dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
+      }, 500);
     } catch (error) {
       const errorMessage = error || translate('projects.import_error', {fromPath: sourceProjectPath, toPath: importProjectPath}); // default warning if exception is not set
       // Catch all errors in nested functions above

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -40,7 +40,7 @@ export const onlineImport = () => {
           ProjectMigrationActions.migrate(importProjectPath, link);
           // assign CC BY-SA license to projects imported from door43
           await CopyrightCheckHelpers.assignLicenseToOnlineImportedProject(importProjectPath);
-          await dispatch(ProjectValidationActions.validate(importProjectPath));
+          await dispatch(ProjectValidationActions.validate(importProjectPath, true));
           const manifest = getProjectManifest(getState());
           const updatedImportPath = getProjectSaveLocation(getState());
           if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest))
@@ -48,7 +48,9 @@ export const onlineImport = () => {
           await dispatch(ProjectImportFilesystemActions.move());
           dispatch(MyProjectsActions.getMyProjects());
           const currentProjectName = getProjectName(getState());
-          dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
+          setTimeout(()=>{
+            dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
+          }, 500);
           resolve();
         } catch (error) {
           // Catch all errors in nested functions above

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -14,7 +14,7 @@ import * as ProjectLoadingActions from '../MyProjects/ProjectLoadingActions';
 import * as TargetLanguageHelpers from '../../helpers/TargetLanguageHelpers';
 import * as OnlineImportWorkflowHelpers from '../../helpers/Import/OnlineImportWorkflowHelpers';
 import * as CopyrightCheckHelpers from '../../helpers/CopyrightCheckHelpers';
-import { getTranslate, getProjectManifest, getProjectSaveLocation, getProjectName } from '../../selectors';
+import { getTranslate, getProjectManifest, getProjectSaveLocation } from '../../selectors';
 import * as ProjectStructureValidationHelpers from "../../helpers/ProjectValidation/ProjectStructureValidationHelpers";
 //consts
 const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
@@ -40,17 +40,17 @@ export const onlineImport = () => {
           ProjectMigrationActions.migrate(importProjectPath, link);
           // assign CC BY-SA license to projects imported from door43
           await CopyrightCheckHelpers.assignLicenseToOnlineImportedProject(importProjectPath);
-          await dispatch(ProjectValidationActions.validate(importProjectPath, true));
+          await dispatch(ProjectValidationActions.validate(importProjectPath));
           const manifest = getProjectManifest(getState());
           const updatedImportPath = getProjectSaveLocation(getState());
-          if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest))
+          if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest)) {
             TargetLanguageHelpers.generateTargetBibleFromTstudioProjectPath(updatedImportPath, manifest);
+            await delay(200);
+            await dispatch(ProjectValidationActions.validate(updatedImportPath));
+          }
           await dispatch(ProjectImportFilesystemActions.move());
           dispatch(MyProjectsActions.getMyProjects());
-          const currentProjectName = getProjectName(getState());
-          setTimeout(()=>{
-            dispatch(ProjectLoadingActions.migrateValidateLoadProject(currentProjectName));
-          }, 500);
+          await dispatch(ProjectLoadingActions.displayTools());
           resolve();
         } catch (error) {
           // Catch all errors in nested functions above
@@ -99,4 +99,10 @@ export function getLink(importLink) {
     type: consts.IMPORT_LINK,
     importLink
   };
+}
+
+function delay(ms) {
+  return new Promise((resolve) =>
+    setTimeout(resolve, ms)
+  );
 }

--- a/src/js/actions/Import/ProjectValidationActions.js
+++ b/src/js/actions/Import/ProjectValidationActions.js
@@ -21,9 +21,8 @@ const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
  * @description Action that call helpers to handle business
  * logic for validations
  * @param {String} projectPath - Full path to the project root folder
- * @param {boolean} importing - Specifiy whether or not the project is being imported
  */
-export const validate = (projectPath, importing = false) => {
+export const validate = (projectPath) => {
   return ((dispatch, getState) => {
     return new Promise(async (resolve, reject) => {
       try {
@@ -33,7 +32,7 @@ export const validate = (projectPath, importing = false) => {
         await projectStructureValidatoinHelpers.detectInvalidProjectStructure(projectPath);
         await setUpProjectDetails(projectPath, dispatch);
         await projectStructureValidatoinHelpers.verifyValidBetaProject(getState());
-        await promptMissingDetails(dispatch, projectPath, importing);
+        await promptMissingDetails(dispatch, projectPath);
         resolve();
       } catch (error) {
         reject(error);
@@ -61,16 +60,15 @@ export const setUpProjectDetails = (projectPath, dispatch) => {
  * @description - Wrapper from asynchronously handling user input from the
  * project import stepper
  * @param {function} dispatch - Redux dispatcher
- * @param {boolean} importing - Specifiy whether or not the project is being imported
  * @returns {Promise}
  */
-export const promptMissingDetails = (dispatch, projectPath, importing) => {
+export const promptMissingDetails = (dispatch, projectPath) => {
   return new Promise(async (resolve, reject) => {
     try {
       // Running this action here because if the project is valid it
       // wont get call in the projectInformationStepperActions.
       await dispatch(updateProjectFolderToNameSpecification(projectPath));
-      dispatch(ProjectImportStepperActions.validateProject(resolve, importing));
+      dispatch(ProjectImportStepperActions.validateProject(resolve));
     } catch (error) {
       reject(error);
     }

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -21,17 +21,14 @@ let importStepperDone = () => { };
  * Wrapper function for handling the initial checking of steps.
  * Calls all corresponding validation methods
  * @param {func} done - callback when validating is done
- * @param {boolean} importing - Specifiy whether or not the project is being imported
  */
-export function validateProject(done, importing) {
+export function validateProject(done) {
   return ((dispatch) => {
     importStepperDone = done;
     dispatch(CopyrightCheckActions.validate());
     dispatch(ProjectInformationCheckActions.validate());
     dispatch(MergeConflictActions.validate());
-    //Not showing missing verses on import
-    //Only on project load
-    if (!importing) dispatch(MissingVersesActions.validate());
+    dispatch(MissingVersesActions.validate());
 
     dispatch(initiateProjectValidationStepper());
   });

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -20,14 +20,18 @@ let importStepperDone = () => { };
 /**
  * Wrapper function for handling the initial checking of steps.
  * Calls all corresponding validation methods
+ * @param {func} done - callback when validating is done
+ * @param {boolean} importing - Specifiy whether or not the project is being imported
  */
-export function validateProject(done) {
+export function validateProject(done, importing) {
   return ((dispatch) => {
     importStepperDone = done;
     dispatch(CopyrightCheckActions.validate());
     dispatch(ProjectInformationCheckActions.validate());
     dispatch(MergeConflictActions.validate());
-    dispatch(MissingVersesActions.validate());
+    //Not showing missing verses on import
+    //Only on project load
+    if (!importing) dispatch(MissingVersesActions.validate());
 
     dispatch(initiateProjectValidationStepper());
   });

--- a/src/js/helpers/manifestHelpers.js
+++ b/src/js/helpers/manifestHelpers.js
@@ -42,14 +42,13 @@ const template = {
  * Retrieves tC manifest and returns it or if not available looks for tS manifest.
  * If neither are available tC has no way to load the project, unless its a usfm project.
  * @param {string} projectPath - path location in the filesystem for the project.
- * @param {string} projectLink - Link to the projects git repo if provided i.e. https://git.door43.org/royalsix/fwe_tit_text_reg.git
  */
-export function getProjectManifest(projectPath, projectLink) {
+export function getProjectManifest(projectPath) {
   let manifest = LoadHelpers.loadFile(projectPath, 'manifest.json');
   let tCManifest = LoadHelpers.loadFile(projectPath, 'tc-manifest.json');
   manifest = manifest || tCManifest;
   if (!manifest || !manifest.tcInitialized) {
-    manifest = setUpManifest(projectPath, projectLink, manifest);
+    manifest = setUpManifest(projectPath, manifest);
   }
   return manifest;
 }
@@ -57,11 +56,10 @@ export function getProjectManifest(projectPath, projectLink) {
 /**
  * @description Generates and saves a translationCore manifest file
  * @param {String} projectSaveLocation - absolute path where the translationCore manifest file will be saved.
- * @param {String} link
  * @param {object} oldManifest - The translationStudio manifest data loaded from a translation
  * studio project
  */
-export function setUpManifest(projectSaveLocation, link, oldManifest) {
+export function setUpManifest(projectSaveLocation, oldManifest) {
   let manifest;
   try {
     let manifestLocation = path.join(projectSaveLocation, 'manifest.json');


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- The missing verses check was opening twice due to a problem with the workflow

#### Please include detailed Test instructions for your pull request:
- Try the last bug mentioned in #4388 (Opening the project given)
- The behavior should now only show the missing verses check once
- Try opening many other projects and observe the behavior, everything should be normal
Note: This is a quick bug fix. A small refactored would need to be made in order to make the import flow more ideal for project behavior such as the one being used.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4396)
<!-- Reviewable:end -->
