### PR TITLE
Fixed software update dialog

### DIFF
--- a/__tests__/CheckSoftwareUpdatesDialog.test.js
+++ b/__tests__/CheckSoftwareUpdatesDialog.test.js
@@ -52,41 +52,41 @@ describe('Get update asset', () => {
     expect(update).toEqual(expectedUpdate);
   });
 
-  it('finds a legacy windows update', () => {
+  it('finds an x32 update', () => {
     const response = {
       extra_info: 'foo',
-      tag_name: 'v0.7.0',
+      tag_name: '2.0.0',
       assets: [{
         extra_info: 'bar',
-        name: 'translationCoreSetup.exe'
+        name: 'translationCore-win-x32-2.0.0.exe'
       }]
     };
     const expectedUpdate = {
       extra_info: 'bar',
-      installed_version: '0.6.0',
-      name: 'translationCoreSetup.exe',
-      latest_version: 'v0.7.0'
+      installed_version: '1.0.0',
+      name: 'translationCore-win-x32-2.0.0.exe',
+      latest_version: '2.0.0'
     };
-    const update = getUpdateAsset(response, '0.6.0', 'x64', 'win32');
+    const update = getUpdateAsset(response, '1.0.0', 'x32', 'win32');
     expect(update).toEqual(expectedUpdate);
   });
 
-  it('finds a legacy macOS update', () => {
+  it('finds an ia32 update', () => {
     const response = {
       extra_info: 'foo',
-      tag_name: 'v0.7.0',
+      tag_name: '2.0.0',
       assets: [{
         extra_info: 'bar',
-        name: 'translationCore-0.7.0.dmg'
+        name: 'translationCore-win-x32-2.0.0.exe'
       }]
     };
     const expectedUpdate = {
       extra_info: 'bar',
-      installed_version: '0.6.0',
-      name: 'translationCore-0.7.0.dmg',
-      latest_version: 'v0.7.0'
+      installed_version: '1.0.0',
+      name: 'translationCore-win-x32-2.0.0.exe',
+      latest_version: '2.0.0'
     };
-    const update = getUpdateAsset(response, '0.6.0', 'x64', 'darwin');
+    const update = getUpdateAsset(response, '1.0.0', 'ia32', 'win32');
     expect(update).toEqual(expectedUpdate);
   });
 });

--- a/src/js/containers/SoftwareUpdateDialog/SoftwareUpdateDialogContainer.js
+++ b/src/js/containers/SoftwareUpdateDialog/SoftwareUpdateDialogContainer.js
@@ -32,6 +32,10 @@ export function getUpdateAsset(response, installedVersion, osArch, osPlatform) {
     'sunos': 'linux',
     'win32': 'win'
   };
+  // TRICKY: some architecture will return ia32 instead of x32
+  if(osArch === 'ia32') {
+    osArch = 'x32';
+  }
   const platform = `${platformNames[osPlatform]}-${osArch}`;
   let update = null;
   for (const asset of response.assets) {

--- a/src/js/containers/SoftwareUpdateDialog/SoftwareUpdateDialogContainer.js
+++ b/src/js/containers/SoftwareUpdateDialog/SoftwareUpdateDialogContainer.js
@@ -32,17 +32,10 @@ export function getUpdateAsset(response, installedVersion, osArch, osPlatform) {
     'sunos': 'linux',
     'win32': 'win'
   };
-  let extension = null;
-  if(osPlatform === 'darwin') {
-    extension = '.dmg';
-  } else if(osPlatform === 'win32') {
-    extension = '.exe';
-  }
   const platform = `${platformNames[osPlatform]}-${osArch}`;
   let update = null;
   for (const asset of response.assets) {
-    const matchesExtension = extension != null && asset.name.endsWith(extension);
-    if (asset.name.includes(platform) || matchesExtension) {
+    if (asset.name.includes(platform)) {
       update = {
         ...asset,
         latest_version: response.tag_name,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
related to #5130 
- Fixes bug in the software update dialog that caused the incorrect windows installer to be downloaded.

#### Please include detailed Test instructions for your pull request:
- As a developer, temporarily change the tC version to something before `1.0`.
- start tc (`npm start`) and check for an update
- You should see an update is available. Download it
- At this point you should be able to tell right away from the filename that you are downloading the correct installer (x64 or x32 depending on our os architecture). To be sure you can finish the download and install the update.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5208)
<!-- Reviewable:end -->
