### PR TITLE
Fix - #5676 - Fixes getting aligned GL text when no quote

### DIFF
--- a/src/js/helpers/gatewayLanguageHelpers.js
+++ b/src/js/helpers/gatewayLanguageHelpers.js
@@ -397,7 +397,7 @@ console.log("bibles: ", bibles);
 console.log("currentToolName: ", currentToolName);
   const selectedGL = currentProjectToolsSelectedGL[currentToolName];
 console.log("selectedGL: ", selectedGL);
-  if (!contextId.quote || ! bibles || ! bibles[selectedGL] || ! Object.keys(bibles[selectedGL]).length)
+  if (! contextId.quote || ! bibles || ! bibles[selectedGL] || ! Object.keys(bibles[selectedGL]).length)
     return contextId.quote;
   const sortedBibleIds = Object.keys(bibles[selectedGL]).sort(bibleIdSort);
   for (let i = 0; i < sortedBibleIds.length; ++i) {

--- a/src/js/helpers/gatewayLanguageHelpers.js
+++ b/src/js/helpers/gatewayLanguageHelpers.js
@@ -397,7 +397,7 @@ console.log("bibles: ", bibles);
 console.log("currentToolName: ", currentToolName);
   const selectedGL = currentProjectToolsSelectedGL[currentToolName];
 console.log("selectedGL: ", selectedGL);
-  if(! bibles || ! bibles[selectedGL] || ! Object.keys(bibles[selectedGL]).length)
+  if (!contextId.quote || ! bibles || ! bibles[selectedGL] || ! Object.keys(bibles[selectedGL]).length)
     return contextId.quote;
   const sortedBibleIds = Object.keys(bibles[selectedGL]).sort(bibleIdSort);
   for (let i = 0; i < sortedBibleIds.length; ++i) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- For bug fix of #5676 and #5680 and #5678 

#### Please include detailed Test instructions for your pull request:
- Load Titus English project
- Go into tW and make a selection for Titus 1:6 for "accuse"
- Go into wA and click on 1:6 and expand scripture pane and edit 1:6. Change the "accused" word in that verse, hit next and give a reason and save.
- Change should persist, no "split" error message in console log.
- Then check in tW that when you select and edit a verse that the selected text does become invalid.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5682)
<!-- Reviewable:end -->
