### PR TITLE
Feature 4885/Improve performance of Project Import and selection

### DIFF
--- a/__tests__/UsfmFileConversionHelpers.test.js
+++ b/__tests__/UsfmFileConversionHelpers.test.js
@@ -127,9 +127,10 @@ describe('UsfmFileConversionHelpers', () => {
       }
     };
     const newUsfmProjectImportsPath = path.join(IMPORTS_PATH, 'project_folder_name', 'eph');
+    const parsedUsfm = UsfmHelpers.getParsedUSFM(validUsfmString);
 
     //when
-    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(parsedUsfm, mockManifest, 'project_folder_name');
 
     //then
     expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
@@ -163,9 +164,10 @@ describe('UsfmFileConversionHelpers', () => {
     const newUsfmProjectImportsPath = path.join(IMPORTS_PATH, 'project_folder_name', 'eph');
     const testDataPath = path.join('__tests__','fixtures','project','alignmentUsfmImport','59-HEB.usfm');
     const validUsfmString = fs.__actual.readFileSync(testDataPath).toString();
+    const parsedUsfm = UsfmHelpers.getParsedUSFM(validUsfmString);
 
     //when
-    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(parsedUsfm, mockManifest, 'project_folder_name');
 
     //then
     expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
@@ -199,9 +201,10 @@ describe('UsfmFileConversionHelpers', () => {
     const resourcePath = path.join(__dirname, 'fixtures/resources');
     const copyFiles = ['grc/bibles/ugnt'];
     fs.__loadFilesIntoMockFs(copyFiles, resourcePath, RESOURCE_PATH);
+    const parsedUsfm = UsfmHelpers.getParsedUSFM(validUsfmString);
 
     //when
-    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(parsedUsfm, mockManifest, 'project_folder_name');
 
     //then
     expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();
@@ -242,9 +245,10 @@ describe('UsfmFileConversionHelpers', () => {
     const resourcePath = path.join(__dirname, 'fixtures/resources');
     const copyFiles = ['grc/bibles/ugnt'];
     fs.__loadFilesIntoMockFs(copyFiles, resourcePath, RESOURCE_PATH);
+    const parsedUsfm = UsfmHelpers.getParsedUSFM(validUsfmString);
 
     //when
-    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(validUsfmString, mockManifest, 'project_folder_name');
+    await UsfmFileConversionHelpers.generateTargetLanguageBibleFromUsfm(parsedUsfm, mockManifest, 'project_folder_name');
 
     //then
     expect(fs.existsSync(newUsfmProjectImportsPath)).toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17971,9 +17971,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.30.tgz",
-      "integrity": "sha512-Mkons/AbOgBKk2YUZ9qhZVTdsstWqOBvGhODndfSXDklHXgvHbrDpOTI9d6hQQ0vCZUH9Ahh4wT2MJqQ0rvrpw==",
+      "version": "1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.31.tgz",
+      "integrity": "sha512-RG++5bt/l/qS6S2RdkgWS4rURm68fIhzitPXXsSofXx2WXG5eZ2u+Qenef5aeoJahjqSyvSzz8qTIZ7UuT4ZGg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "rimraf": "2.6.2",
@@ -18379,6 +18379,16 @@
           "requires": {
             "escape-string-regexp": "1.0.5",
             "replace-ext": "1.0.0"
+          }
+        },
+        "usfm-js": {
+          "version": "1.0.0-beta.30",
+          "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-1.0.0-beta.30.tgz",
+          "integrity": "sha512-Mkons/AbOgBKk2YUZ9qhZVTdsstWqOBvGhODndfSXDklHXgvHbrDpOTI9d6hQQ0vCZUH9Ahh4wT2MJqQ0rvrpw==",
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "rimraf": "2.6.2",
+            "transform-runtime": "0.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "tc-ui-toolkit": "0.9.18",
     "telnet-client": "0.15.5",
     "truncate-utf8-bytes": "1.0.2",
-    "usfm-js": "1.0.0-beta.30",
+    "usfm-js": "1.0.0-beta.31",
     "uuid": "3.2.1",
     "word-aligner": "0.1.1",
     "word-map": "0.1.9",

--- a/src/js/helpers/ProjectMigration/manifestUtils.js
+++ b/src/js/helpers/ProjectMigration/manifestUtils.js
@@ -129,7 +129,7 @@ export function fixManifestVerThree(oldManifest) {
 /**
  * @description Sets up a USFM project manifest according to tC standards.
  *
- * @param {object} parsedUSFM - The object containing usfm parsed by chapters
+ * @param {object} parsedUSFM - The object containing usfm parsed by header/chapters
  */
 export function setUpDefaultUSFMManifest(parsedUSFM) {
   let usfmDetails = usfmHelpers.getUSFMDetails(parsedUSFM);

--- a/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
+++ b/src/js/helpers/ProjectValidation/ProjectStructureValidationHelpers.js
@@ -132,19 +132,18 @@ export const getUniqueBookIds = (projectPath, limit = -1, bookIDs = []) => {
   let newIDs = [...bookIDs];
   for (let file of fs.readdirSync(projectPath)) {
     if (['.', '..', '.git'].indexOf(file) > -1) continue;
-    let filePath = path.join(projectPath, file);
+    const filePath = path.join(projectPath, file);
     if (fs.lstatSync(filePath).isDirectory()) {
       newIDs = getUniqueBookIds(filePath, limit, newIDs);
     } else {
-      let usfmPath = isUSFMProject(filePath);
+      const usfmPath = isUSFMProject(filePath);
       if (usfmPath) {
-        let usfmData = usfmHelpers.loadUSFMFile(usfmPath);
+        const usfmData = usfmHelpers.loadUSFMFile(usfmPath);
         if (!usfmData.includes('\\id') && !usfmData.includes('\\h')) {
           //This is not a usfm file, so we are not adding it to detected usfm files
           break;
         }
-        let parsedUSFM = usfmHelpers.getParsedUSFM(usfmData);
-        let id = usfmHelpers.getUSFMDetails(parsedUSFM).book.id;
+        const id = usfmHelpers.parseUsfmDetails(usfmData).book.id;
         if (newIDs.indexOf(id) === -1 && books[id]) {
           newIDs.push(id);
         }

--- a/src/js/helpers/manifestHelpers.js
+++ b/src/js/helpers/manifestHelpers.js
@@ -117,7 +117,7 @@ export function checkIfValidBetaProject(manifest) {
 
 /**
  * @description Sets up a USFM project manifest according to tC standards.
- * @param {object} parsedUSFM - The object containing usfm parsed by chapters
+ * @param {object} parsedUSFM - The object containing usfm parsed by header/chapters
  */
 export function generateManifestForUsfmProject(parsedUSFM) {
   let usfmDetails = usfmHelpers.getUSFMDetails(parsedUSFM);

--- a/src/js/helpers/myProjectsHelpers.js
+++ b/src/js/helpers/myProjectsHelpers.js
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
 import moment from 'moment';
-import usfmJS from 'usfm-js';
 // helpers
 import * as usfmHelpers from './usfmHelpers';
 import * as ProjectStructureValidationHelpers from './ProjectValidation/ProjectStructureValidationHelpers';
@@ -90,8 +89,7 @@ export function getProjectsFromFS(selectedProjectSaveLocation, loadProjectsLocat
         bookName = manifest.project.name;
       } else {
         const usfmText = fs.readFileSync(projectFolders[projectName].usfmPath).toString();
-        const usfmObject = usfmJS.toJSON(usfmText);
-        let usfmHeadersObject = usfmHelpers.getUSFMDetails(usfmObject);
+        let usfmHeadersObject = usfmHelpers.parseUsfmDetails(usfmText);
         bookName = usfmHeadersObject.book.name;
         target_language.id = usfmHeadersObject.language.id;
         target_language.name = usfmHeadersObject.language.name;

--- a/src/js/helpers/usfmHelpers.js
+++ b/src/js/helpers/usfmHelpers.js
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import usfm from 'usfm-js';
 // helpers
 import * as bibleHelpers from './bibleHelpers';
-import * as usfmHelpers from './usfmHelpers';
 
 /**
  * @description Sets up the folder in the tC save location for a USFM project
@@ -58,7 +57,7 @@ export function getHeaderTag(headers, tag) {
 export function getUsfmHeaderInfo(usfmData) {
   const pos = usfmData.indexOf('\\c ');
   const header = (pos >= 0) ? usfmData.substr(0, pos) : usfmData; // if chapter marker is found, process only that part
-  return usfmHelpers.getParsedUSFM(header);
+  return getParsedUSFM(header);
 }
 
 /**

--- a/src/js/helpers/usfmHelpers.js
+++ b/src/js/helpers/usfmHelpers.js
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import usfm from 'usfm-js';
 // helpers
 import * as bibleHelpers from './bibleHelpers';
+import * as usfmHelpers from './usfmHelpers';
 
 /**
  * @description Sets up the folder in the tC save location for a USFM project
@@ -20,12 +21,12 @@ export function loadUSFMFile(usfmFilePath) {
 
 /**
  * @description Parses the usfm file using usfm-parse library.
- * @param {string} usfmFile - Path in which the USFM project is being loaded from
+ * @param {string} usfmData - USFM data to parse
  */
-export function getParsedUSFM(usfmFile) {
+export function getParsedUSFM(usfmData) {
   try {
-    if (usfmFile)
-      return usfm.toJSON(usfmFile, {convertToInt: ["occurrence", "occurrences"]});
+    if (usfmData)
+      return usfm.toJSON(usfmData, {convertToInt: ["occurrence", "occurrences"]});
   } catch (e) {
     console.error(e);
   }
@@ -47,6 +48,27 @@ export function getHeaderTag(headers, tag) {
     }
   }
   return null;
+}
+
+/**
+ * parses only the header information of a valid usfm file.  Header information is the part before the first chapter marker.
+ * @param {String} usfmData - USFM data to parse
+ * @return {*}
+ */
+export function getUsfmHeaderInfo(usfmData) {
+  const pos = usfmData.indexOf('\\c ');
+  const header = (pos >= 0) ? usfmData.substr(0, pos) : usfmData; // if chapter marker is found, process only that part
+  return usfmHelpers.getParsedUSFM(header);
+}
+
+/**
+ * parse USFM header details from usfm data
+ * @param {String} usfmData - USFM data to parse
+ * @return {*}
+ */
+export function parseUsfmDetails(usfmData) {
+  const usfmObject = getUsfmHeaderInfo(usfmData);
+  return getUSFMDetails(usfmObject);
 }
 
 /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Updated to latest usfm-js with Joel's performance tweak
- modified app to just parse USFM header data to get project details.

#### Please include detailed Test instructions for your pull request:
-  Should see noticeable speed up to USFM3 import and project selection.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4896)
<!-- Reviewable:end -->
