### PR TITLE
QA Fail Fix Removing Unavailable Check Categories On Load

### DIFF
--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -31,9 +31,7 @@ export const loadCurrentCheckCategories = (toolName, bookName, projectSaveLocati
   return (dispatch, getState) => {
     const currentProjectToolsSelectedGL = getCurrentProjectToolsSelectedGL(getState());
     const availableCheckCategories = ProjectDetailsHelpers.getAvailableCheckCategories(currentProjectToolsSelectedGL);
-    console.log("availableCheckCategories", availableCheckCategories);
     let selectedCategories = ProjectDetailsHelpers.getCachedCategoriesFromProject(toolName, bookName, projectSaveLocation);
-    console.log("selectedCategories", selectedCategories);
     selectedCategories = selectedCategories.filter((category) => availableCheckCategories[toolName] && availableCheckCategories[toolName].includes(category));
     dispatch(setCategories(selectedCategories, toolName));
   };

--- a/src/js/containers/home/ToolsManagementContainer.js
+++ b/src/js/containers/home/ToolsManagementContainer.js
@@ -7,7 +7,7 @@ import HomeContainerContentWrapper
 import * as ProjectDetailsActions from "../../actions/ProjectDetailsActions";
 import * as ProjectDetailsHelpers from "../../helpers/ProjectDetailsHelpers";
 import {
-  getTools, getIsUserLoggedIn
+  getTools, getIsUserLoggedIn, getProjectSaveLocation, getProjectBookId
 } from "../../selectors";
 import { openTool } from "../../actions/ToolActions";
 import { openAlertDialog } from "../../actions/AlertModalActions";
@@ -16,6 +16,17 @@ class ToolsManagementContainer extends Component {
   constructor(props) {
     super(props);
     this.handleSelectTool = this.handleSelectTool.bind(this);
+  }
+
+  componentDidMount() {
+    const {tools, reducers} = this.props;
+    const projectSaveLocation = getProjectSaveLocation(reducers);
+    const bookId = getProjectBookId(reducers);
+    if (projectSaveLocation && bookId) {
+      tools.forEach(({name:toolName}) => {
+        this.props.actions.loadCurrentCheckCategories(toolName, bookId, projectSaveLocation);
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- If the user checks a category i.e. names and then deletes the names folder, that check is still being saved as selected in the future. This fixes that bug.

#### Please include detailed Test instructions for your pull request:
- Load a project select all the check categories
- Delete one category such as "names" from the fs.(`~/translationCore/resources/en/translationHelps/translationWords/v9/names`)
- Reload tC
- Go to same project, uncheck all categories
- The launch button should be disabled


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5637)
<!-- Reviewable:end -->
