### PR TITLE
Fixes bug in loading tools

### DIFF
--- a/src/js/helpers/toolHelper.js
+++ b/src/js/helpers/toolHelper.js
@@ -8,16 +8,14 @@ import fs from "fs-extra";
  */
 export const loadToolsInDir = async toolsDir => {
   const tools = [];
-  let files = [];
 
-  // TRICKY: fs.pathExists does not work on directories within an asar so we perform in a try catch
-  try {
-    files = await fs.readdir(toolsDir);
-  } catch (e) {
+  // https://github.com/electron/electron/issues/6555 fs.access is broken
+  if(!fs.existsSync(toolsDir)) {
     console.warn(`No tools found in missing directory ${toolsDir}.`);
     return [];
   }
 
+  const files = await fs.readdir(toolsDir);
   for(const f of files) {
     const toolPath = path.join(toolsDir, f);
     const stat = await fs.stat(toolPath);

--- a/src/js/helpers/toolHelper.js
+++ b/src/js/helpers/toolHelper.js
@@ -9,7 +9,7 @@ import fs from "fs-extra";
 export const loadToolsInDir = async toolsDir => {
   const tools = [];
 
-  // https://github.com/electron/electron/issues/6555 fs.access is broken
+  // TRICKY: fs.access does not work on asar directories so we cannot use `fs.access`
   if(!fs.existsSync(toolsDir)) {
     console.warn(`No tools found in missing directory ${toolsDir}.`);
     return [];

--- a/src/js/helpers/toolHelper.js
+++ b/src/js/helpers/toolHelper.js
@@ -8,14 +8,16 @@ import fs from "fs-extra";
  */
 export const loadToolsInDir = async toolsDir => {
   const tools = [];
+  let files = [];
 
-  const toolsExist = await fs.pathExists(toolsDir);
-  if(!toolsExist) {
-    console.warn(`No tools found in missing directory ${toolsDir}`);
+  // TRICKY: fs.pathExists does not work on directories within an asar so we perform in a try catch
+  try {
+    files = await fs.readdir(toolsDir);
+  } catch (e) {
+    console.warn(`No tools found in missing directory ${toolsDir}.`);
     return [];
   }
 
-  const files = await fs.readdir(toolsDir);
   for(const f of files) {
     const toolPath = path.join(toolsDir, f);
     const stat = await fs.stat(toolPath);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to #5543
- This corrects an unusual bug that prevented tools from being loaded from an asar file.
It turns out that `fs.access` does not work on directories within an asar. See https://github.com/electron/electron/issues/6555. `fs-extra.pathExists` uses `fs.access` internally which caused this bug.

I've opted to use `fs.existsSync` instead which does correctly identify directories within an asar.

#### Please include detailed Test instructions for your pull request:
- open the application
- select a project
- the tools should be shown on the page.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5548)
<!-- Reviewable:end -->
