### PR TITLE
bugfix 5048/Remove settings migrations of ulb and udb in English

### DIFF
--- a/__tests__/SettingsMigrationActions.test.js
+++ b/__tests__/SettingsMigrationActions.test.js
@@ -26,7 +26,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings1', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings1());
@@ -54,7 +54,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings2', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings2());
@@ -95,7 +95,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings3', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings3());
@@ -180,7 +180,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
@@ -232,7 +232,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
@@ -336,7 +336,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());

--- a/__tests__/SettingsMigrationActions.test.js
+++ b/__tests__/SettingsMigrationActions.test.js
@@ -113,7 +113,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
       toolSettingsData: [
         {
           languageId: 'en',
-          bibleId: 'ult'
+          bibleId: 'ulb'
         },
         {
           languageId: 'hi',
@@ -126,7 +126,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
       ]
     }
   ];
-  test('Migrates scriptrue pane settings from ulb bible id to ult bible id only for English', () => {
+  test('Does not migrate scripture pane settings for ulb bible id in English', () => {
     const initialState = {
       settingsReducer: {
         toolsSettings: {
@@ -149,7 +149,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
         }
       }
     };
-    // set up mok store
+    // set up mock store
     const store = mockStore(initialState);
     // dispatch action
     store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
@@ -157,7 +157,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  test('Migrates scriptrue pane settings from ult bible id to ulb bible id only for Hindi', () => {
+  test('Migrates scripture pane settings from ult bible id to ulb bible id only for Hindi', () => {
     const initialState = {
       settingsReducer: {
         toolsSettings: {
@@ -165,7 +165,7 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
             currentPaneSettings: [
               {
                 languageId: 'en',
-                bibleId: 'ult'
+                bibleId: 'ulb'
               },
               {
                 languageId: 'hi',
@@ -187,4 +187,161 @@ describe('SettingsMigrationActions.migrateCurrentPaneSettings4', () => {
 
     expect(store.getActions()).toEqual(expectedActions);
   });
+
+  test('Migrates scripture pane settings from udb bible id to udt bible id only for Hindi', () => {
+    const expectedActions = [
+      {
+        type: ActionTypes.UPDATE_TOOL_SETTINGS,
+        moduleNamespace: "ScripturePane",
+        settingsPropertyName: "currentPaneSettings",
+        toolSettingsData: [
+          {
+            languageId: 'en',
+            bibleId: 'ust'
+          },
+          {
+            languageId: 'hi',
+            bibleId: 'udt'
+          },
+          {
+            languageId: 'targetLanguage',
+            bibleId: 'targetBible'
+          }
+        ]
+      }
+    ];
+    const initialState = {
+      settingsReducer: {
+        toolsSettings: {
+          'ScripturePane': {
+            currentPaneSettings: [
+              {
+                languageId: 'en',
+                bibleId: 'ust'
+              },
+              {
+                languageId: 'hi',
+                bibleId: 'udb'
+              },
+              {
+                languageId: 'targetLanguage',
+                bibleId: 'targetBible'
+              }
+            ]
+          }
+        }
+      }
+    };
+    // set up mok store
+    const store = mockStore(initialState);
+    // dispatch action
+    store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  test('Does not migrate scripture pane settings for udb bible id in English', () => {
+    const expectedActions = [
+      {
+        type: ActionTypes.UPDATE_TOOL_SETTINGS,
+        moduleNamespace: "ScripturePane",
+        settingsPropertyName: "currentPaneSettings",
+        toolSettingsData: [
+          {
+            languageId: 'en',
+            bibleId: 'udb'
+          },
+          {
+            languageId: 'hi',
+            bibleId: 'ulb'
+          },
+          {
+            languageId: 'targetLanguage',
+            bibleId: 'targetBible'
+          }
+        ]
+      }
+    ];
+    const initialState = {
+      settingsReducer: {
+        toolsSettings: {
+          'ScripturePane': {
+            currentPaneSettings: [
+              {
+                languageId: 'en',
+                bibleId: 'udb'
+              },
+              {
+                languageId: 'hi',
+                bibleId: 'ulb'
+              },
+              {
+                languageId: 'targetLanguage',
+                bibleId: 'targetBible'
+              }
+            ]
+          }
+        }
+      }
+    };
+    // set up mock store
+    const store = mockStore(initialState);
+    // dispatch action
+    store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  test('Migrates scripture pane settings from udt bible id to ust bible id only for English', () => {
+    const expectedActions = [
+      {
+        type: ActionTypes.UPDATE_TOOL_SETTINGS,
+        moduleNamespace: "ScripturePane",
+        settingsPropertyName: "currentPaneSettings",
+        toolSettingsData: [
+          {
+            languageId: 'en',
+            bibleId: 'ust'
+          },
+          {
+            languageId: 'hi',
+            bibleId: 'ulb'
+          },
+          {
+            languageId: 'targetLanguage',
+            bibleId: 'targetBible'
+          }
+        ]
+      }
+    ];
+    const initialState = {
+      settingsReducer: {
+        toolsSettings: {
+          'ScripturePane': {
+            currentPaneSettings: [
+              {
+                languageId: 'en',
+                bibleId: 'udt'
+              },
+              {
+                languageId: 'hi',
+                bibleId: 'ult'
+              },
+              {
+                languageId: 'targetLanguage',
+                bibleId: 'targetBible'
+              }
+            ]
+          }
+        }
+      }
+    };
+    // set up mok store
+    const store = mockStore(initialState);
+    // dispatch action
+    store.dispatch(SettingsMigrationActions.migrateCurrentPaneSettings4());
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
 });

--- a/src/js/actions/SettingsMigrationActions.js
+++ b/src/js/actions/SettingsMigrationActions.js
@@ -95,7 +95,7 @@ export function migrateCurrentPaneSettings3() {
 }
 
 /**
- * Migrates the scriture pane bible settings to use ult for
+ * Migrates the scripture pane bible settings to use ult for
  * English and ulb for Hindi and uses udt instead of udb.
  */
 export function migrateCurrentPaneSettings4() {
@@ -110,9 +110,7 @@ export function migrateCurrentPaneSettings4() {
       const foundUlbOrUltBibleId = currentPaneSettings.find((paneSettings) => foundUlbOrUltBibleIdCondition(paneSettings));
       if (foundUlbOrUltBibleId) {
         const newCurrentPaneSettings = currentPaneSettings.map((paneSettings) => {
-          if (paneSettings.bibleId === 'ulb' && paneSettings.languageId === 'en') paneSettings.bibleId = 'ult';
           if (paneSettings.bibleId === 'ult' && paneSettings.languageId === 'hi') paneSettings.bibleId = 'ulb';
-          if (paneSettings.bibleId === 'udb' && paneSettings.languageId === 'en') paneSettings.bibleId = 'ust';
           if (paneSettings.bibleId === 'udt' && paneSettings.languageId === 'en') paneSettings.bibleId = 'ust';
           if (paneSettings.bibleId === 'udb' && paneSettings.languageId === 'hi') paneSettings.bibleId = 'udt';
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- removed English migrations for ulb and udb in settings since we now ship with those resources.

#### Please include detailed Test instructions for your pull request:
- select a project and open in WA.  Add en_ulb and en_udb to the Scripture Pane
- restart app
- select a project and open in WA.  Should still see the en_ulb and en_udb to the Scripture Pane
- open tW.  Should also see the en_ulb and en_udb to the Scripture Pane

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5316)
<!-- Reviewable:end -->
