### PR TITLE
bugfix 4793/Check for project already exists was not case insensitive.

### DIFF
--- a/__tests__/ProjectImportFilesystemHelpers.test.js
+++ b/__tests__/ProjectImportFilesystemHelpers.test.js
@@ -104,3 +104,171 @@ describe('ProjectImportFilesystemHelpers.projectExistsInProjectsFolder',()=> {
    expect(ProjectImportFilesystemHelpers.projectExistsInProjectsFolder(fromPath)).toEqual(false);
   });
 });
+
+describe('areStringsEqualCaseInsensitive()', () => {
+
+  test('expect "HI" == "HI"', () => {
+    // given
+    const expectedResult = true;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("HI", "HI");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "hI" == "Hi"', () => {
+    // given
+    const expectedResult = true;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("hI", "Hi");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "hi" == "hi"', () => {
+    // given
+    const expectedResult = true;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("hi", "hi");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "hi" == "HI"', () => {
+    // given
+    const expectedResult = true;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("hi", "HI");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "" != "HI"', () => {
+    // given
+    const expectedResult = false;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("", "HI");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect null != "HI"', () => {
+    // given
+    const expectedResult = false;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive(null, "HI");
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "hi" != undefined', () => {
+    // given
+    const expectedResult = false;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("hi", undefined);
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+
+  test('expect "hi" != 5', () => {
+    // given
+    const expectedResult = false;
+
+    // when
+    const results = ProjectImportFilesystemHelpers.areStringsEqualCaseInsensitive("hi", 5);
+
+    // then
+    expect(results).toEqual(expectedResult);
+  });
+});
+
+describe('ProjectDetailsActions.getProjectsByType()', () => {
+  const projectsPath = path.join(PROJECTS_PATH);
+
+  beforeEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+    // Set up mock filesystem before each test
+    fs.ensureDirSync(projectsPath);
+
+    createMockProject(projectsPath, "en_ult_eph_book", "en", "eph", "ult");
+  });
+
+  test('finds project', () => {
+    // given
+    const expectedResults = ["en_ult_eph_book"];
+    const langID = "en";
+    const bookID = "eph";
+    const resourceId = "ult";
+
+    // when
+    const results = ProjectImportFilesystemHelpers.getProjectsByType(langID, bookID, resourceId);
+
+    // then
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('finds project with upppercase', () => {
+    // given
+    const expectedResults = ["en_ult_eph_book"];
+    const langID = "EN";
+    const bookID = "EPH";
+    const resourceId = "ULT";
+
+    // when
+    const results = ProjectImportFilesystemHelpers.getProjectsByType(langID, bookID, resourceId);
+
+    // then
+    expect(results).toEqual(expectedResults);
+  });
+
+  test('does not find project with different resource', () => {
+    // given
+    const expectedResults = [ ];
+    const langID = "EN";
+    const bookID = "EPH";
+    const resourceId = "ULTT";
+
+    // when
+    const results = ProjectImportFilesystemHelpers.getProjectsByType(langID, bookID, resourceId);
+
+    // then
+    expect(results).toEqual(expectedResults);
+  });
+});
+
+//
+// helpers
+//
+
+function createMockProject(projectsPath, fileName, langID, bookID, resourceID) {
+  fileName = fileName || (langID + "_" + resourceID + "_" + bookID + "_book");
+  const projectFolderPath = path.join(projectsPath, fileName.toLowerCase());
+  fs.ensureDirSync(projectFolderPath);
+  const manifest = {
+    target_language: {
+      id: langID
+    },
+    project: {
+      id: bookID
+    },
+    resource: {
+      id: resourceID
+    }
+  };
+  fs.outputJsonSync(path.join(projectFolderPath, "manifest.json"), manifest);
+}

--- a/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
+++ b/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
@@ -65,6 +65,19 @@ export function projectExistsInProjectsFolder(fromPath) {
 }
 
 /**
+ * case insensitive compare of two strings
+ * @param {String} a
+ * @param {String} b
+ * @return {boolean} true if equal in lowercase
+ */
+export function areStringsEqualCaseInsensitive(a, b) {
+  return (
+    (typeof a === 'string') &&
+    (typeof a === typeof b) &&
+    (a.toLowerCase() === b.toLowerCase()));
+}
+
+/**
  * Helper function to get projects from the projects folder by a given type
  *
  * @param {string} tLId - Target language id. e.g. hi
@@ -80,7 +93,9 @@ export function getProjectsByType(tLId, bookId, resourceId) {
     const importProjectManifest = manifestHelpers.getProjectManifest(path.join(PROJECTS_PATH, projectName));
     const { target_language: { id }, project, resource } = importProjectManifest;
     const resourceId_ = resource && resource.id ? resource.id : '';
-    return id === tLId && project.id === bookId && resourceId_ === resourceId;
+    return areStringsEqualCaseInsensitive(id, tLId) &&
+      areStringsEqualCaseInsensitive(project.id, bookId) &&
+      areStringsEqualCaseInsensitive(resourceId_, resourceId);
   });
 }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixed getProjectsByType() so that it matches ids all in lower case.

#### Please include detailed Test instructions for your pull request:
- Import an english Titus project and use target identifier of "algn".  Save to DCS for later testing.
- do USFM import of a Titus project using 'en' as langID and use "ALGN" for target identifier.  Should see warning that a project already exists.  Cancel import.
- do import from DCS of the english Titus project using 'en' as langID and use "ALGN" for target identifier.  Should see warning that a project already exists.  Cancel import.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4931)
<!-- Reviewable:end -->
