### PR TITLE
updates tc-ui-toolkit dependency so we get the new menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14350,15 +14350,16 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.12.11",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.12.11.tgz",
-      "integrity": "sha512-GwRZuM0jZqJf4gu819uE1Wz/k5bRu+Jzeh5pSyVOsMfSADsyW2VRuy25Sc2FP7htr7S9zhAXfiw/oIBuIAdVaQ==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.13.11.tgz",
+      "integrity": "sha512-Jlpx4gc7orfJ6Zdh321NaRumWJvZPjG6r2IECL4g8unpih16kd8qkKS6LhuHbNTy+RmYEuf6mLP4dNDWmfclHA==",
       "requires": {
-        "@material-ui/core": "^3.8.1",
-        "@material-ui/icons": "^3.0.1",
+        "@material-ui/core": "^3.8.3",
+        "@material-ui/icons": "^3.0.2",
         "deep-equal": "^1.0.1",
         "jest-environment-jsdom": "^23.4.0",
         "lodash": "^4.17.5",
+        "memoize-one": "^5.0.0",
         "prop-types": "^15.6.1",
         "react-bootstrap": "^0.32.1",
         "react-container-dimensions": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "tc-source-content-updater": "0.3.4",
     "tc-strings": "0.1.7",
     "tc-tool": "2.1.0",
-    "tc-ui-toolkit": "0.12.11",
+    "tc-ui-toolkit": "0.13.11",
     "truncate-utf8-bytes": "1.0.2",
     "usfm-js": "1.0.12",
     "uuid": "3.2.1",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to #4443 

- update the toolkit

Merging this in will provide access to the new `GroupedMenu`. This is blocking the following PRs

* https://github.com/translationCoreApps/wordAlignment/pull/143
* https://github.com/translationCoreApps/translationWords/pull/226

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5715)
<!-- Reviewable:end -->
