### PR TITLE
CSV External Edit Tool Name Fix

### DIFF
--- a/__tests__/ProjectOverwriteHelpers.test.js
+++ b/__tests__/ProjectOverwriteHelpers.test.js
@@ -96,5 +96,6 @@ describe('ProjectOverwriteHelpers.createVerseEditsForAllChangedVerses() tests', 
     const verseEdit = fs.readJsonSync(path.join(verseEditsPath, verseEditFiles[0]));
     expect(verseEdit['verseBefore']).toEqual(expectedVerseBefore);
     expect(verseEdit['verseAfter']).toEqual(expectedVerseAfter);
+    expect(verseEdit.contextId.tool).toEqual('[External edit]');
   });
 });

--- a/src/js/helpers/ProjectOverwriteHelpers.js
+++ b/src/js/helpers/ProjectOverwriteHelpers.js
@@ -130,7 +130,7 @@ export const createVerseEdit = (projectPath, verseBefore, verseAfter, bookId, ch
         chapter,
         verse
       },
-      tool: 'wordAlignment',
+      tool: '[External edit]',
       groupId: 'chapter_' + chapter
     },
   };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes a bug where edits from outside the tool were being logged as being done from the wordAlignment.

#### Please include detailed Test instructions for your pull request:
1. Import a project
2. Export the project to USFM2 (no alignments)
3. Edit the exported file to make changes to the verse texts
4. Save the edited USFM file
5. Import the edited file using the same translation id as the original and choose the overwrite options
6. Export the file to CSV
7. Ensure the VerseEdits CSV file have the `tool` field as `[External edit]`

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5619)
<!-- Reviewable:end -->
