### PR TITLE
Bugfix 4027/catch invalid langs

### DIFF
--- a/__tests__/ProjectInformationCheckHelpers.test.js
+++ b/__tests__/ProjectInformationCheckHelpers.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+// actions
+import * as ProjectInformationCheckHelpers from '../src/js/helpers/ProjectInformationCheckHelpers';
+
+describe('ProjectInformationCheckHelpers', () => {
+
+  test('checkLanguageDetails() with valid language settings should be valid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'fr',
+        name: 'francais',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(false);
+  });
+
+  test('checkLanguageDetails() with empty manifest should be invalid', () => {
+    // given
+    const manifest = { };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with language id & name swapped should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'francais',
+        name: 'fr',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with invalid language id should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'zk',
+        name: 'Zanaki',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with empty language id should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: '',
+        name: 'francais',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with missing language id should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        name: 'francais',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with empty language name should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'fr',
+        name: '',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with missing language name should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'fr',
+        direction: 'ltr'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with missing language direction should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'fr',
+        name: 'francais'
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+  test('checkLanguageDetails() with blank language direction should be invalid', () => {
+    // given
+    const manifest = {
+      target_language: {
+        id: 'fr',
+        name: 'francais',
+        direction: ''
+      }
+    };
+
+    // when
+    const invalid = ProjectInformationCheckHelpers.checkLanguageDetails(manifest);
+
+    // then
+    expect(invalid).toEqual(true);
+  });
+
+});

--- a/src/js/helpers/ProjectInformationCheckHelpers.js
+++ b/src/js/helpers/ProjectInformationCheckHelpers.js
@@ -18,15 +18,15 @@ export function checkBookReference(manifest) {
  * language direction, language id and language name.
  * It will return true if either is missing.
  * @param {object} manifest - project manifest file.
- * @return {bool} - It will return true if either is missing.
+ * @return {bool} - It will return true if language details are missing or invalid.
  */
 export function checkLanguageDetails(manifest) {
   return (
-    manifest.target_language &&
-    manifest.target_language.direction &&
-    manifest.target_language.id &&
-    LangHelpers.isLanguageCodeValid(manifest.target_language.id) &&
-    manifest.target_language.name ? false : true
+    !(manifest.target_language &&
+      manifest.target_language.direction &&
+      manifest.target_language.id &&
+      LangHelpers.isLanguageCodeValid(manifest.target_language.id) &&
+      manifest.target_language.name)
   );
 }
 

--- a/src/js/helpers/ProjectInformationCheckHelpers.js
+++ b/src/js/helpers/ProjectInformationCheckHelpers.js
@@ -25,6 +25,7 @@ export function checkLanguageDetails(manifest) {
     manifest.target_language &&
     manifest.target_language.direction &&
     manifest.target_language.id &&
+    LangHelpers.isLanguageCodeValid(manifest.target_language.id) &&
     manifest.target_language.name ? false : true
   );
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Adds validation that language code is a valid code.  This should catch cases where language code and name are reversed in manifest.

#### Please include detailed Test instructions for your pull request:
- run the app and import from door43: https://git.door43.org/tc01/am_1co_text_ulb
- should get Project details prompt showing language code and name being invalid.  Set language code to `am` and continue.  Project card should show project name as `am_1co_ulb` and have `(am)` as language code.
- Now try to import from Door43: https://git.door43.org/tc02/am_1co_ulb
- Should get prompt that reimporting existing projects is not supported.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4469)
<!-- Reviewable:end -->
