### PR TITLE
Feature 4975/Force English GL language to always be available in WA

### DIFF
--- a/__tests__/gatewayLanguageHelpers.test.js
+++ b/__tests__/gatewayLanguageHelpers.test.js
@@ -213,20 +213,22 @@ describe('Test getGatewayLanguageList() for WA',()=>{
       fs.__resetMockFS();
     });
 
-    test('should return an empty list for Titus if no alignments', () => {
+    test('should default to english for Titus if no alignments', () => {
       const copyFiles = ['en/bibles/ult/v11', 'en/translationHelps/translationWords', 'grc/bibles/ugnt'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('tit', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
 
-    test('should return empty list for gal with Hindi (gal is not aligned in en or hi here)', () => {
+    test('should default to english for gal with Hindi (gal is not aligned in en or hi here)', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'grc/bibles/ugnt'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('gal', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
   });
 
@@ -241,7 +243,7 @@ describe('Test getGatewayLanguageList() for WA',()=>{
       fs.__resetMockFS();
     });
 
-    test('should return an empty list for Titus if ULT not checked', () => {
+    test('should default to english for Titus if ULT not checked', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'grc/bibles/ugnt'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
       const jsonPath = path.join(RESOURCE_PATH, 'en/bibles/ult/v12.1/manifest.json');
@@ -250,16 +252,18 @@ describe('Test getGatewayLanguageList() for WA',()=>{
       fs.outputJsonSync(jsonPath, json);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('tit', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
 
-    test('should return an empty list for Titus if ULT not checking 3', () => {
+    test('should default to english for Titus if ULT not checking 3', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'grc/bibles/ugnt'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
       setCheckingLevel(path.join(RESOURCE_PATH, 'en/bibles/ult/v12.1/manifest.json'), 2);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('tit', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
   });
 
@@ -274,28 +278,31 @@ describe('Test getGatewayLanguageList() for WA',()=>{
       fs.__resetMockFS();
     });
 
-    test('should return an empty list for Luke (NT, no ULT)', () => {
+    test('should default to english for Luke (NT, no ULT)', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'grc/bibles/ugnt'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('luk', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
 
-    test('should return an empty list for Genesis (OT, no ULT)', () => {
+    test('should default to english for Genesis (OT, no ULT)', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'he/bibles/uhb'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('gen', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
 
-    test('should return an empty list for Joel (OT, no ULT)', () => {
+    test('should default to english for Joel (OT, no ULT)', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'he/bibles/uhb'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, RESOURCE_PATH);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('jol', toolName);
-      expect(languages.length).toEqual(0);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
     });
   });
 });

--- a/src/js/helpers/gatewayLanguageHelpers.js
+++ b/src/js/helpers/gatewayLanguageHelpers.js
@@ -193,7 +193,7 @@ function getValidResourcePath(langPath, subpath) {
 export function getValidGatewayBibles(langCode, bookId, helpsChecks=null) {
   const languagePath = path.join(ResourcesHelpers.USER_RESOURCES_PATH, langCode);
   const biblesPath = path.join(languagePath, 'bibles');
-  let bibles = fs.readdirSync(biblesPath);
+  const bibles = fs.existsSync(biblesPath) ? fs.readdirSync(biblesPath) : [];
   const validBibles = bibles.filter(bible => {
     if (!fs.lstatSync(path.join(biblesPath, bible)).isDirectory()) { // verify it's a valid directory
       return false;

--- a/src/js/helpers/gatewayLanguageHelpers.js
+++ b/src/js/helpers/gatewayLanguageHelpers.js
@@ -65,8 +65,10 @@ export function getRequiredHelpsForTool(toolName) {
  */
 export function getGatewayLanguageList(bookId = null, toolName = null) {
   const helpsCheck = getRequiredHelpsForTool(toolName);
-  const languageBookData = getSupportedGatewayLanguageResourcesList(bookId, helpsCheck);
-  const supportedLanguages = Object.keys(languageBookData).map(code => {
+  const forceLanguageId = (toolName === 'wordAlignment') ? 'en' : null;
+  const languageBookData = getSupportedGatewayLanguageResourcesList(bookId, helpsCheck, forceLanguageId);
+  const supportedLanguageCodes = Object.keys(languageBookData);
+  const supportedLanguages = supportedLanguageCodes.map(code => {
     let lang = getLanguageByCodeSelection(code);
     if (!lang && (code === 'grc')) { // add special handling for greek - even though it is an Original Language, it can be used as a gateway Language also
       lang = {
@@ -232,9 +234,10 @@ export function getValidGatewayBibles(langCode, bookId, helpsChecks=null) {
  *
  * @param {String|null} bookId - optionally filter on book
  * @param {Array|null} helpsChecks - array of helps to check for (subpaths to the helps folders that must exist)
+ * @param {String|null} forceLanguageId - if not null, then add this language code
  * @return {Object} set of supported languages and their supported bibles
  */
-export function getSupportedGatewayLanguageResourcesList(bookId = null, helpsChecks = null) {
+export function getSupportedGatewayLanguageResourcesList(bookId = null, helpsChecks = null, forceLanguageId = null) {
   const allLanguages = ResourcesHelpers.getAllLanguageIdsFromResourceFolder(true) || [];
   const filteredLanguages = {};
   for (let language of allLanguages) {
@@ -246,6 +249,12 @@ export function getSupportedGatewayLanguageResourcesList(bookId = null, helpsChe
         bibles: validBibles
       };
     }
+  }
+  if (forceLanguageId && !Object.keys(filteredLanguages).length) { // TODO: this is a temporary fix to be removed later
+    filteredLanguages[forceLanguageId] = {
+      default_literal: 'ult',
+      bibles: ['ult']
+    };
   }
   return filteredLanguages;
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- this is a temporary fix until we fix validation of GL languages for WA

#### Please include detailed Test instructions for your pull request:
- Since we have updated en ult with alignments.  To test you will have to remove the ult from en folder.  The open an acts project (which will not have alignments in ust) and you should still see English as a GL selection.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5002)
<!-- Reviewable:end -->
