### PR TITLE
Bugfix 5714/Fix lexicon entries to read from latest version

### DIFF
--- a/__tests__/LexiconHelpers.test.js
+++ b/__tests__/LexiconHelpers.test.js
@@ -5,6 +5,10 @@ import ospath from 'ospath';
 import * as LexiconHelpers from '../src/js/helpers/LexiconHelpers';
 
 describe('LexiconHelpers', () => {
+  beforeEach(() => {
+    fs.__resetMockFS();
+  });
+
   test('LexiconHelpers.getLexiconData loads lexicon data for a specific lexiconIda and entryId', () => {
     const languageId = 'en';
     const resourceVersion = 'v0';
@@ -15,9 +19,26 @@ describe('LexiconHelpers', () => {
       "brief": "the first letter of the Greek alphabet",
       "long": "alpha; the first letter of the Greek alphabet."
     };
-    fs.__setMockFS({
-      [lexiconFilePath]: lexiconContent
-    });
+    fs.outputFileSync(lexiconFilePath, lexiconContent);
+    const expectedResult = {
+      [lexiconId]: {
+        [entryId]: lexiconContent
+      }
+    };
+    expect(LexiconHelpers.getLexiconData(lexiconId, entryId)).toEqual(expectedResult);
+  });
+
+  test('LexiconHelpers.getLexiconData loads lexicon data for v0.1 resource', () => {
+    const languageId = 'en';
+    const resourceVersion = 'v0.1';
+    const lexiconId = 'uhl';
+    const entryId = '1';
+    const lexiconFilePath = path.join(ospath.home(), 'translationCore', 'resources', languageId, 'lexicons', lexiconId, resourceVersion, 'content', '1.json');
+    const lexiconContent = {
+      "brief": "father",
+      "long": "<i>Meaning:</i> \"father\", in a literal and immediate, or figurative and remote application.<br/><i>Usage:</i> chief, (fore-) father(-less), × patrimony, principal. Compare names in 'Abi-'.<br/><i>Source:</i> a primitive word;"
+    };
+    fs.outputFileSync(lexiconFilePath, lexiconContent);
     const expectedResult = {
       [lexiconId]: {
         [entryId]: lexiconContent

--- a/src/js/helpers/LexiconHelpers.js
+++ b/src/js/helpers/LexiconHelpers.js
@@ -1,16 +1,16 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
+import ResourceAPI from "./ResourceAPI";
 // constants
 const USER_RESOURCES_PATH = path.join(ospath.home(), 'translationCore', 'resources');
 
 export function getLexiconData(lexiconId, entryId) {
   try {
-    const languageId = 'en';
-    const resourceVersion = 'v0';
-    // generate path from resourceType and articleId
-    const lexiconPath = path.join(USER_RESOURCES_PATH, languageId, 'lexicons', lexiconId, resourceVersion, 'content');
-    const entryPath = path.join(lexiconPath, entryId + '.json');
+    const languageId = 'en'; // TODO: need to add other language support
+    // generate path from resourceType and articleId and get latest version
+    const latestVersion = ResourceAPI.getLatestVersion(path.join(USER_RESOURCES_PATH, languageId, 'lexicons', lexiconId));
+    const entryPath = path.join(latestVersion, 'content', entryId + '.json');
     let entryData;
     if (fs.existsSync(entryPath)) {
       entryData = fs.readJsonSync(entryPath, 'utf8'); // get file from fs

--- a/src/js/helpers/LexiconHelpers.js
+++ b/src/js/helpers/LexiconHelpers.js
@@ -9,8 +9,8 @@ export function getLexiconData(lexiconId, entryId) {
   try {
     const languageId = 'en'; // TODO: need to add other language support
     // generate path from resourceType and articleId and get latest version
-    const latestVersion = ResourceAPI.getLatestVersion(path.join(USER_RESOURCES_PATH, languageId, 'lexicons', lexiconId));
-    const entryPath = path.join(latestVersion, 'content', entryId + '.json');
+    const latestVersionPath = ResourceAPI.getLatestVersion(path.join(USER_RESOURCES_PATH, languageId, 'lexicons', lexiconId));
+    const entryPath = path.join(latestVersionPath, 'content', entryId + '.json');
     let entryData;
     if (fs.existsSync(entryPath)) {
       entryData = fs.readJsonSync(entryPath, 'utf8'); // get file from fs


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixed version path for getLexiconData()

#### Please include detailed Test instructions for your pull request:
- before testing delete version folder `resources/en/lexicons/uhl/v0`
- in OT books opened in WA, the word popup the Lexicon entry should not be empty.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5719)
<!-- Reviewable:end -->
