### PR TITLE
QA Fail 4751/Fix Import When Book ID changes

### DIFF
--- a/__tests__/ProjectDetailsHelpers.test.js
+++ b/__tests__/ProjectDetailsHelpers.test.js
@@ -728,6 +728,115 @@ describe('ProjectDetailsHelpers.getDetailsFromProjectName', () => {
   });
 });
 
+describe('ProjectDetailsHelpers.getInitialBibleDataFolderName', () => {
+  const bookId = "php";
+  const projectFilename = "en_php";
+  const initialState_ =
+  {
+    projectDetailsReducer: {
+      manifest: {
+        project: {
+          id: bookId
+        }
+      }
+    }
+  };
+
+  test('if manifest.project.id present, it should be returned', () => {
+    const expectedResults = bookId;
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState_, projectFilename);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('if manifest.project.id is not present, it should return projectFilename', () => {
+    const expectedResults = projectFilename;
+    const initialState = JSON.parse(JSON.stringify(initialState_));
+    delete initialState.projectDetailsReducer.manifest.project.id;
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('if manifest.project is not present, it should return projectFilename', () => {
+    const expectedResults = projectFilename;
+    const initialState = JSON.parse(JSON.stringify(initialState_));
+    delete initialState.projectDetailsReducer.manifest.project;
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('if manifest is not present, it should return projectFilename', () => {
+    const expectedResults = projectFilename;
+    const initialState = JSON.parse(JSON.stringify(initialState_));
+    delete initialState.projectDetailsReducer.manifest;
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    expect(results).toEqual(expectedResults);
+  });
+});
+
+describe('ProjectDetailsHelpers.fixBibleDataFolderName', () => {
+  const bookId = "php";
+  const projectFilename = "en_php";
+  const initialBibleDataFolderName = "php";
+  const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
+  const projectPath = path.join (IMPORTS_PATH, projectFilename);
+  const projectBibleDataPath = path.join (projectPath, initialBibleDataFolderName);
+  const manifest_ = {
+    project: {
+      id: bookId
+    }
+  };
+
+  beforeEach(() => {
+    fs.__resetMockFS();
+    fs.ensureDirSync(projectBibleDataPath);
+  });
+
+  test('if manifest.project.id unchanged, it should not move file', () => {
+    const expectedPath = projectBibleDataPath;
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest_, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+
+  test('if manifest.project.id changed, it should move file', () => {
+    const newProjectId = "gal";
+    const expectedPath = path.join (projectPath, newProjectId);
+    const manifest = JSON.parse(JSON.stringify(manifest_));
+    manifest.project.id = newProjectId;
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+
+  test('if manifest.project.id is missing, it should not move file', () => {
+    const expectedPath = projectBibleDataPath;
+    const manifest = JSON.parse(JSON.stringify(manifest_));
+    delete manifest.project.id;
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+
+  test('if manifest.project is missing, it should not move file', () => {
+    const expectedPath = projectBibleDataPath;
+    const manifest = JSON.parse(JSON.stringify(manifest_));
+    delete manifest.project;
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+
+  test('if manifest is empty, it should not move file', () => {
+    const expectedPath = projectBibleDataPath;
+    const manifest = {};
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+
+  test('if manifest is null, it should not move file', () => {
+    const expectedPath = projectBibleDataPath;
+    const manifest = null;
+    ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath);
+    expect(fs.existsSync(expectedPath)).toBeTruthy();
+  });
+});
+
 //
 // helpers
 //

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
 import {ipcRenderer} from 'electron';

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -51,18 +51,13 @@ export const localImport = () => {
     try {
       // convert file to tC acceptable project format
       const projectInfo = await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);
-      const initialManifest = getProjectManifest(getState());
-      const initialBibleDataFolderName = initialManifest.project.id || selectedProjectFilename;
+      const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(getState(), selectedProjectFilename);
       ProjectMigrationActions.migrate(importProjectPath);
       dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(true, projectInfo.usfmProject));
       await dispatch(ProjectValidationActions.validate(importProjectPath));
       const manifest = getProjectManifest(getState());
       const updatedImportPath = getProjectSaveLocation(getState());
-      if (manifest.project.id && (manifest.project.id !== initialBibleDataFolderName)) { // if project.id has changed
-        const initialBibleFolderPath = path.join(updatedImportPath, initialBibleDataFolderName);
-        const updatedBibleFolderPath = path.join(updatedImportPath, manifest.project.id);
-        fs.moveSync(initialBibleFolderPath, updatedBibleFolderPath);
-      }
+      ProjectDetailsHelpers.fixBibleDataFolderName(manifest, initialBibleDataFolderName, updatedImportPath);
       if (!TargetLanguageHelpers.targetBibleExists(updatedImportPath, manifest)) {
         dispatch(AlertModalActions.openAlertDialog(translate("projects.loading_ellipsis"), true));
         TargetLanguageHelpers.generateTargetBibleFromTstudioProjectPath(updatedImportPath, manifest);

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -1,5 +1,4 @@
 import consts from '../../actions/ActionTypes';
-import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
 // actions

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -475,18 +475,18 @@ export function updateProjectFolderName(newProjectName, projectSaveLocation, old
 /**
  * the folder name is normally the bookId, but if there is not a valid project.id in manifest we fall back to using
  *      the project name
- * @param {Object) state
- * @param {String} selectedProjectFilename
+ * @param {Object} state
+ * @param {String} projectFilename
  * @return {String} project folder name
  */
-export function getInitialBibleDataFolderName(state, selectedProjectFilename) {
+export function getInitialBibleDataFolderName(state, projectFilename) {
   const initialManifest = getProjectManifest(state);
-  return (initialManifest && initialManifest.project && initialManifest.project.id) || selectedProjectFilename;
+  return (initialManifest && initialManifest.project && initialManifest.project.id) || projectFilename;
 }
 
 /**
  * if the project.id has been changed in the manifest, we need to move the bible data to new folder
- * @param {Object) manifest
+ * @param {Object} manifest
  * @param {String} initialBibleDataFolderName
  * @param {String} projectPath
  */

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -7,7 +7,7 @@ import * as OnlineModeConfirmActions from "../actions/OnlineModeConfirmActions";
 import * as ProjectInformationCheckActions from "../actions/ProjectInformationCheckActions";
 import * as HomeScreenActions from "../actions/HomeScreenActions";
 // helpers
-import {getTranslate} from "../selectors";
+import {getProjectManifest, getTranslate} from "../selectors";
 import * as MissingVersesHelpers from './ProjectValidation/MissingVersesHelpers';
 import * as GogsApiHelpers from "./GogsApiHelpers";
 import BooksOfTheBible from "../common/BooksOfTheBible";
@@ -471,3 +471,30 @@ export function updateProjectFolderName(newProjectName, projectSaveLocation, old
   if (fs.existsSync(sourcePath) && !fs.existsSync(destinationPath))
     fs.moveSync(sourcePath, destinationPath);
 }
+
+/**
+ * the folder name is normally the bookId, but if there is not a valid project.id in manifest we fall back to using
+ *      the project name
+ * @param {Object) state
+ * @param {String} selectedProjectFilename
+ * @return {String} project folder name
+ */
+export function getInitialBibleDataFolderName(state, selectedProjectFilename) {
+  const initialManifest = getProjectManifest(state);
+  return (initialManifest && initialManifest.project && initialManifest.project.id) || selectedProjectFilename;
+}
+
+/**
+ * if the project.id has been changed in the manifest, we need to move the bible data to new folder
+ * @param {Object) manifest
+ * @param {String} initialBibleDataFolderName
+ * @param {String} projectPath
+ */
+export function fixBibleDataFolderName(manifest, initialBibleDataFolderName, projectPath) {
+  if (manifest && manifest.project && manifest.project.id && (manifest.project.id !== initialBibleDataFolderName)) { // if project.id has changed
+    const initialBibleFolderPath = path.join(projectPath, initialBibleDataFolderName);
+    const updatedBibleFolderPath = path.join(projectPath, manifest.project.id);
+    fs.moveSync(initialBibleFolderPath, updatedBibleFolderPath);
+  }
+}
+

--- a/src/js/helpers/ProjectMigration/migrateToAddTargetLanguageBookName.js
+++ b/src/js/helpers/ProjectMigration/migrateToAddTargetLanguageBookName.js
@@ -7,8 +7,8 @@ import * as usfmHelpers from '../usfmHelpers';
 /**
  * @description Look at several places inside project path for translated book name
  * then place it into the manifest if it is not already there.
- * 
- * @param {*} projectPath - Project where all related documentation resides 
+ *
+ * @param {*} projectPath - Project where all related documentation resides
  */
 const migrateToAddTargetLanguageBookName = (projectPath) => {
   return new Promise ((resolve, reject) => {
@@ -17,8 +17,8 @@ const migrateToAddTargetLanguageBookName = (projectPath) => {
       if(fs.existsSync(manifestPath)) {
         const manifest = fs.readJsonSync(manifestPath);
         let targetBookName = '';
-        if (!manifest.target_language.book || 
-            typeof manifest.target_language.book.name !== 'string' || 
+        if (!manifest.target_language.book ||
+            typeof manifest.target_language.book.name !== 'string' ||
             manifest.target_language.book.name.length === 0) {
           const titlePath = path.join(projectPath, 'front', 'title.txt');
           const titleAlternatePath = path.join(projectPath, '00', 'title.txt');
@@ -39,8 +39,8 @@ const migrateToAddTargetLanguageBookName = (projectPath) => {
 
           manifest.target_language['book'] = { name: targetBookName };
         }
-        resolve(manifest); // This is for unit test.
         fs.outputJsonSync(manifestPath, manifest);
+        resolve(manifest); // This is for unit test.
       } else {
         throw new Error("Manifest not found.");
       }
@@ -53,8 +53,8 @@ const migrateToAddTargetLanguageBookName = (projectPath) => {
 
 /**
  * @description look for a header inside the USFM text for the translated book name
- * 
- * @param {*} projectPath - root of places to look 
+ *
+ * @param {*} projectPath - root of places to look
  * @param {*} manifest - place to put translated book name when found
  */
 const getTargetLanguageNameFromUsfm = (projectPath, manifest) => {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix for when project id changes on import.  The problem was that when the bookId was not set correctly on USFM import that project.id was empty in manifest, so the project name was used for the bible data folder.  Now when the bookId is changed on import, the bible data folder will be renamed appropriately.

#### Please include detailed Test instructions for your pull request:
- should be able to import the project in QA fail.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4752)
<!-- Reviewable:end -->
