### PR TITLE
Fix - #4570 - Fixes manifest.json from being created in tC root dir

### DIFF
--- a/__tests__/saveMethods.test.js
+++ b/__tests__/saveMethods.test.js
@@ -1,0 +1,47 @@
+import fs from 'fs-extra';
+import path from 'path-extra';
+import * as saveMethods from '../src/js/localStorage/saveMethods';
+
+describe('Tests for saveMethods', () => {
+  it('should not save the manifest file since projectSaveLocation is empty', () => {
+    const state = {
+      projectDetailsReducer: {
+        manifest: {
+          id: 'id'
+        }
+      }
+    };
+    saveMethods.saveProjectManifest(state);
+    const manifestPath = 'manifest.json';
+    expect(fs.existsSync(manifestPath)).not.toBeTruthy();
+  });
+
+  it('should not save the manifest file since manifest is empty', () => {
+    const state = {
+      projectDetailsReducer: {
+        manifest: {},
+        projectSaveLocation: '/tmp/',
+      }
+    };
+    saveMethods.saveProjectManifest(state);
+    const manifestPath = path.join(state.projectDetailsReducer.projectSaveLocation, 'manifest.json');
+    expect(fs.existsSync(manifestPath)).not.toBeTruthy();
+  });
+
+  it('should save the manifest file', () => {
+    const state = {
+      projectDetailsReducer: {
+        manifest: {
+          id: 'id'
+        },
+        projectSaveLocation: '/tmp/'
+      }
+    };
+    saveMethods.saveProjectManifest(state);
+    const manifestPath = path.join(state.projectDetailsReducer.projectSaveLocation, 'manifest.json');
+    expect(fs.existsSync(manifestPath)).toBeTruthy();
+    const json = fs.readJsonSync(manifestPath);
+    expect(json).toEqual(state.projectDetailsReducer.manifest);
+    fs.unlinkSync(manifestPath);
+  });
+});

--- a/__tests__/saveMethods.test.js
+++ b/__tests__/saveMethods.test.js
@@ -20,7 +20,7 @@ describe('Tests for saveMethods', () => {
     const state = {
       projectDetailsReducer: {
         manifest: {},
-        projectSaveLocation: '/tmp/',
+        projectSaveLocation: '/tmp',
       }
     };
     saveMethods.saveProjectManifest(state);
@@ -34,7 +34,7 @@ describe('Tests for saveMethods', () => {
         manifest: {
           id: 'id'
         },
-        projectSaveLocation: '/tmp/'
+        projectSaveLocation: '/tmp'
       }
     };
     saveMethods.saveProjectManifest(state);

--- a/src/js/localStorage/index.js
+++ b/src/js/localStorage/index.js
@@ -49,7 +49,7 @@ export const saveState = (prevState, newState) => {
     saveSettings(newState);
     saveLocalUserdata(newState);
     // save manifest only if it is defined.
-    if (newState.projectSaveLocation && newState.projectDetailsReducer.manifest && Object.keys(newState.projectDetailsReducer.manifest).length > 0) {
+    if (newState.projectDetailsReducer.projectSaveLocation && newState.projectDetailsReducer.manifest && Object.keys(newState.projectDetailsReducer.manifest).length > 0) {
       saveProjectManifest(newState);
     }
     // only save checkData and targetLanguage reducers if contextId hasn't changed

--- a/src/js/localStorage/index.js
+++ b/src/js/localStorage/index.js
@@ -49,7 +49,7 @@ export const saveState = (prevState, newState) => {
     saveSettings(newState);
     saveLocalUserdata(newState);
     // save manifest only if it is defined.
-    if (newState.projectDetailsReducer.manifest && Object.keys(newState.projectDetailsReducer.manifest).length > 0) {
+    if (newState.projectSaveLocation && newState.projectDetailsReducer.manifest && Object.keys(newState.projectDetailsReducer.manifest).length > 0) {
       saveProjectManifest(newState);
     }
     // only save checkData and targetLanguage reducers if contextId hasn't changed

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -257,10 +257,11 @@ export function saveLocalUserdata(state) {
  */
 export function saveProjectManifest(state) {
   const { manifest, projectSaveLocation } = state.projectDetailsReducer;
-  const fileName = 'manifest.json';
-  const savePath = path.join(projectSaveLocation, fileName);
-
-  fs.outputJsonSync(savePath, manifest);
+  if (projectSaveLocation && manifest) {
+    const fileName = 'manifest.json';
+    const savePath = path.join(projectSaveLocation, fileName);
+    fs.outputJsonSync(savePath, manifest);
+  }
 }
 
 /**

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -257,7 +257,8 @@ export function saveLocalUserdata(state) {
  */
 export function saveProjectManifest(state) {
   const { manifest, projectSaveLocation } = state.projectDetailsReducer;
-  if (projectSaveLocation && manifest) {
+  if (projectSaveLocation && manifest && Object.keys(manifest).length) {
+    console.log("HERE", state);
     const fileName = 'manifest.json';
     const savePath = path.join(projectSaveLocation, fileName);
     fs.outputJsonSync(savePath, manifest);

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -258,7 +258,6 @@ export function saveLocalUserdata(state) {
 export function saveProjectManifest(state) {
   const { manifest, projectSaveLocation } = state.projectDetailsReducer;
   if (projectSaveLocation && manifest && Object.keys(manifest).length) {
-    console.log("HERE", state);
     const fileName = 'manifest.json';
     const savePath = path.join(projectSaveLocation, fileName);
     fs.outputJsonSync(savePath, manifest);

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -257,7 +257,7 @@ export function saveLocalUserdata(state) {
  */
 export function saveProjectManifest(state) {
   const { manifest, projectSaveLocation } = state.projectDetailsReducer;
-  if (projectSaveLocation && manifest && Object.keys(manifest).length) {
+  if (projectSaveLocation && manifest && Object.keys(manifest).length > 0) {
     const fileName = 'manifest.json';
     const savePath = path.join(projectSaveLocation, fileName);
     fs.outputJsonSync(savePath, manifest);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Address #4570 - manifest.json appearing in the root directory when projectSaveLocation is empty and the subscribe function is called.

#### Please include detailed Test instructions for your pull request:
- You should no longer see a manifest.json in the root of your translationCore repo directory. This was due to always saving the manifest.json file even on start up for a project. The projectSaveLocation is empty, so it just uses the program dir.
- Make sure manifest.json is being created for a project at other times, when you actually are in a project.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4573)
<!-- Reviewable:end -->
