### PR TITLE
Bugfix mcleanb 5513/Fix export of alignments with numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15577,8 +15577,9 @@
       }
     },
     "word-aligner": {
-      "version": "github:translationCoreApps/word-aligner#e509713e8305b75451a1456edad9d2f3edcbd363",
-      "from": "github:translationCoreApps/word-aligner#bugfix-mcleanb-5513",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.2.10.tgz",
+      "integrity": "sha512-q/hHJgevdTZUNliin143IfEkeQF/kdNruPHOmmeBCiFx7552e3PBg4wm45i5wSqIPacAUXtdOEDxd8waXeMwsw==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "fs-extra": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15577,9 +15577,8 @@
       }
     },
     "word-aligner": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.2.9.tgz",
-      "integrity": "sha512-26FdD/EB55J/cHlolFEPJw5pIePNfDl+DMxoFEe0BSEfeoLfWGqAuc9rzBF0WObxRKiLq1UeSfaaKWLpHTKSaQ==",
+      "version": "github:translationCoreApps/word-aligner#e509713e8305b75451a1456edad9d2f3edcbd363",
+      "from": "github:translationCoreApps/word-aligner#bugfix-mcleanb-5513",
       "requires": {
         "babel-runtime": "^6.26.0",
         "fs-extra": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "truncate-utf8-bytes": "1.0.2",
     "usfm-js": "1.0.12",
     "uuid": "3.2.1",
-    "word-aligner": "0.2.9",
+    "word-aligner": "github:translationCoreApps/word-aligner#bugfix-mcleanb-5513",
     "wordmap": "0.4.3",
     "wordmap-lexer": "0.3.4",
     "xregexp": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "truncate-utf8-bytes": "1.0.2",
     "usfm-js": "1.0.12",
     "uuid": "3.2.1",
-    "word-aligner": "github:translationCoreApps/word-aligner#bugfix-mcleanb-5513",
+    "word-aligner": "0.2.10",
     "wordmap": "0.4.3",
     "wordmap-lexer": "0.3.4",
     "xregexp": "3.2.0",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- merged word-aligner fixes that were in v1.0.3

#### Please include detailed Test instructions for your pull request:
- use steps at end of attached issue (https://github.com/unfoldingWord-dev/translationCore/issues/5647) to align 430.  On upload or export with alignments should not get alignments reset warning.
![screen shot 2019-01-09 at 1 49 58 pm](https://user-images.githubusercontent.com/14238574/50921546-4fabb580-1416-11e9-991f-099a60a7996b.png)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5650)
<!-- Reviewable:end -->

