### PR TITLE
feature 4550/Update Search dialog to handle the various project name formats and display correct book name

### DIFF
--- a/__tests__/ProjectDetailsHelpers.test.js
+++ b/__tests__/ProjectDetailsHelpers.test.js
@@ -656,7 +656,6 @@ describe('ProjectDetailsHelpers.handleDcsRenameCollision', () => {
 });
 
 describe('ProjectDetailsHelpers.doesDcsProjectNameAlreadyExist', () => {
-  const projectPath = path.join('path', 'to', 'project', 'PROJECT_NAME');
 
   beforeEach(() => {
     mock_repoExists = false;
@@ -685,6 +684,48 @@ describe('ProjectDetailsHelpers.doesDcsProjectNameAlreadyExist', () => {
     });
   });
 
+});
+
+describe('ProjectDetailsHelpers.getDetailsFromProjectName', () => {
+  test('null project name should not crash', () => {
+    const projectName = null;
+    const expectedResults = {"bookId": "", "bookName": "", "languageId": ""};
+
+    let results = ProjectDetailsHelpers.getDetailsFromProjectName(projectName);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('empty project name should not crash', () => {
+    const projectName = "";
+    const expectedResults = {"bookId": "", "bookName": "", "languageId": ""};
+
+    let results = ProjectDetailsHelpers.getDetailsFromProjectName(projectName);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('short name should succeed', () => {
+    const projectName = "en_tit";
+    const expectedResults = {"bookId": "tit", "bookName": "Titus", "languageId": "en"};
+
+    let results = ProjectDetailsHelpers.getDetailsFromProjectName(projectName);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('old tStudio format name should succeed', () => {
+    const projectName = "aaw_php_text_reg";
+    const expectedResults = {"bookId": "php", "bookName": "Philippians", "languageId": "aaw"};
+
+    let results = ProjectDetailsHelpers.getDetailsFromProjectName(projectName);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('new format name should succeed', () => {
+    const projectName = "el_ult_tit_book";
+    const expectedResults = {"bookId": "tit", "bookName": "Titus", "languageId": "el"};
+
+    let results = ProjectDetailsHelpers.getDetailsFromProjectName(projectName);
+    expect(results).toEqual(expectedResults);
+  });
 });
 
 //

--- a/src/js/components/home/projectsManagement/OnlineImportModal/SearchResults.js
+++ b/src/js/components/home/projectsManagement/OnlineImportModal/SearchResults.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Checkbox } from 'material-ui';
 import { Glyphicon } from 'react-bootstrap';
 import TranslateIcon from 'material-ui/svg-icons/action/translate';
-import BooksOfTheBible from '../../../../common/BooksOfTheBible';
 import {getBookTranslationShort} from "../../../../helpers/localizationHelpers";
+import {getDetailsFromProjectName} from "../../../../helpers/ProjectDetailsHelpers";
 
 const SearchResults = ({
   repos,
@@ -22,10 +22,8 @@ const SearchResults = ({
           </tr>
         :
           repos.map((project, index) => {
-            const bookAbbreviation = project.name.split("_")[1];
-            const bookName = BooksOfTheBible.newTestament[bookAbbreviation];
-            const BookNameLocalized = getBookTranslationShort(translate, bookName, bookAbbreviation) || '';
-            const languageId = project.name.split("_")[0];
+            const { bookId, bookName, languageId} = getDetailsFromProjectName(project.name);
+            const BookNameLocalized = getBookTranslationShort(translate, bookName, bookId) || '';
             let disabledCheckBox = false;
             if (project.html_url === importLink) {
               disabledCheckBox = false;
@@ -58,7 +56,7 @@ const SearchResults = ({
                 <td>
                   <Glyphicon glyph={"book"} style={{ color: "#000000" }} />
                   &nbsp;{BookNameLocalized}
-                  &nbsp;({bookAbbreviation})
+                  &nbsp;({bookId})
                 </td>
               </tr>
             );

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -10,6 +10,7 @@ import * as HomeScreenActions from "../actions/HomeScreenActions";
 import {getTranslate} from "../selectors";
 import * as MissingVersesHelpers from './ProjectValidation/MissingVersesHelpers';
 import * as GogsApiHelpers from "./GogsApiHelpers";
+import BooksOfTheBible from "../common/BooksOfTheBible";
 
 const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
 
@@ -274,6 +275,30 @@ export function doesDcsProjectNameAlreadyExist(newFilename, userdata) {
   });
 }
 
+/**
+ * separate book and language
+ * @param projectName
+ * @return {{bookId: string, languageId: *}}
+ */
+export function getDetailsFromProjectName(projectName) {
+  let bookId = "";
+  let bookName = "";
+  let languageId = "";
+  if (projectName) {
+    const parts = projectName.split("_");
+    languageId = parts[0];
+    // we can have a bunch of old formats (e.g. en_act, aaw_php_text_reg) and new format (en_ult_tit_book)
+    for (let i = 1; i < parts.length; i++) { // iteratively try the fields to see if valid book ids
+      const possibleBookId = parts[i].toLowerCase();
+      bookName = BooksOfTheBible.newTestament[possibleBookId];
+      if (bookName) {
+        bookId = possibleBookId; // if valid bookName use this book id
+        break;
+      }
+    }
+  }
+  return { bookId, languageId, bookName};
+}
 /**
  * generate new project name to match spec
  * @param manifest


### PR DESCRIPTION

#### Describe what your pull request addresses (Please include relevant issue numbers):
- Search fixes to handle all the project name formats and display correct bible id and translated name.  Fixes QA issue 1

#### Please include detailed Test instructions for your pull request:
- Fixes QA issue 1 - on search should now show correct bible if correct code is in project name (limited to NT books).

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4750)
<!-- Reviewable:end -->
