### PR TITLE
Fix Tool Invalidated System For TranslationWords

### DIFF
--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -11,6 +11,8 @@ import * as ProjectDetailsActions from '../ProjectDetailsActions';
 import * as ProjectImportStepperActions from '../ProjectImportStepperActions';
 //helpers
 import * as manifestHelpers from '../../helpers/manifestHelpers';
+import { changeSelections } from '../SelectionsActions';
+
 import {
   getActiveLocaleLanguage,
   getProjectManifest,
@@ -159,7 +161,10 @@ function makeToolProps(dispatch, state, projectDir, bookId) {
         verse: "1"
       }
     },
-
+    username: getUsername(state),
+    changeSelections: (selections, userName) => {
+      dispatch(changeSelections(selections, userName));
+    },
     // deprecated props
     readProjectDir: (...args) => {
       console.warn('DEPRECATED: readProjectDir is deprecated. Use readProjectDataDir instead.');


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix for the translationWords invalidated selection notification.

#### Please include detailed Test instructions for your pull request:
1. Open tW
2. Make a selection in tW (note the word/s you selected)
3. Open wA
4. Open the expanded scripture pane , edit the word(s) you selected
5. Go back to the tools card on the home page.
6. Ensure there is a broken link icon on the translationWords tool card

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5744)
<!-- Reviewable:end -->
