### PR TITLE
bugfix 4823/Fix Continue Button when opening/migrating Old Projects

### DIFF
--- a/__tests__/__snapshots__/ProjectLoadingActions.test.js.snap
+++ b/__tests__/__snapshots__/ProjectLoadingActions.test.js.snap
@@ -494,12 +494,12 @@ Array [
     "type": "ADD_PROJECT_VALIDATION_STEP",
   },
   Object {
-    "showProjectValidationStepper": false,
-    "type": "TOGGLE_PROJECT_VALIDATION_STEPPER",
-  },
-  Object {
     "type": "ONLY_SHOW_PROJECT_INFORMATION_SCREEN",
     "value": true,
+  },
+  Object {
+    "showProjectValidationStepper": false,
+    "type": "TOGGLE_PROJECT_VALIDATION_STEPPER",
   },
   Object {
     "nextDisabled": true,

--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -55,13 +55,21 @@ export function insertProjectInformationCheckToStepper() {
   });
 }
 
+/**
+ * if we are at the project information stepper, then set the initial state for the continue button.
+ *    The default initial state for the stepper is to be disabled, but for the project information stepper, we want
+ *    it to be reflect the validation state of the project details displayed unless we are only editing the project
+ *    details
+ * @return {Function}
+ */
 export function initializeProjectInformationCheckContinueButton() {
   return ((dispatch, getState) => {
-    const { projectInformationCheckReducer, projectValidationReducer} = getState();
-    const importing = projectInformationCheckReducer && !projectInformationCheckReducer.alreadyImported;
-    if (projectValidationReducer && projectValidationReducer.projectValidationStepsArray && importing) { // if we are doing import, need to initially enable save button if data is valid
-      if (projectValidationReducer.projectValidationStepsArray[0].namespace === PROJECT_INFORMATION_CHECK_NAMESPACE) {
-        dispatch(toggleProjectInformationCheckSaveButton());
+    const {projectValidationReducer} = getState();
+    const doingProjectInformationCheck = projectValidationReducer && projectValidationReducer.projectValidationStepsArray && projectValidationReducer.projectValidationStepsArray[0].namespace === PROJECT_INFORMATION_CHECK_NAMESPACE;
+    if (doingProjectInformationCheck) {
+      const editingProjectDetails = projectValidationReducer.onlyShowProjectInformationScreen;
+      if (!editingProjectDetails) {
+        dispatch(toggleProjectInformationCheckSaveButton()); // if not editing project details, then initialize continue button based on validation of project details, otherwise it defaults to disabled
       }
     }
   });
@@ -434,8 +442,8 @@ export function openOnlyProjectDetailsScreen(projectPath, initiallyEnableSaveIfV
     dispatch(ProjectValidationActions.initializeReducersForProjectOpenValidation());
     dispatch(setProjectDetailsInProjectInformationReducer(manifest));
     dispatch(ProjectImportStepperActions.addProjectValidationStep(PROJECT_INFORMATION_CHECK_NAMESPACE));
-    dispatch(ProjectImportStepperActions.updateStepperIndex());
     dispatch({ type: consts.ONLY_SHOW_PROJECT_INFORMATION_SCREEN, value: true });
+    dispatch(ProjectImportStepperActions.updateStepperIndex());
     if (initiallyEnableSaveIfValid) {
       dispatch(toggleProjectInformationCheckSaveButton());
     }

--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -56,10 +56,10 @@ export function insertProjectInformationCheckToStepper() {
 }
 
 /**
- * if we are at the project information stepper, then set the initial state for the continue button.
- *    The default initial state for the stepper is to be disabled, but for the project information stepper, we want
- *    it to be reflect the validation state of the project details displayed unless we are only editing the project
- *    details
+ * if we are at the project information page in stepper, then set the initial state for the continue button.
+ *    The default initial state for the stepper is for continue button to be disabled, but for the project information
+ *    page, we want the continue button to reflect the validation state of the project details displayed unless we are
+ *    only editing the project details
  * @return {Function}
  */
 export function initializeProjectInformationCheckContinueButton() {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix for bug that continue button on project details page started disabled on migration even though details were valid.

#### Please include detailed Test instructions for your pull request:
- test by opening projects in issue.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4826)
<!-- Reviewable:end -->
