### PR TITLE
Removed CSV Blank Field Restriction, Updated Verse Edit Save Workflow

### DIFF
--- a/__tests__/CheckDataLoadActions.test.js
+++ b/__tests__/CheckDataLoadActions.test.js
@@ -126,36 +126,6 @@ describe('CheckDataLoadActions.generateLoadPath', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it('runs CheckDataLoadActions.loadVerseEdit', () => {
-    const expectedActions = [
-      {
-        type:"ADD_VERSE_EDIT",
-        before:"Huu ni ujumbe wa kuaminika. Ninawataka myanene kwa ujasiri mambo haya , ili kwamba wale wanaomwamini Mungu wawe na dhamira juu ya kazi nzuri ambayo aliiweka mbele yao. Mambo haya ni mazuri na yanafaida kwa ajili ya watu wote. TEST",
-        after:"Huu ni ujumbe wa kuaminika. Ninawataka myanene kwa ujasiri mambo haya , ili kwamba wale wanaomwamini Mungu wawe na dhamira juu ya kazi nzuri ambayo aliiweka mbele yao. Mambo haya ni mazuri na yanafaida kwa ajili ya watu wote.",
-        tags:["punctuation"],
-        activeBook: 'tit',
-        activeChapter: 3,
-        activeVerse: 8,
-        modifiedTimestamp:"2017-04-28T14:28:24.328Z",
-        gatewayLanguageCode: null,
-        gatewayLanguageQuote: null,
-        reference: {
-          bookId: 'tit',
-          chapter: 3,
-          verse: 8
-        },
-        username: undefined
-      }
-    ];
-    const store = mockStore({
-      projectDetailsReducer,
-      contextIdReducer
-    });
-
-    store.dispatch(CheckDataLoadActions.loadVerseEdit());
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
   it('runs CheckDataLoadActions.loadReminders: should not load another tools data', () => {
     const expectedActions = [
       {

--- a/__tests__/csvHelpers.test.js
+++ b/__tests__/csvHelpers.test.js
@@ -106,24 +106,6 @@ describe('csvHelpers.combineData', () => {
     _combinedData.time = combinedData.time;
     expect(combinedData).toEqual(_combinedData);
   });
-
-  test('should return the right response for combinedData if using make blank flag', () => {
-    const data = { enabled: true };
-    const combinedData = csvHelpers.combineData(data, tWContextId, 'klappy', '2017-08-23T02:33:45.377Z', true);
-    // Due to timezone issues this is a pain to test.
-    expect(combinedData.groupName).toBeFalsy();
-    expect(combinedData.groupId).toBeFalsy();
-    expect(combinedData.quote).toBeFalsy();
-    expect(combinedData.occurrence).toBeFalsy();
-    expect(combinedData['gateway Language Quote']).toBeFalsy();
-    expect(combinedData.bookId).toBeTruthy();
-    expect(combinedData.chapter).toBeTruthy();
-    expect(combinedData.verse).toBeTruthy();
-    expect(combinedData.tool).toBeTruthy();
-    expect(combinedData.username).toBeTruthy();
-    expect(combinedData.time).toBeTruthy();
-    expect(combinedData.date).toBeTruthy();
-  });
 });
 
 describe('csvHelpers.getToolFolderNames', () => {

--- a/src/js/actions/CSVExportActions.js
+++ b/src/js/actions/CSVExportActions.js
@@ -249,7 +249,6 @@ export const saveVerseEditsToCSV = (projectPath) => {
     loadProjectDataByType(projectPath, 'verseEdits')
       .then((array) => {
         const objectArray = array.map(data => {
-          debugger;
           const groupsIndex = csvHelpers.getGroupsIndexForCsvExport(data);
           const groupName = groupsIndexHelpers.getGroupFromGroupsIndex(groupsIndex, data.contextId.groupId) ?
             groupsIndexHelpers.getGroupFromGroupsIndex(groupsIndex, data.contextId.groupId).name : '';

--- a/src/js/actions/CSVExportActions.js
+++ b/src/js/actions/CSVExportActions.js
@@ -264,7 +264,7 @@ export const saveVerseEditsToCSV = (projectPath) => {
             'gateway Language Code': data.gatewayLanguageCode || 'en',
             'gateway Language Quote': gatewayLanguageQuote
           };
-          return csvHelpers.combineData(_data, data.contextId, data.userName, data.modifiedTimestamp, true);
+          return csvHelpers.combineData(_data, data.contextId, data.userName, data.modifiedTimestamp);
         });
         const dataPath = csvHelpers.dataPath(projectPath);
         const filePath = path.join(dataPath, 'output', 'VerseEdits.csv');

--- a/src/js/actions/CSVExportActions.js
+++ b/src/js/actions/CSVExportActions.js
@@ -249,6 +249,7 @@ export const saveVerseEditsToCSV = (projectPath) => {
     loadProjectDataByType(projectPath, 'verseEdits')
       .then((array) => {
         const objectArray = array.map(data => {
+          debugger;
           const groupsIndex = csvHelpers.getGroupsIndexForCsvExport(data);
           const groupName = groupsIndexHelpers.getGroupFromGroupsIndex(groupsIndex, data.contextId.groupId) ?
             groupsIndexHelpers.getGroupFromGroupsIndex(groupsIndex, data.contextId.groupId).name : '';

--- a/src/js/actions/CheckDataLoadActions.js
+++ b/src/js/actions/CheckDataLoadActions.js
@@ -9,7 +9,6 @@ import path from 'path-extra';
 import * as gatewayLanguageHelpers from '../helpers/gatewayLanguageHelpers';
 // consts declaration
 const CHECKDATA_DIRECTORY = path.join('.apps', 'translationCore', 'checkData');
-import {recordTargetVerseEdit} from './VerseEditActions';
 
 /**
  * Generates the output directory.
@@ -218,28 +217,6 @@ export function loadSelections() {
         selections: [],
         userName: ""
       });
-    }
-  };
-}
-/**
- * Loads the latest verseEdit file from the file system for the specific
- * contextID.
- * @deprecated there is no reason to load the verse edits.
- * @return {object} Dispatches an action that loads the verseEditReducer with data.
- */
-export function loadVerseEdit() {
-  return (dispatch, getState) => {
-    const {projectDetailsReducer, contextIdReducer} = getState();
-    let loadPath = generateLoadPath(projectDetailsReducer, contextIdReducer, 'verseEdits');
-    let verseEditsObject = loadCheckData(loadPath, contextIdReducer.contextId);
-    if (verseEditsObject) {
-      const {verseBefore, verseAfter, userName, tags, modifiedTimestamp} = verseEditsObject;
-      const {bookId, chapter, verse} = contextIdReducer.contextId.reference;
-      dispatch(recordTargetVerseEdit(bookId, chapter, verse, verseBefore, verseAfter, tags, userName, modifiedTimestamp, null, null, chapter, verse));
-    } else {
-      debugger;
-      // The object is undefined because the file wasn't found in the directory thus we init the reducer to a default value.
-      dispatch(recordTargetVerseEdit('', '', '', '', '', [], [], '', null, null));
     }
   };
 }

--- a/src/js/actions/CheckDataLoadActions.js
+++ b/src/js/actions/CheckDataLoadActions.js
@@ -237,6 +237,7 @@ export function loadVerseEdit() {
       const {bookId, chapter, verse} = contextIdReducer.contextId.reference;
       dispatch(recordTargetVerseEdit(bookId, chapter, verse, verseBefore, verseAfter, tags, userName, modifiedTimestamp, null, null, chapter, verse));
     } else {
+      debugger;
       // The object is undefined because the file wasn't found in the directory thus we init the reducer to a default value.
       dispatch(recordTargetVerseEdit('', '', '', '', '', [], [], '', null, null));
     }

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -63,7 +63,7 @@ export const editTargetVerse = (chapter, verse, before, after, tags, username=nu
       }
     };
     dispatch(validateSelections(after, verseContextId, chapter, verse));
-    dispatch(recordTargetVerseEdit(bookId, chapter, verse, before, after, tags, userAlias, generateTimestamp(), gatewayLanguageCode, gatewayLanguageQuote, currentChapter, currentVerse));
+    dispatch(recordTargetVerseEdit(bookId, chapter, verse, before, after, tags, userAlias, generateTimestamp(), gatewayLanguageCode, gatewayLanguageQuote, verseContextId));
     dispatch(updateTargetVerse(chapter, verse, after));
     dispatch({
       type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
@@ -106,7 +106,8 @@ export const editTargetVerse = (chapter, verse, before, after, tags, username=nu
  * @param {string|null} [glQuote=null] - the gateway language code
  * @return {*}
  */
-export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tags, username, modified, glCode=null, glQuote=null, activeChapter, activeVerse) => ({
+export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tags, username, modified, glCode=null, glQuote=null, 
+  {reference:{chapter:activeChapter, verse:activeVerse}, quote, groupId, occurrence}) => ({
   type: types.ADD_VERSE_EDIT,
   before,
   after,
@@ -122,7 +123,10 @@ export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tag
     bookId,
     chapter: parseInt(chapter),
     verse: parseInt(verse)
-  }
+  },
+  quote,
+  groupId,
+  occurrence
 });
 
 /**

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -122,10 +122,10 @@ export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tag
   reference: {
     bookId,
     chapter: parseInt(chapter),
-    verse: parseInt(verse)
+    verse: parseInt(verse),
+    groupId
   },
   quote,
-  groupId,
   occurrence
 });
 

--- a/src/js/actions/__tests__/VerseEditActions.test.js
+++ b/src/js/actions/__tests__/VerseEditActions.test.js
@@ -26,8 +26,12 @@ describe('verse edit actions', () => {
     const verse = 2;
     const activeChapter = 1;
     const activeVerse = 17;
+    const quote = 'quote';
+    const groupId = 'group';
+    const occurrence = 1;
 
-    const result = actions.recordTargetVerseEdit(book, chapter, verse, before, after, tags, username, modified, null, null, activeChapter, activeVerse);
+    const result = actions.recordTargetVerseEdit(book, chapter, verse, before, after, tags, username, modified, null, null, 
+      {reference: {chapter:activeChapter, verse: activeVerse}}, quote, groupId, occurrence);
     expect(result).toEqual({
       type: types.ADD_VERSE_EDIT,
       tags,
@@ -61,8 +65,12 @@ describe('verse edit actions', () => {
     const verse = 2;
     const activeChapter = 1;
     const activeVerse = 17;
+    const quote = 'quote';
+    const groupId = 'group';
+    const occurrence = 1;
 
-    const result = actions.recordTargetVerseEdit(book, chapter, verse, before, after, tags, username, modified, glCode, glQuote, activeChapter, activeVerse);
+    const result = actions.recordTargetVerseEdit(book, chapter, verse, before, after, tags, username, modified, glCode, glQuote, 
+      {reference: {chapter:activeChapter, verse: activeVerse}}, quote, groupId, occurrence);
     expect(result).toEqual({
       type: types.ADD_VERSE_EDIT,
       tags,

--- a/src/js/helpers/csvHelpers.js
+++ b/src/js/helpers/csvHelpers.js
@@ -45,7 +45,6 @@ function cacheIndicies() {
 }
 
 /**
- * todo: fix makeBlank
  * @description - combines all data needed for csv
  * @param {object} data - the data that the rest appends to
  * @param {object} contextId - to be merged in
@@ -56,14 +55,10 @@ function cacheIndicies() {
  * @param {boolean} - This is a temporary flag to hide bad data
  * @return {object}
  */
-export function combineData(data, contextId, username, timestamp, makeBlank = false) {
-  const blankParams = ['groupId', 'groupName', 'gateway Language Quote', 'occurrence', 'quote'];
+export function combineData(data, contextId, username, timestamp) {
   const flatContextId = flattenContextId(contextId);
   const userTimestamp = userTimestampObject(username, timestamp);
   const combinedData = Object.assign({}, data, flatContextId, userTimestamp);
-  if (makeBlank) blankParams.forEach((key) => {
-    if (combinedData[key]) combinedData[key] = '';
-  });
   return combinedData;
 }
 /**

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -162,7 +162,6 @@ export const saveSelections = state => {
  */
 export const saveVerseEdit = state => {
   try {
-    debugger;
     const projectSaveDir = getProjectSaveLocation(state);
     const verseEditPayload = getEditedVerse(state, state.contextIdReducer.contextId.tool);
     const {bookId, chapter, verse} = verseEditPayload.contextId.reference;

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -162,6 +162,7 @@ export const saveSelections = state => {
  */
 export const saveVerseEdit = state => {
   try {
+    debugger;
     const projectSaveDir = getProjectSaveLocation(state);
     const verseEditPayload = getEditedVerse(state, state.contextIdReducer.contextId.tool);
     const {bookId, chapter, verse} = verseEditPayload.contextId.reference;

--- a/src/js/reducers/__tests__/verseEditReducer.test.js
+++ b/src/js/reducers/__tests__/verseEditReducer.test.js
@@ -6,23 +6,26 @@ describe('verse edit reducer',  () => {
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
-      verseBefore: null,
-      verseAfter: null,
-      tags: null,
-      userName: null,
-      activeBook: null,
-      activeChapter: null,
-      activeVerse: null,
-      modifiedTimestamp: null,
-      gatewayLanguageCode: null,
-      gatewayLanguageQuote: null,
+      activeBook: null, 
+      activeChapter: null, 
+      activeVerse: null, 
+      gatewayLanguageCode: null, 
+      gatewayLanguageQuote: null, 
+      modifiedTimestamp: null, 
+      occurrence: null, quote: null, 
       reference: {
-        bookId: null,
-        chapter: null,
+        bookId: null, 
+        chapter: null, 
+        groupId: null, 
         verse: null
-      }
+      }, 
+      tags: null, 
+      userName: null, 
+      verseAfter: null, 
+      verseBefore: null
     });
   });
+
 
   it('should handle ADD_VERSE_EDIT with empty data', () => {
     expect(
@@ -120,8 +123,11 @@ describe('verse edit selectors', () => {
       reference: {
         bookId: 'book',
         chapter: 1,
-        verse: 2
-      }
+        verse: 2,
+        groupId:'group'
+      },
+      quote:'quote',
+      occurrence: 1
     };
     const saveState = getSaveStructure(state, 'wordAlignment');
     expect(saveState).toEqual({
@@ -132,14 +138,19 @@ describe('verse edit selectors', () => {
       modifiedTimestamp: timestamp,
       gatewayLanguageCode: 'code',
       gatewayLanguageQuote: 'quote',
+      occurrence: 1,
+      quote: "quote",
       contextId: {
         reference: {
           bookId: 'book',
           chapter: 1,
-          verse: 2
+          verse: 2,
+          groupId: "group"
         },
+        occurrence: 1,
+        quote: "quote",
         tool: 'wordAlignment',
-        groupId: 'chapter_1'
+        groupId: "group"
       }
     });
   });

--- a/src/js/reducers/verseEditReducer.js
+++ b/src/js/reducers/verseEditReducer.js
@@ -14,17 +14,16 @@ const initialState = {
   reference: {
     bookId: null,
     chapter: null,
-    verse: null
+    verse: null,
+    groupId: null
   },
   quote: null,
-  groupId: null,
   occurrence: null
 };
 
 const verseEditReducer = (state = initialState, action) => {
   switch (action.type) {
     case types.ADD_VERSE_EDIT:
-    debugger;
       return {
         ...state,
         verseBefore: action.before,
@@ -40,10 +39,10 @@ const verseEditReducer = (state = initialState, action) => {
         reference: {
           bookId: action.reference.bookId,
           chapter: action.reference.chapter,
-          verse: action.reference.verse
+          verse: action.reference.verse,
+          groupId: action.reference.groupId
         },
         quote: action.quote,
-        groupId: action.groupId,
         occurrence: action.occurrence
       };
     default:
@@ -60,13 +59,14 @@ export default verseEditReducer;
  * @return {*}
  */
 export const getSaveStructure = (state, toolName) => {
-  debugger;
   const obj = {
     ...state,
     contextId: {
       reference: state.reference,
       tool: toolName,
-      // groupId: `chapter_${state.reference.chapter}`
+      groupId: state.reference.groupId,
+      occurrence: state.occurrence,
+      quote: state.quote
     }
   };
   delete obj.reference;

--- a/src/js/reducers/verseEditReducer.js
+++ b/src/js/reducers/verseEditReducer.js
@@ -15,12 +15,16 @@ const initialState = {
     bookId: null,
     chapter: null,
     verse: null
-  }
+  },
+  quote: null,
+  groupId: null,
+  occurrence: null
 };
 
 const verseEditReducer = (state = initialState, action) => {
   switch (action.type) {
     case types.ADD_VERSE_EDIT:
+    debugger;
       return {
         ...state,
         verseBefore: action.before,
@@ -37,7 +41,10 @@ const verseEditReducer = (state = initialState, action) => {
           bookId: action.reference.bookId,
           chapter: action.reference.chapter,
           verse: action.reference.verse
-        }
+        },
+        quote: action.quote,
+        groupId: action.groupId,
+        occurrence: action.occurrence
       };
     default:
       return state;
@@ -53,12 +60,13 @@ export default verseEditReducer;
  * @return {*}
  */
 export const getSaveStructure = (state, toolName) => {
+  debugger;
   const obj = {
     ...state,
     contextId: {
       reference: state.reference,
       tool: toolName,
-      groupId: `chapter_${state.reference.chapter}`
+      // groupId: `chapter_${state.reference.chapter}`
     }
   };
   delete obj.reference;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR adds back the functionality for the CSV export for verse edits.

#### Please include detailed Test instructions for your pull request:
- Ensure that normal CSV functionalities are working
- Ensure that verse edit functionality is working correctly
- Main feature testing:
  - Import a project 
  - Do a verse edit
  - Export the project to CSV
  - Ensure that the csv includes the verse edit and has the following fields
  ```
    gateway Language Quote
    groupId
    groupName
    occurence
    quote
```

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5569)
<!-- Reviewable:end -->
