### PR TITLE
Fix For Source Content Updater Modal Bug

### DIFF
--- a/src/js/actions/OnlineModeConfirmActions.js
+++ b/src/js/actions/OnlineModeConfirmActions.js
@@ -18,7 +18,7 @@ export function confirmOnlineAction(onConfirm, onCancel) {
     const translate = getTranslate(getState());
     const cancelText = translate('buttons.cancel_button');
     const onlineMode = getState().settingsReducer.onlineMode;
-
+    
     if (!onlineMode) {
       const onConfirmCheckCallback = (val) => {
         dispatch(checkBox(val));

--- a/src/js/actions/OnlineModeConfirmActions.js
+++ b/src/js/actions/OnlineModeConfirmActions.js
@@ -18,7 +18,7 @@ export function confirmOnlineAction(onConfirm, onCancel) {
     const translate = getTranslate(getState());
     const cancelText = translate('buttons.cancel_button');
     const onlineMode = getState().settingsReducer.onlineMode;
-    
+
     if (!onlineMode) {
       const onConfirmCheckCallback = (val) => {
         dispatch(checkBox(val));

--- a/src/js/actions/SourceContentUpdatesActions.js
+++ b/src/js/actions/SourceContentUpdatesActions.js
@@ -65,6 +65,7 @@ export const getListOfSourceContentToUpdate = async (closeSourceContentDialog) =
         });
     } else {
       dispatch(openAlertDialog(translate('no_internet')));
+      closeSourceContentDialog();
     }
   });
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- If the user selects to Check for content updates when there is no Internet connection, the Cannot connect to serve alert is correctly displayed. However, after restoring the Internet connection, when the Check for content updates is clicked, nothing happens.

#### Please include detailed Test instructions for your pull request:
- Do the following scenario above and the result should be the dialog shows like normal

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5004)
<!-- Reviewable:end -->
