### PR TITLE
deselects the project after saving project information

### DIFF
--- a/__tests__/ProjectDetailsActions.test.js
+++ b/__tests__/ProjectDetailsActions.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 jest.mock('fs-extra');
 jest.mock('../src/js/helpers/ProjectAPI');
+jest.mock('../')
 import fs from 'fs-extra';
 import path from 'path-extra';
 import ospath from 'ospath';
@@ -297,9 +298,11 @@ describe('ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting()', (
     const store = mockStore(storeData);
 
     // when
-    await store.dispatch(actions.updateProjectNameIfNecessaryAndDoPrompting());
+    const results = {};
+    await store.dispatch(actions.updateProjectNameIfNecessary(results));
 
     // then
+    expect(results.repoRenamed).toBe(true);
     expect(cleanupPaths(store.getActions())).toMatchSnapshot();
     expect(fs.pathExistsSync(currentProjectPath)).not.toBeTruthy();
     expect(fs.pathExistsSync(expectedProjectPath)).toBeTruthy();
@@ -314,9 +317,11 @@ describe('ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting()', (
     const store = mockStore(storeData);
 
     // when
-    await store.dispatch(actions.updateProjectNameIfNecessaryAndDoPrompting());
+    const results = {};
+    await store.dispatch(actions.updateProjectNameIfNecessary(results));
 
     // then
+    expect(results.repoRenamed).toBe(true);
     cleanupPaths(store.getActions());
     expect(fs.pathExistsSync(currentProjectPath)).not.toBeTruthy();
     expect(fs.pathExistsSync(expectedProjectPath)).toBeTruthy();
@@ -331,9 +336,11 @@ describe('ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting()', (
     const store = mockStore(storeData);
 
     // when
-    await store.dispatch(actions.updateProjectNameIfNecessaryAndDoPrompting());
+    const results = {};
+    await store.dispatch(actions.updateProjectNameIfNecessary(results));
 
     // then
+    expect(results.repoRenamed).toBe(true);
     expect(cleanupPaths(store.getActions())).toMatchSnapshot();
     expect(fs.pathExistsSync(currentProjectPath)).not.toBeTruthy();
     expect(fs.pathExistsSync(expectedProjectPath)).toBeTruthy();
@@ -350,9 +357,11 @@ describe('ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting()', (
     const store = mockStore(storeData);
 
     // when
-    await store.dispatch(actions.updateProjectNameIfNecessaryAndDoPrompting());
+    const results = {};
+    await store.dispatch(actions.updateProjectNameIfNecessary(results));
 
     // then
+    expect(results.repoRenamed).toBe(true);
     expect(cleanupPaths(store.getActions())).toMatchSnapshot();
     expect(fs.pathExistsSync(currentProjectPath)).not.toBeTruthy();
     expect(fs.pathExistsSync(expectedProjectPath)).toBeTruthy();

--- a/__tests__/__snapshots__/ProjectDetailsActions.test.js.snap
+++ b/__tests__/__snapshots__/ProjectDetailsActions.test.js.snap
@@ -12,15 +12,6 @@ Array [
     "pathLocation": "am_ult_eph_book",
     "type": "SET_SAVE_PATH_LOCATION",
   },
-  Object {
-    "alertMessage": "projects.renamed_project",
-    "button1Text": "buttons.ok_button",
-    "button2Text": undefined,
-    "buttonLinkText": null,
-    "callback": [Function],
-    "callback2": null,
-    "type": "OPEN_OPTION_DIALOG",
-  },
 ]
 `;
 
@@ -30,15 +21,6 @@ Array [
     "pathLocation": "fr_ult_eph_book",
     "type": "SET_SAVE_PATH_LOCATION",
   },
-  Object {
-    "alertMessage": "projects.renamed_project",
-    "button1Text": "buttons.ok_button",
-    "button2Text": undefined,
-    "buttonLinkText": null,
-    "callback": [Function],
-    "callback2": null,
-    "type": "OPEN_OPTION_DIALOG",
-  },
 ]
 `;
 
@@ -47,15 +29,6 @@ Array [
   Object {
     "pathLocation": "fr_lib_eph_book",
     "type": "SET_SAVE_PATH_LOCATION",
-  },
-  Object {
-    "alertMessage": "projects.renamed_project",
-    "button1Text": "buttons.ok_button",
-    "button2Text": undefined,
-    "buttonLinkText": null,
-    "callback": [Function],
-    "callback2": null,
-    "type": "OPEN_OPTION_DIALOG",
   },
 ]
 `;

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -103,7 +103,7 @@ export const localImport = () => {
     // Either import was canceled or error occurred. We clean up here.
     // clear last project must be called before any other action.
     // to avoid triggering auto-saving.
-    dispatch(ProjectLoadingActions.clearLastProject());
+    dispatch(ProjectLoadingActions.closeProject());
     dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
     // remove failed project import
     const projectName = getState().localImportReducer.selectedProjectFilename;

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -131,7 +131,7 @@ export const onlineImport = () => {
  */
 export const recoverFailedOnlineImport = (errorMessage) => (dispatch) => {
   // TRICKY: clear last project first to avoid triggering autos-saving.
-  dispatch(ProjectLoadingActions.clearLastProject());
+  dispatch(ProjectLoadingActions.closeProject());
   dispatch(AlertModalActions.openAlertDialog(errorMessage));
   dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
   dispatch({ type: "LOADED_ONLINE_FAILED" });

--- a/src/js/actions/Import/ProjectValidationActions.js
+++ b/src/js/actions/Import/ProjectValidationActions.js
@@ -56,7 +56,7 @@ export const validateProject = (projectPath) => {
  */
 export const setUpProjectDetails = (projectPath, dispatch) => {
   return new Promise((resolve) => {
-    dispatch(ProjectLoadingActions.clearLastProject());
+    dispatch(ProjectLoadingActions.closeProject());
     let manifest = manifestHelpers.getProjectManifest(projectPath);
     dispatch(ProjectLoadingActions.loadProjectDetails(projectPath, manifest));
     resolve();

--- a/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
+++ b/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
@@ -46,7 +46,7 @@ jest.mock('../ProjectImportFilesystemActions', () => ({
 }));
 jest.mock('../../MyProjects/MyProjectsActions', () => ({ getMyProjects: () => ({ type: 'GET_MY_PROJECTS' }) }));
 jest.mock('../../MyProjects/ProjectLoadingActions', () => ({
-  clearLastProject: () => ({ type: 'CLEAR_LAST_PROJECT' }),
+  closeProject: () => ({ type: 'CLEAR_LAST_PROJECT' }),
   displayTools: jest.fn(() => ({ type: 'DISPLAY_TOOLS' }))
 }));
 jest.mock('../../../helpers/TargetLanguageHelpers', ()=> ({

--- a/src/js/actions/LoginActions.js
+++ b/src/js/actions/LoginActions.js
@@ -49,7 +49,7 @@ export function logoutUser() {
     dispatch({
       type: types.LOGOUT_USER
     });
-    dispatch(ProjectLoadingActions.clearLastProject());
+    dispatch(ProjectLoadingActions.closeProject());
     dispatch(BodyUIActions.toggleHomeView(true));
     dispatch({ type: types.RESET_ONLINE_MODE_WARNING_ALERT });
     dispatch(BodyUIActions.goToStep(1));

--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -103,7 +103,7 @@ export const openProject = (name, skipValidation=false) => {
       if (e.type !== 'div') console.warn(e);
       // clear last project must be called before any other action.
       // to avoid triggering autosaving.
-      dispatch(clearLastProject());
+      dispatch(closeProject());
       dispatch(openAlertDialog(e));
       dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
     }
@@ -216,7 +216,7 @@ export function displayTools() {
  * @description - Wrapper to clear everything in the store that could
  * prevent a new project from loading
  */
-export function clearLastProject() {
+export function closeProject() {
   return (dispatch) => {
     /**
      * ATTENTION: THE project details reducer must be reset

--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -337,7 +337,7 @@ export function updateProjectNameIfNecessaryAndDoPrompting() {
     const renamingResults = {};
     await dispatch(updateProjectNameIfNecessary(renamingResults));
     if (renamingResults.repoRenamed) {
-      dispatch(doRenamePrompting());
+      await dispatch(doRenamePrompting());
     }
   });
 }

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -168,7 +168,7 @@ export function removeProjectValidationStep(namespace) {
 export function cancelProjectValidationStepper() {
   return ((dispatch, getState) => {
     dispatch(toggleProjectValidationStepper(false));
-    dispatch(ProjectLoadingActions.clearLastProject());
+    dispatch(ProjectLoadingActions.closeProject());
     dispatch({ type: consts.CLEAR_COPYRIGHT_CHECK_REDUCER });
     dispatch({ type: consts.CLEAR_PROJECT_INFORMATION_REDUCER });
     dispatch({ type: consts.CLEAR_MERGE_CONFLICTS_REDUCER });

--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -17,6 +17,7 @@ import * as ProjectValidationActions from './Import/ProjectValidationActions';
 import * as AlertModalActions from './AlertModalActions';
 import {getTranslate} from '../selectors';
 import BooksOfBible from '../../../tcResources/books';
+import { closeProject } from "./MyProjects/ProjectLoadingActions";
 
 // constants
 const PROJECT_INFORMATION_CHECK_NAMESPACE = 'projectInformationCheck';
@@ -111,7 +112,7 @@ export function finalize() {
       } catch (error) {
         dispatch(AlertModalActions.openAlertDialog(error));
         dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
-        dispatch(ProjectLoadingActions.clearLastProject());
+        dispatch(closeProject());
       }
     }
   });
@@ -480,9 +481,10 @@ export function saveAndCloseProjectInformationCheckIfValid() {
       dispatch(ProjectImportStepperActions.removeProjectValidationStep(PROJECT_INFORMATION_CHECK_NAMESPACE));
       dispatch(ProjectImportStepperActions.toggleProjectValidationStepper(false));
       dispatch({type: consts.ONLY_SHOW_PROJECT_INFORMATION_SCREEN, value: false});
-      dispatch(ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting()).then(() => {
-        dispatch(MyProjectsActions.getMyProjects());
-      });
+      await dispatch(ProjectDetailsActions.updateProjectNameIfNecessaryAndDoPrompting());
+      // TRICKY: close the project so that changes can be re-loaded by the tools.
+      dispatch(closeProject());
+      dispatch(MyProjectsActions.getMyProjects());
     }
   });
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
Related to #5657 
- The project is now de-selected after editing it's information from the project details dialog.

This ensures the tools are not looking in the wrong location for the project.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5736)
<!-- Reviewable:end -->
