### PR TITLE
Remove the block that prevents any New Testament from being loaded in the tW too

### DIFF
--- a/__tests__/ToolCardHelpers.test.js
+++ b/__tests__/ToolCardHelpers.test.js
@@ -5,29 +5,27 @@ import * as ToolCardHelpers from "../src/js/helpers/ToolCardHelpers";
 describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch status',()=>{
   const translate = (key) => key;
 
-  test('Should return the status that the book is not supported for translationWords', () => {
+  test('Should return the status that the book is supported for translationWords', () => {
     //given
-    const toolName = 'translationWords';
     const bookId = 'rom';
     const developerMode = false;
 
     //when
-    const status = ToolCardHelpers.isToolSupported(toolName, bookId, developerMode);
+    const status = ToolCardHelpers.isToolSupported(bookId, developerMode);
 
     //then
-    expect(status).toEqual(false);
+    expect(status).toEqual(true);
   });
 
   test('In developerMode, should return a GL needs to be selected for translationWords', () => {
     //given
-    const toolName = 'translationWords';
     const langId = null;
     const bookId = 'rom';
     const developerMode = true;
     const expectedStatus = 'tools.please_select_gl';
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -35,13 +33,12 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Even with a langId, should return the status that the book is not supported for translationWords', () => {
     //given
-    const toolName = 'translationWords';
     const bookId = 'rom';
     const developerMode = false;
-    const expectedStatus = false;
+    const expectedStatus = true;
 
     //when
-    const status = ToolCardHelpers.isToolSupported(toolName, bookId, developerMode);
+    const status = ToolCardHelpers.isToolSupported(bookId, developerMode);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -49,14 +46,13 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('In developerMode, it should return null for an unsupported book for translationWords', () => {
     //given
-    const toolName = 'translationWords';
     const langId = 'en';
     const bookId = 'rom';
     const developerMode = true;
     const expectedStatus = null;
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -64,14 +60,13 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Should return a GL needs to be selected for wordAlignment', () => {
     //given
-    const toolName = 'wordAlignment';
     const langId = null;
     const bookId = 'rom';
     const developerMode = false;
     const expectedStatus = 'tools.please_select_gl';
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -79,14 +74,13 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Even in developerMode, should return a GL needs to be selected for wordAlignment', () => {
     //given
-    const toolName = 'wordAlignment';
     const langId = null;
     const bookId = 'rom';
     const developerMode = true;
     const expectedStatus = 'tools.please_select_gl';
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -94,14 +88,13 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Should return null status for wordAlignment and a language', () => {
     //given
-    const toolName = 'wordAlignment';
     const langId = 'en';
     const bookId = 'rom';
     const developerMode = false;
     const expectedStatus = null;
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -109,13 +102,12 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Should return book not supported status for wordAlignment with an OT book', () => {
     //given
-    const toolName = 'wordAlignment';
     const bookId = 'psa';
     const developerMode = false;
     const expectedStatus = false;
 
     //when
-    const status = ToolCardHelpers.isToolSupported(toolName, bookId, developerMode);
+    const status = ToolCardHelpers.isToolSupported(bookId, developerMode);
 
     //then
     expect(status).toEqual(expectedStatus);
@@ -123,14 +115,13 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
   test('Should return null status for translationWords tool, a language and bookId of "tit"', () => {
     //given
-    const toolName = 'translationWords';
     const langId = 'en';
     const bookId = 'tit';
     const developerMode = false;
     const expectedStatus = null;
 
     //when
-    const status = ToolCardHelpers.getToolCardLaunchStatus(toolName, langId, bookId, developerMode, translate);
+    const status = ToolCardHelpers.getToolCardLaunchStatus(langId, bookId, developerMode, translate);
 
     //then
     expect(status).toEqual(expectedStatus);

--- a/src/js/components/home/toolsManagement/ToolCard.js
+++ b/src/js/components/home/toolsManagement/ToolCard.js
@@ -56,7 +56,7 @@ export default class ToolCard extends Component {
             developerMode
           } = this.props;
     const progress = currentProjectToolsProgress[name] ? currentProjectToolsProgress[name] : 0;
-    const launchStatus = ToolCardHelpers.getToolCardLaunchStatus(name, this.state.selectedGL, id, developerMode, translate);
+    const launchStatus = ToolCardHelpers.getToolCardLaunchStatus(this.state.selectedGL, id, developerMode, translate);
     let desc_key = null;
     switch (name) {
       case 'wordAlignment':

--- a/src/js/helpers/ToolCardHelpers.js
+++ b/src/js/helpers/ToolCardHelpers.js
@@ -10,8 +10,8 @@ import BooksOfTheBible from '../common/BooksOfTheBible';
  * @param {Function} translate
  * @return {String} - Reason why it can't be launched
  */
-export function getToolCardLaunchStatus(toolName, language, bookId, developerMode, translate) {
-  if (!isToolSupported(toolName, bookId, developerMode)) {
+export function getToolCardLaunchStatus(language, bookId, developerMode, translate) {
+  if (!isToolSupported(bookId, developerMode)) {
     return translate('tools.book_not_supported');
   }
   if (!language) {
@@ -31,13 +31,10 @@ export function isNtBook(bookId) {
 
 /**
  * Checks if a tool is supported.
- * @param {string} toolName
  * @param {string} bookId
  * @param {bool} developerMode
  * @return {boolean}
  */
-export function isToolSupported(toolName, bookId, developerMode) {
-  const isTitus = bookId === 'tit';
-  const isNTAlignment = (toolName === 'wordAlignment') && isNtBook(bookId);
-  return developerMode || (isTitus || isNTAlignment);
+export function isToolSupported(bookId, developerMode) {
+  return developerMode || isNtBook(bookId);
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Removes the block that prevents any New Testament from being loaded in the tW too

#### Please include detailed Test instructions for your pull request:
- Try loading projects and ensure the following is true
In developer mode: Can load any projects
Not in developer mode:
tW NT
wA NT

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4939)
<!-- Reviewable:end -->
