### PR TITLE
QA_Fail-4949/Fixes for two and three button dialogs.

### DIFF
--- a/__tests__/ProjectImportStepperActions.test.js
+++ b/__tests__/ProjectImportStepperActions.test.js
@@ -122,16 +122,15 @@ describe('ProjectImportStepperActions.removeProjectValidationStep', () => {
 
 describe('ProjectImportStepperActions.confirmContinueOrCancelImportValidation', () => {
   test('should cancel the import stepper process', () => {
-    const anonymous = () => {};
     const expectedActions = [
       {
         type: 'OPEN_OPTION_DIALOG',
         alertMessage: 'projects.cancel_import_alert',
-        callback: anonymous,
+        callback: expect.any(Function),
         button1Text: 'buttons.continue_import_button',
         button2Text: 'buttons.cancel_import_button',
         buttonLinkText: null,
-        callback2: anonymous
+        callback2: null
       }
     ];
     const store = mockStore({
@@ -140,7 +139,7 @@ describe('ProjectImportStepperActions.confirmContinueOrCancelImportValidation', 
       }
     });
     store.dispatch(ProjectImportStepperActions.confirmContinueOrCancelImportValidation());
-    expect(JSON.stringify(store.getActions())).toEqual(JSON.stringify(expectedActions));
+    expect(store.getActions()).toEqual(expectedActions);
   });
 });
 

--- a/__tests__/__snapshots__/ProjectDetailsHelpers.test.js.snap
+++ b/__tests__/__snapshots__/ProjectDetailsHelpers.test.js.snap
@@ -6,7 +6,7 @@ Array [
     "alertText": "projects.dcs_rename_project",
     "button1": "buttons.rename_repo",
     "button2": "buttons.create_new_repo",
-    "buttonLink": null,
+    "buttonLink": undefined,
     "callback": [Function],
     "type": "OPEN_OPTION_DIALOG",
   },
@@ -25,7 +25,7 @@ Array [
     "alertText": "projects.dcs_rename_project",
     "button1": "buttons.rename_repo",
     "button2": "buttons.create_new_repo",
-    "buttonLink": null,
+    "buttonLink": undefined,
     "callback": [Function],
     "type": "OPEN_OPTION_DIALOG",
   },
@@ -70,9 +70,6 @@ Array [
   Object {
     "type": "CLOSE_ALERT_DIALOG",
   },
-  Object {
-    "type": "ProjectInformationCheckActions.openOnlyProjectDetailsScreen",
-  },
 ]
 `;
 
@@ -88,9 +85,6 @@ Array [
   },
   Object {
     "type": "CLOSE_ALERT_DIALOG",
-  },
-  Object {
-    "type": "ProjectInformationCheckActions.openOnlyProjectDetailsScreen",
   },
 ]
 `;
@@ -127,9 +121,6 @@ Array [
   Object {
     "type": "CLOSE_ALERT_DIALOG",
   },
-  Object {
-    "type": "CONFIRM_ONLINE_MODE",
-  },
 ]
 `;
 
@@ -145,9 +136,6 @@ Array [
   },
   Object {
     "type": "CLOSE_ALERT_DIALOG",
-  },
-  Object {
-    "type": "CONFIRM_ONLINE_MODE",
   },
 ]
 `;

--- a/src/js/actions/AlertModalActions.js
+++ b/src/js/actions/AlertModalActions.js
@@ -21,10 +21,11 @@ export function openAlertDialog(alertMessage, loading) {
 /**
  * @description opens the option dialog with the specified alert message, and options.
  * @param {String} alertMessage - message to be displayed inside the alert dialog.
- * @param {function} callback - callback function that is trigger when clicking button1Text.
+ * @param {function} callback - callback function that is called when clicking on button.  First parameter is text on button. Exception is when callback2 is given.
  * @param {String} button1Text - button text to show right button.
  * @param {String} button2Text - button text to show left of right button. (optional - if not present button is not added)
  * @param {String} buttonLinkText - button text to show on left link button. (optional - if not present button is not added)
+ * @param {function} callback2 - optional callback function that is called user clicks on button2Text.
  * @return {Object} action content.
  */
 export function openOptionDialog(alertMessage, callback, button1Text, button2Text, buttonLinkText = null, callback2 = null) {

--- a/src/js/actions/OnlineModeConfirmActions.js
+++ b/src/js/actions/OnlineModeConfirmActions.js
@@ -26,20 +26,17 @@ export function confirmOnlineAction(onConfirm, onCancel) {
       // TODO: this is a very bad idea. We should not be storing react components in the state
       dispatch(AlertModalActions.openOptionDialog(
         <OnlineDialog onChecked={onConfirmCheckCallback}/>,
-        () => {
-          dispatch(AlertModalActions.closeAlertDialog());
-          onConfirm();
-        },
-        translate('access_internet'),
-        cancelText,
-        null,
-        () => {
-          dispatch(AlertModalActions.closeAlertDialog());
-          if (typeof onCancel === 'function') {
-            onCancel();
+        (result) => {
+          if (result !== cancelText) {
+            dispatch(AlertModalActions.closeAlertDialog());
+            onConfirm();
+          } else {
+            dispatch(AlertModalActions.closeAlertDialog());
+            if(typeof onCancel === 'function') {
+              onCancel();
+            }
           }
-        }
-      ));
+        }, translate('access_internet'), cancelText));
     } else onConfirm();
   });
 }

--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -197,21 +197,20 @@ export function renameProject(projectSaveLocation, newProjectName) {
         const continueText = translate('buttons.continue_import_button');
         dispatch(
           AlertModalActions.openOptionDialog(translate('projects.cancel_import_alert'),
-            () => {
-              // if 'cancel import' then close
-              // alert and cancel import process.
-              dispatch(AlertModalActions.closeAlertDialog());
-              dispatch(cancelProjectValidationStepper());
+            (result) => {
+              if (result === cancelText) {
+                // if 'cancel import' then close
+                // alert and cancel import process.
+                dispatch(AlertModalActions.closeAlertDialog());
+                dispatch(cancelProjectValidationStepper());
+              } else {
+                // if 'Continue Import' then just close alert
+                dispatch(AlertModalActions.closeAlertDialog());
+              }
               resolve();
             },
             continueText,
-            cancelText,
-            null,
-            () => {
-              // if 'Continue Import' then just close alert
-              dispatch(AlertModalActions.closeAlertDialog());
-              resolve();
-            }
+            cancelText
           )
         );
       }
@@ -295,24 +294,23 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
         );
       }
       dispatch(
-        AlertModalActions.openOptionDialog(
-          overwriteMessage,
-          () => {
-            dispatch(AlertModalActions.closeAlertDialog());
-            const oldProjectPath = path.join(PROJECTS_PATH, projectName);
-            ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath);
-            fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
-            fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
-            dispatch(setSaveLocation(oldProjectPath));
-            resolve(true);
+        AlertModalActions.openOptionDialog(overwriteMessage,
+          (result) => {
+            if (result === confirmText) {
+              dispatch(AlertModalActions.closeAlertDialog());
+              const oldProjectPath = path.join(PROJECTS_PATH, projectName);
+              ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath);
+              fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
+              fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
+              dispatch(setSaveLocation(oldProjectPath));
+              resolve(true);
+            } else { // if cancel
+              dispatch(AlertModalActions.closeAlertDialog());
+              resolve(false);
+            }
           },
           cancelText,
-          confirmText,
-          null,
-          () => { // if cancel
-            dispatch(AlertModalActions.closeAlertDialog());
-            resolve(false);
-          }
+          confirmText
         )
       );
     });

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -195,21 +195,20 @@ export const confirmContinueOrCancelImportValidation = () => {
       const cancelText = translate('buttons.cancel_import_button');
       const continueText = translate('buttons.continue_import_button');
       dispatch(
-        AlertModalActions.openOptionDialog(
-          translate('projects.cancel_import_alert'),
-          () => {
+        AlertModalActions.openOptionDialog(translate('projects.cancel_import_alert'),
+          (result) => {
+            if (result === cancelText) {
               // if 'cancel import' then close
               // alert and cancel import process.
               dispatch(AlertModalActions.closeAlertDialog());
               dispatch(cancelProjectValidationStepper());
+            } else {
+              // if 'Continue Import' then just close alert
+              dispatch(AlertModalActions.closeAlertDialog());
+            }
           },
           continueText,
-          cancelText,
-          null,
-          () => {
-            // if 'Continue Import' then just close alert
-            dispatch(AlertModalActions.closeAlertDialog());
-          }
+          cancelText
         )
       );
     }

--- a/src/js/actions/USFMExportActions.js
+++ b/src/js/actions/USFMExportActions.js
@@ -120,21 +120,16 @@ export function getExportType(projectPath) {
       else {
         const onSelect = (choice) => dispatch(setSetting('usfmExportType', choice));
         dispatch(AlertModalActions.openOptionDialog(
-          <USFMExportDialog onSelect={onSelect} />,
-          () => {
+          <USFMExportDialog onSelect={onSelect} />, (res) => {
+          if (res === 'Export') {
             const {usfmExportType} = getState().settingsReducer.currentSettings;
-            dispatch(AlertModalActions.closeAlertDialog());
             resolve(usfmExportType);
-          },
-          'Export',
-          'Cancel',
-          null,
-          () => {
+          } else {
             //used to cancel the entire process
-            dispatch(AlertModalActions.closeAlertDialog());
             reject();
           }
-        ));
+          dispatch(AlertModalActions.closeAlertDialog());
+        }, 'Export', 'Cancel'));
       }
     });
   });

--- a/src/js/components/dialogComponents/Alert.js
+++ b/src/js/components/dialogComponents/Alert.js
@@ -33,12 +33,13 @@ class Alert extends Component {
       </button>
     ];
     if (this.props.alertModalReducer.button1 && button2) {
+      const callback_ = callback2 || callback;
       buttonActions.unshift(
         <button
           label={translate('buttons.cancel_button')}
           className="btn-second"
           disabled={alertDialogLoading}
-          onClick={callback2 ? () => { callback2(button2) } : (callback ? () => { callback(buttonLink) } : closeAlertDialog)}
+          onClick={callback_ ? () => { callback_(button2) } : closeAlertDialog}
         > {this.props.alertModalReducer.button2}
         </button>
       );

--- a/src/js/components/dialogComponents/Alert.js
+++ b/src/js/components/dialogComponents/Alert.js
@@ -38,7 +38,7 @@ class Alert extends Component {
           label={translate('buttons.cancel_button')}
           className="btn-second"
           disabled={alertDialogLoading}
-          onClick={callback2 ? () => { callback2(button2) } : closeAlertDialog}
+          onClick={callback2 ? () => { callback2(button2) } : (callback ? () => { callback(buttonLink) } : closeAlertDialog)}
         > {this.props.alertModalReducer.button2}
         </button>
       );


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated alert container to call callback if callback2 not defined to support original behavior.
- Reverted changes to dialogs with two and three buttons.

#### Please include detailed Test instructions for your pull request:
- test build at bottom of PR.  It should fix behavior listed in issue where dialog actions were reversed.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4958)
<!-- Reviewable:end -->
