### PR TITLE
QA Fail 3559/Fix for finding duplicates on import

### DIFF
--- a/__tests__/ProjectInformationCheckHelpers.test.js
+++ b/__tests__/ProjectInformationCheckHelpers.test.js
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import path from "path-extra";
 import ospath from "ospath";
 const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
+const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
 
 describe('ProjectDetailsActions.getDuplicateProjectWarning()', () => {
   const currentProjectName = "fr_ult_eph_book";
@@ -45,7 +46,7 @@ describe('ProjectDetailsActions.getDuplicateProjectWarning()', () => {
     fs.__resetMockFS();
   });
 
-  test('does nothing if project name is valid', () => {
+  test('does nothing if current project is only match for settings', () => {
     // given
     const expectedResults = null;
     fs.outputJsonSync(currentProjectManifestPath, manifest);
@@ -57,13 +58,38 @@ describe('ProjectDetailsActions.getDuplicateProjectWarning()', () => {
     expect(results).toEqual(expectedResults);
   });
 
-  test('does nothing if project name is valid', () => {
+  test('does nothing if current project is in imports and nothing is in projects folder', () => {
+    // given
+    const expectedResults = null;
+    fs.__resetMockFS();
+
+    // when
+    const results = ProjectInformationCheckHelpers.getDuplicateProjectWarning(resourceId, langID, bookId, currentProjectPath);
+
+    // then
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('returns error message if another project has same settings', () => {
     // given
     const expectedResults = 'project_validation.conflicting_project';
     fs.outputJsonSync(currentProjectManifestPath, manifest);
     const duplicateProject = "fr_ult_eph";
     const duplicateProjectPath = path.join(PROJECTS_PATH, duplicateProject);
     fs.copySync(currentProjectPath, duplicateProjectPath);
+
+    // when
+    const results = ProjectInformationCheckHelpers.getDuplicateProjectWarning(resourceId, langID, bookId, currentProjectPath);
+
+    // then
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('returns error message current project is in imports and another project has same settings', () => {
+    // given
+    const expectedResults = 'project_validation.conflicting_project';
+    fs.outputJsonSync(currentProjectManifestPath, manifest);
+    const currentProjectPath = path.join(IMPORTS_PATH, currentProjectName);
 
     // when
     const results = ProjectInformationCheckHelpers.getDuplicateProjectWarning(resourceId, langID, bookId, currentProjectPath);

--- a/src/js/helpers/ProjectInformationCheckHelpers.js
+++ b/src/js/helpers/ProjectInformationCheckHelpers.js
@@ -1,7 +1,10 @@
 import path from 'path-extra';
+import ospath from 'ospath';
 import * as LangHelpers from "./LanguageHelpers";
 import * as ProjectImportFilesystemHelpers from "./Import/ProjectImportFilesystemHelpers";
 import {getIsOverwritePermitted} from "../selectors";
+
+const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
 
 /**
  * Checks if the project manifest includes required project details.
@@ -56,15 +59,19 @@ export function getResourceIdWarning(resourceId) {
  * @return {String|null} - string if duplicate warning, else null
  */
 export function getDuplicateProjectWarning(resourceId, langID, bookId, projectSaveLocation) {
-  const projectsThatMatchImportType = ProjectImportFilesystemHelpers.getProjectsByType(langID, bookId, resourceId,
-                                          projectSaveLocation);
+  let projectsThatMatchImportType = ProjectImportFilesystemHelpers.getProjectsByType(langID, bookId, resourceId,
+                                      projectSaveLocation);
   if (projectsThatMatchImportType && projectsThatMatchImportType.length > 0) {
-    // ignore current project
     const currentProjectName = path.basename(projectSaveLocation);
-    const otherProjectsThatMatchImportType = projectsThatMatchImportType.filter((projectName) => {
-      return (currentProjectName !== projectName);
-    });
-    if (otherProjectsThatMatchImportType && otherProjectsThatMatchImportType.length > 0) {
+    const inProjectsFolder = (projectSaveLocation === path.join(PROJECTS_PATH, currentProjectName));
+    if (inProjectsFolder) { // if the selected project is in Projects folder, remove it from duplicates list
+      // ignore current project
+      const otherProjectsThatMatchImportType = projectsThatMatchImportType.filter((projectName) => {
+        return (currentProjectName !== projectName);
+      });
+      projectsThatMatchImportType = otherProjectsThatMatchImportType;
+    }
+    if (projectsThatMatchImportType && projectsThatMatchImportType.length > 0) {
       return 'project_validation.conflicting_project';
     }
   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for looking for duplicates if current project is in imports folder.  This fixes item #1 in the QA fail.

#### Please include detailed Test instructions for your pull request:
- This fixes QA fail item 1
- cannot reproduce QA fail item 2 on current build in windows.
- QA fail items 2 & 3 moved to new issues.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4748)
<!-- Reviewable:end -->
