### PR TITLE
Now reloading all bible resources when updating source contents while in a tool

### DIFF
--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -210,32 +210,36 @@ export const loadBooks = contextId => dispatch => {
  */
 export const loadBiblesChapter = (contextId) => {
   return (dispatch) => {
-    try {
-      let bookId = contextId.reference.bookId; // bible book abbreviation.
-      let chapter = contextId.reference.chapter;
-      const languagesIds = ResourcesHelpers.getLanguageIdsFromResourceFolder(bookId);
+    return new Promise((resolve, reject) => {
+      try {
+        let bookId = contextId.reference.bookId; // bible book abbreviation.
+        let chapter = contextId.reference.chapter;
+        const languagesIds = ResourcesHelpers.getLanguageIdsFromResourceFolder(bookId);
 
-      languagesIds.forEach((languageId) => {
-        const biblesPath = path.join(USER_RESOURCES_PATH, languageId, 'bibles');
-        if(fs.existsSync(biblesPath)) {
-          let biblesFolders = fs.readdirSync(biblesPath)
-            .filter(folder => folder !== '.DS_Store'); // filter out .DS_Store
-          biblesFolders.forEach((bibleId) => { // bibleId = ult, udt, ugnt.
-            const bibleData = loadChapterResource(bibleId, bookId, languageId, chapter);
-            if (bibleData) {
-              // TODO: load the entire bible
-              dispatch(addNewBible(languageId, bibleId, bibleData));
-            }
-          });
-        } else {
-          console.log('Directory not found, ' + biblesPath);
-        }
-      });
-      // Then load target language bible
-      dispatch(TargetLanguageActions.loadTargetLanguageChapter(chapter));
-    } catch(err) {
-      console.warn(err);
-    }
+        languagesIds.forEach((languageId) => {
+          const biblesPath = path.join(USER_RESOURCES_PATH, languageId, 'bibles');
+          if(fs.existsSync(biblesPath)) {
+            let biblesFolders = fs.readdirSync(biblesPath)
+              .filter(folder => folder !== '.DS_Store'); // filter out .DS_Store
+            biblesFolders.forEach((bibleId) => { // bibleId = ult, udt, ugnt.
+              const bibleData = loadChapterResource(bibleId, bookId, languageId, chapter);
+              if (bibleData) {
+                // TODO: load the entire bible
+                dispatch(addNewBible(languageId, bibleId, bibleData));
+              }
+            });
+          } else {
+            console.log('Directory not found, ' + biblesPath);
+          }
+        });
+        // Then load target language bible
+        dispatch(TargetLanguageActions.loadTargetLanguageChapter(chapter));
+        resolve();
+      } catch(err) {
+        console.warn(err);
+        reject(err);
+      }
+    });
   };
 };
 

--- a/src/js/helpers/sourceContentUpdatesHelpers.js
+++ b/src/js/helpers/sourceContentUpdatesHelpers.js
@@ -21,6 +21,7 @@ const cleanReaddirSync = (path) => {
 
 export const getLocalResourceList = () => {
   try {
+    if (!fs.existsSync(USER_RESOURCES_PATH)) fs.ensureDirSync(USER_RESOURCES_PATH);
     const localResourceList = [];
     const resourceLanguages = fs.readdirSync(USER_RESOURCES_PATH)
       .filter(file => path.extname(file) !== '.json' && file !== '.DS_Store');


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Try to update a source content while in a tool.
- The downloaded content should be available in the resources dropdown list even without the user reloading the project in the tool.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/4984)
<!-- Reviewable:end -->
