### PR TITLE
QA fail 4751/USFM import fails with invalid id

### DIFF
--- a/__tests__/ProjectDetailsHelpers.test.js
+++ b/__tests__/ProjectDetailsHelpers.test.js
@@ -728,7 +728,7 @@ describe('ProjectDetailsHelpers.getDetailsFromProjectName', () => {
   });
 });
 
-describe('ProjectDetailsHelpers.getDefaultBibleDataFolderName', () => {
+describe('ProjectDetailsHelpers.getInitialBibleDataFolderName', () => {
   const bookId = "php";
   const projectFilename = "en_php";
   const initialBibleDataFolderName = "php";

--- a/__tests__/ProjectDetailsHelpers.test.js
+++ b/__tests__/ProjectDetailsHelpers.test.js
@@ -728,47 +728,52 @@ describe('ProjectDetailsHelpers.getDetailsFromProjectName', () => {
   });
 });
 
-describe('ProjectDetailsHelpers.getInitialBibleDataFolderName', () => {
+describe('ProjectDetailsHelpers.getDefaultBibleDataFolderName', () => {
   const bookId = "php";
   const projectFilename = "en_php";
-  const initialState_ =
-  {
-    projectDetailsReducer: {
-      manifest: {
-        project: {
-          id: bookId
-        }
-      }
+  const initialBibleDataFolderName = "php";
+  const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
+  const projectPath = path.join (IMPORTS_PATH, projectFilename);
+  const projectBibleDataPath = path.join (projectPath, initialBibleDataFolderName);
+  const manifest_ = {
+    project: {
+      id: bookId
     }
   };
 
-  test('if manifest.project.id present, it should be returned', () => {
+  beforeEach(() => {
+    fs.__resetMockFS();
+    fs.ensureDirSync(projectBibleDataPath);
+  });
+
+  test('if project.id present in manifest.json and folder present, it should be returned', () => {
     const expectedResults = bookId;
-    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState_, projectFilename);
+    fs.outputJsonSync(path.join(projectPath, 'manifest.json'), manifest_);
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(projectFilename, projectPath);
     expect(results).toEqual(expectedResults);
   });
 
-  test('if manifest.project.id is not present, it should return projectFilename', () => {
+  test('if project.id is not present in manifest.json, it should return projectFilename', () => {
     const expectedResults = projectFilename;
-    const initialState = JSON.parse(JSON.stringify(initialState_));
-    delete initialState.projectDetailsReducer.manifest.project.id;
-    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    const manifest = JSON.parse(JSON.stringify(manifest_));
+    delete manifest.project.id;
+    fs.outputJsonSync(path.join(projectPath, 'manifest.json'), manifest);
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(projectFilename, projectBibleDataPath);
     expect(results).toEqual(expectedResults);
   });
 
-  test('if manifest.project is not present, it should return projectFilename', () => {
+  test('if project is not present in manifest.json, it should return projectFilename', () => {
     const expectedResults = projectFilename;
-    const initialState = JSON.parse(JSON.stringify(initialState_));
-    delete initialState.projectDetailsReducer.manifest.project;
-    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    const manifest = JSON.parse(JSON.stringify(manifest_));
+    fs.outputJsonSync(path.join(projectPath, 'manifest.json'), manifest);
+    delete manifest.project;
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(projectFilename, projectBibleDataPath);
     expect(results).toEqual(expectedResults);
   });
 
-  test('if manifest is not present, it should return projectFilename', () => {
+  test('if manifest.json is not present, it should return projectFilename', () => {
     const expectedResults = projectFilename;
-    const initialState = JSON.parse(JSON.stringify(initialState_));
-    delete initialState.projectDetailsReducer.manifest;
-    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(initialState, projectFilename);
+    let results = ProjectDetailsHelpers.getInitialBibleDataFolderName(projectFilename, projectBibleDataPath);
     expect(results).toEqual(expectedResults);
   });
 });

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -50,9 +50,9 @@ export const localImport = () => {
     try {
       // convert file to tC acceptable project format
       const projectInfo = await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);
+      dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(true, projectInfo.usfmProject));
       const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(getState(), selectedProjectFilename);
       ProjectMigrationActions.migrate(importProjectPath);
-      dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(true, projectInfo.usfmProject));
       await dispatch(ProjectValidationActions.validate(importProjectPath));
       const manifest = getProjectManifest(getState());
       const updatedImportPath = getProjectSaveLocation(getState());

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -50,9 +50,9 @@ export const localImport = () => {
     try {
       // convert file to tC acceptable project format
       const projectInfo = await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);
-      dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(true, projectInfo.usfmProject));
-      const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(getState(), selectedProjectFilename);
+      const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(selectedProjectFilename, importProjectPath);
       ProjectMigrationActions.migrate(importProjectPath);
+      dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(true, projectInfo.usfmProject));
       await dispatch(ProjectValidationActions.validate(importProjectPath));
       const manifest = getProjectManifest(getState());
       const updatedImportPath = getProjectSaveLocation(getState());

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -43,6 +43,7 @@ export const onlineImport = () => {
           // or at least we could pass in the locale key here.
           dispatch(AlertModalActions.openAlertDialog(translate('projects.importing_project_alert', {project_url: link}), true));
           const selectedProjectFilename = await OnlineImportWorkflowHelpers.clone(link);
+          dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(false));
           dispatch({ type: consts.UPDATE_SELECTED_PROJECT_FILENAME, selectedProjectFilename });
           importProjectPath = path.join(IMPORTS_PATH, selectedProjectFilename);
           await ProjectStructureValidationHelpers.ensureSupportedVersion(importProjectPath, translate);
@@ -50,7 +51,6 @@ export const onlineImport = () => {
           ProjectMigrationActions.migrate(importProjectPath, link);
           // assign CC BY-SA license to projects imported from door43
           await CopyrightCheckHelpers.assignLicenseToOnlineImportedProject(importProjectPath);
-          dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(false));
           await dispatch(ProjectValidationActions.validate(importProjectPath));
           const manifest = getProjectManifest(getState());
           const updatedImportPath = getProjectSaveLocation(getState());

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -43,14 +43,14 @@ export const onlineImport = () => {
           // or at least we could pass in the locale key here.
           dispatch(AlertModalActions.openAlertDialog(translate('projects.importing_project_alert', {project_url: link}), true));
           const selectedProjectFilename = await OnlineImportWorkflowHelpers.clone(link);
-          dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(false));
           dispatch({ type: consts.UPDATE_SELECTED_PROJECT_FILENAME, selectedProjectFilename });
           importProjectPath = path.join(IMPORTS_PATH, selectedProjectFilename);
           await ProjectStructureValidationHelpers.ensureSupportedVersion(importProjectPath, translate);
-          const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(getState(), selectedProjectFilename);
+          const initialBibleDataFolderName = ProjectDetailsHelpers.getInitialBibleDataFolderName(selectedProjectFilename, importProjectPath);
           ProjectMigrationActions.migrate(importProjectPath, link);
           // assign CC BY-SA license to projects imported from door43
           await CopyrightCheckHelpers.assignLicenseToOnlineImportedProject(importProjectPath);
+          dispatch(ProjectValidationActions.initializeReducersForProjectImportValidation(false));
           await dispatch(ProjectValidationActions.validate(importProjectPath));
           const manifest = getProjectManifest(getState());
           const updatedImportPath = getProjectSaveLocation(getState());

--- a/src/js/actions/Import/ProjectValidationActions.js
+++ b/src/js/actions/Import/ProjectValidationActions.js
@@ -167,7 +167,6 @@ export const initializeReducersForProjectValidation = (localImport, alreadyImpor
   return (dispatch) => {
     dispatch({ type: consts.RESET_PROJECT_VALIDATION_REDUCER });
     dispatch({ type: consts.CLEAR_PROJECT_INFORMATION_REDUCER });
-    dispatch(ProjectDetailsActions.setProjectManifest({ project: {}, resource: {} })); // clear manifest from reducer
     dispatch(setValuesForProjectValidation(localImport, alreadyImported, usfmProject));
   };
 };

--- a/src/js/actions/Import/ProjectValidationActions.js
+++ b/src/js/actions/Import/ProjectValidationActions.js
@@ -167,6 +167,7 @@ export const initializeReducersForProjectValidation = (localImport, alreadyImpor
   return (dispatch) => {
     dispatch({ type: consts.RESET_PROJECT_VALIDATION_REDUCER });
     dispatch({ type: consts.CLEAR_PROJECT_INFORMATION_REDUCER });
+    dispatch(ProjectDetailsActions.setProjectManifest({ project: {}, resource: {} })); // clear manifest from reducer
     dispatch(setValuesForProjectValidation(localImport, alreadyImported, usfmProject));
   };
 };

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -477,14 +477,14 @@ export function updateProjectFolderName(newProjectName, projectSaveLocation, old
  * the folder name is normally the bookId, but if there is not a valid project.id in manifest we fall back to using
  *      the project name.  This function determines if we used the default
  * @param {String} projectFilename
- * @param {String} importPath
+ * @param {String} projectPath
  * @return {String} project folder name
  */
-export function getInitialBibleDataFolderName(projectFilename, importPath) {
-  const initialManifest = manifestHelpers.getProjectManifest(importPath);
-  const expectedProjectId = (initialManifest && initialManifest.project && initialManifest.project.id) || null;
+export function getInitialBibleDataFolderName(projectFilename, projectPath) {
+  const initialManifest = manifestHelpers.getProjectManifest(projectPath);
+  const expectedProjectId = (initialManifest && initialManifest.project && initialManifest.project.id);
   if (expectedProjectId) { // if we have a project id, verify that this is what was actually used for bible data
-    const expectedBibleDataPath = path.join(importPath, expectedProjectId);
+    const expectedBibleDataPath = path.join(projectPath, expectedProjectId);
     if (fs.existsSync(expectedBibleDataPath)) {
       if(fs.lstatSync(expectedBibleDataPath).isDirectory()) {
         return expectedProjectId;

--- a/src/js/helpers/ProjectDetailsHelpers.js
+++ b/src/js/helpers/ProjectDetailsHelpers.js
@@ -7,9 +7,10 @@ import * as OnlineModeConfirmActions from "../actions/OnlineModeConfirmActions";
 import * as ProjectInformationCheckActions from "../actions/ProjectInformationCheckActions";
 import * as HomeScreenActions from "../actions/HomeScreenActions";
 // helpers
-import {getProjectManifest, getTranslate} from "../selectors";
+import {getTranslate} from "../selectors";
 import * as MissingVersesHelpers from './ProjectValidation/MissingVersesHelpers';
 import * as GogsApiHelpers from "./GogsApiHelpers";
+import * as manifestHelpers from "./manifestHelpers";
 import BooksOfTheBible from "../common/BooksOfTheBible";
 
 const PROJECTS_PATH = path.join(ospath.home(), 'translationCore', 'projects');
@@ -474,14 +475,23 @@ export function updateProjectFolderName(newProjectName, projectSaveLocation, old
 
 /**
  * the folder name is normally the bookId, but if there is not a valid project.id in manifest we fall back to using
- *      the project name
- * @param {Object} state
+ *      the project name.  This function determines if we used the default
  * @param {String} projectFilename
+ * @param {String} importPath
  * @return {String} project folder name
  */
-export function getInitialBibleDataFolderName(state, projectFilename) {
-  const initialManifest = getProjectManifest(state);
-  return (initialManifest && initialManifest.project && initialManifest.project.id) || projectFilename;
+export function getInitialBibleDataFolderName(projectFilename, importPath) {
+  const initialManifest = manifestHelpers.getProjectManifest(importPath);
+  const expectedProjectId = (initialManifest && initialManifest.project && initialManifest.project.id) || null;
+  if (expectedProjectId) { // if we have a project id, verify that this is what was actually used for bible data
+    const expectedBibleDataPath = path.join(importPath, expectedProjectId);
+    if (fs.existsSync(expectedBibleDataPath)) {
+      if(fs.lstatSync(expectedBibleDataPath).isDirectory()) {
+        return expectedProjectId;
+      }
+    }
+  }
+  return projectFilename; // defaulted to project filename
 }
 
 /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- changed to get manifest data from manifest.json instead of reducer.
- verify that project.id was used for parsed data.
- This should fix issue that second USFM import would pick up project details from previous successful import.

#### Please include detailed Test instructions for your pull request:
- Repeated imports of [php_usfm_badId.txt.zip](https://github.com/unfoldingWord-dev/translationCore/files/2215675/php_usfm_badId.txt.zip) should now work.  This should also fix QA items 1,3,4 at bottom of issue.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4786)
<!-- Reviewable:end -->
