### PR TITLE
Decoupled some tool loading logic

### DIFF
--- a/src/js/actions/ToolSelectionActions.js
+++ b/src/js/actions/ToolSelectionActions.js
@@ -72,12 +72,15 @@ function loadSupportingToolApis(currentToolName) {
       try {
         let tool = require(
           path.join(toolMeta.folderName, toolMeta.main)).default;
+
         // TRICKY: compatibility for older tools
         if ('container' in tool.container && 'name' in tool.container) {
           tool = tool.container;
         }
+        // end compatability
+
         if (tool.api) {
-          dispatch(registerToolApi(tool.name, tool.api));
+          dispatch(registerToolApi(toolMeta.name, tool.api));
         }
       } catch (e) {
         console.error(`Failed to load tool api for ${toolMeta.name}`, toolMeta, e);
@@ -106,7 +109,6 @@ const registerToolApi = (name, api) => ({
 export function saveToolViews(checkArray, toolPackage) {
   return (dispatch => {
     for (let module of checkArray) {
-
       try {
         let tool = require(path.join(module.location, toolPackage.main)).default;
 
@@ -122,7 +124,7 @@ export function saveToolViews(checkArray, toolPackage) {
           module: tool.container
         });
         if(tool.api) {
-          dispatch(registerToolApi(tool.name, tool.api));
+          dispatch(registerToolApi(module.name, tool.api));
         }
       } catch (e) {
         console.error(`Failed to load ${module.name} tool`, e);

--- a/src/js/actions/ToolSelectionActions.js
+++ b/src/js/actions/ToolSelectionActions.js
@@ -32,7 +32,7 @@ export function selectTool(moduleFolderName, currentToolName) {
           type: consts.SET_CURRENT_TOOL_TITLE,
           currentToolTitle: dataObject.title
         });
-        dispatch(saveToolViews(checkArray));
+        dispatch(saveToolViews(checkArray, dataObject));
         dispatch(loadSupportingToolApis(currentToolName));
         // load project data
         dispatch(ProjectDataLoadingActions.loadProjectData(currentToolName));
@@ -103,15 +103,19 @@ const registerToolApi = (name, api) => ({
  * @param {Array} checkArray - Array of the checks that the views should be loaded.
  * @return {object} action object.
  */
-export function saveToolViews(checkArray) {
+export function saveToolViews(checkArray, toolPackage) {
   return (dispatch => {
     for (let module of checkArray) {
+
       try {
-        let tool = require(path.join(module.location, 'index')).default;
+        let tool = require(path.join(module.location, toolPackage.main)).default;
+
         // TRICKY: compatibility for older tools
         if('container' in tool.container && 'name' in tool.container) {
           tool = tool.container;
         }
+        // end compatibility fix
+
         dispatch({
           type: consts.SAVE_TOOL_VIEW,
           identifier: module.name,

--- a/src/js/actions/ToolsMetadataActions.js
+++ b/src/js/actions/ToolsMetadataActions.js
@@ -3,7 +3,6 @@ import path from 'path-extra';
 import fs from 'fs-extra';
 // constant declarations
 const PACKAGE_SUBMODULE_LOCATION = path.join(__dirname, '../../../tC_apps');
-const TOOLS_TO_SHOW = ['wordAlignment', 'translationWords'];
 
 export function getToolsMetadatas() {
   return ((dispatch) => {
@@ -29,14 +28,9 @@ const getDefaultTools = (callback) => {
   });
   if (folders) {
     for (let folder of folders) {
-      try {
-        let manifestPath = path.join(moduleBasePath, folder, 'package.json');
-        let packageJson = require(manifestPath);
-        if (packageJson.display === 'app' && TOOLS_TO_SHOW.includes(packageJson.name)) {
-          defaultTools.push(manifestPath);
-        }
-      } catch (e) {
-        console.log(e);
+      let manifestPath = path.join(moduleBasePath, folder, 'package.json');
+      if(fs.pathExists(manifestPath)) {
+        defaultTools.push(manifestPath);
       }
     }
   }
@@ -56,7 +50,7 @@ const fillDefaultTools = (moduleFilePathList, callback) => {
   let doneFiles = 0;
   function onComplete() {
     doneFiles++;
-    if (doneFiles == totalFiles) {
+    if (doneFiles === totalFiles) {
       callback(tempMetadatas);
     }
   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
This is a tiny move towards supporting tools packaged as npm modules.

- Decouples tool loading a little more by the `main` script defined in `package.json` instead of hard coding it in tC.
- Removes restriction of which tools are loaded.

#### Please include detailed Test instructions for your pull request:
- Open a tool. If it opens without a big red error screen it works!

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5037)
<!-- Reviewable:end -->
