### PR TITLE
fixed bug in loading context id

### DIFF
--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -138,7 +138,7 @@ export function loadCurrentContextId() {
         let loadPath = path.join(projectSaveLocation, INDEX_DIRECTORY, toolName, bookId, "currentContextId", fileName);
         if (fs.existsSync(loadPath)) {
           contextId = fs.readJsonSync(loadPath);
-          const contextIdExistInGroups = groupsIndex.indexOf(({id}) => id === contextId.groupId) >= 0;
+          const contextIdExistInGroups = groupsIndex.map(({id}) => id === contextId.groupId).length >= 0;
           if (contextId && contextIdExistInGroups) {
             return dispatch(changeCurrentContextId(contextId));
           }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to #5551 
- There was a typo in the code that loaded the current context id. This has been corrected.

#### Please include detailed Test instructions for your pull request:
- open a tool
- pick a verse/group other than the first one
- close and re-open the tool
- the correct context should have been loaded.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5552)
<!-- Reviewable:end -->
