### PR TITLE
fixes the renaming dialogs so they do not disappear right away

### DIFF
--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -291,9 +291,9 @@ export function doRenamePrompting() {
     const {projectDetailsReducer: {projectSaveLocation}, loginReducer: login} = getState();
     const pointsToCurrentUsersRepo = await GogsApiHelpers.hasGitHistoryForCurrentUser(projectSaveLocation, login);
     if (pointsToCurrentUsersRepo) {
-      dispatch(ProjectDetailsHelpers.doDcsRenamePrompting());
+      await dispatch(ProjectDetailsHelpers.doDcsRenamePrompting());
     } else { // do not rename on dcs
-      dispatch(ProjectDetailsHelpers.showRenamedDialog());
+      await dispatch(ProjectDetailsHelpers.showRenamedDialog());
     }
   });
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to #5618
- Corrects the rename dialog so it stays open until dismissed.

#### Please include detailed Test instructions for your pull request:
- Import a usfm project. The rename dialog should appear and wait for you to dismiss it before the project finishes loading.
- do the same for an online import.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5661)
<!-- Reviewable:end -->
