### PR TITLE
QA Fail - #3559 - targetBible missing when reimporting

### DIFF
--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -301,7 +301,7 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
               const oldProjectPath = path.join(PROJECTS_PATH, projectName);
               ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath);
               fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
-              fs.move(newProjectPath, oldProjectPath); // replace it with new project
+              fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
               dispatch(setSaveLocation(oldProjectPath));
               resolve(true);
             } else { // if cancel


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixes QA Fail for #3559, reimporting local USFM file and tW throws an error

#### Please include detailed Test instructions for your pull request:
- See  https://github.com/unfoldingWord-dev/translationCore/issues/3559#issuecomment-407884701 for the Win64 issue
- See https://github.com/unfoldingWord-dev/translationCore/issues/3559#issuecomment-407879268 for the Mac issue and steps to reproduce

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4776)
<!-- Reviewable:end -->
