### PR TITLE
tW Invalidation Loading At Project Load fix

### DIFF
--- a/src/js/actions/CheckDataLoadActions.js
+++ b/src/js/actions/CheckDataLoadActions.js
@@ -207,15 +207,17 @@ export function loadSelections() {
         type: consts.CHANGE_SELECTIONS,
         modifiedTimestamp: selectionsObject.modifiedTimestamp,
         selections: selectionsObject.selections,
-        userName: selectionsObject.userName
+        userName: selectionsObject.userName,
+        gatewayLanguageCode: selectionsObject.gatewayLanguageCode,
+        gatewayLanguageQuote: selectionsObject.gatewayLanguageQuote
       });
     } else {
       // The object is undefined because the file wasn't found in the directory thus we init the reducer to a default value.
       dispatch({
         type: consts.CHANGE_SELECTIONS,
-        modifiedTimestamp: "",
+        modifiedTimestamp: null,
         selections: [],
-        userName: ""
+        userName: null
       });
     }
   };

--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -166,8 +166,10 @@ function makeToolProps(dispatch, state, projectDir, bookId) {
       }
     },
     username: getUsername(state),
-    changeSelections: (selections, userName) => {
-      dispatch(changeSelections(selections, userName));
+    actions: {
+      changeSelections: (selections, userName) => {
+        dispatch(changeSelections(selections, userName));
+      }
     },
     // deprecated props
     readProjectDir: (...args) => {

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -2,14 +2,14 @@ import types from './ActionTypes';
 import isEqual from 'deep-equal';
 import path from 'path-extra';
 import fs from 'fs-extra';
-import { checkSelectionOccurrences } from 'selections';
+import {checkSelectionOccurrences} from 'selections';
 // actions
 import * as AlertModalActions from './AlertModalActions';
 import * as InvalidatedActions from './InvalidatedActions';
 import * as CheckDataLoadActions from './CheckDataLoadActions';
 // helpers
 import {getTranslate, getUsername, getSelectedToolName} from '../selectors';
-import { generateTimestamp } from '../helpers/index';
+import {generateTimestamp} from '../helpers/index';
 import * as gatewayLanguageHelpers from '../helpers/gatewayLanguageHelpers';
 import * as saveMethods from "../localStorage/saveMethods";
 import usfm from "usfm-js";
@@ -34,7 +34,7 @@ export const changeSelections = (selections, userName, invalidated = false, cont
         gatewayLanguageQuote
       } = gatewayLanguageHelpers.getGatewayLanguageCodeAndQuote(getState(), contextId);
       if (sameContext(currentContextId, contextId)) { // see if we need to update current selection
-        const modifiedTimestamp = generateTimestamp();       
+        const modifiedTimestamp = generateTimestamp();
         dispatch({
           type: types.CHANGE_SELECTIONS,
           modifiedTimestamp: modifiedTimestamp,
@@ -43,7 +43,6 @@ export const changeSelections = (selections, userName, invalidated = false, cont
           selections,
           userName
         });
-
         dispatch(InvalidatedActions.set(userName, modifiedTimestamp, invalidated));
       } else {
         saveMethods.saveSelectionsForOtherContext(getState(), gatewayLanguageCode, gatewayLanguageQuote, selections, invalidated, userName, contextId);
@@ -86,56 +85,43 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
   return (dispatch, getState) => {
     const state = getState();
     contextId = contextId || state.contextIdReducer.contextId;
-    const { projectSaveLocation, manifest: { project } } = state.projectDetailsReducer;
-    const { bookId, chapter, verse } = contextId.reference;
-
+    const {projectSaveLocation} = state.projectDetailsReducer;
+    const {bookId, chapter, verse} = contextId.reference;
+    const selectionsObject = getSelectionsFromChapterAndVerseCombo(
+      bookId,
+      chapterNumber || chapter,
+      verseNumber || verse,
+      projectSaveLocation
+    );
+    const {selections, gatewayLanguageCode, gatewayLanguageQuote} = selectionsObject;
+    const validSelections = checkSelectionOccurrences(targetVerse, selections);
+    const selectionsChanged = !isEqual(selections, validSelections);
     if (getSelectedToolName(state) === 'translationWords') {
       const username = getUsername(state);
-      const selections = getSelectionsFromChapterAndVerseCombo(
-        bookId,
-        chapterNumber || chapter,
-        verseNumber || verse,
-        projectSaveLocation
-      );
-      const validSelections = checkSelectionOccurrences(targetVerse, selections);
-      const selectionsChanged = (selections.length !== validSelections.length);
       if (selectionsChanged) {
+        //If the selections are invalidated then we need to clear the selections for the verse
         dispatch(changeSelections([], username, true, contextId)); // clear selections
       }
-      const results = {selectionsChanged: selectionsChanged};
+      const results = {selectionsChanged};
       dispatch(validateAllSelectionsForVerse(targetVerse, results, true, contextId, true));
     } else if (getSelectedToolName(state) === 'wordAlignment') {
-      const bibleId = project.id;
-      const selectionsPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'selections', bibleId, chapter.toString(), verse.toString());
-
-      if (fs.existsSync(selectionsPath)) {
-        let files = fs.readdirSync(selectionsPath);
-        files = files.filter(file => { // filter the filenames to only use .json
-          return path.extname(file) === '.json';
-        });
-        const sorted = files.sort().reverse(); // sort the files to use latest
-        const filename = sorted[0];
-        const selectionsData = fs.readJsonSync(path.join(selectionsPath, filename));
-        const validSelections = checkSelectionOccurrences(targetVerse, selectionsData.selections);
-
-        if (!isEqual(selectionsData.selections, validSelections)) { // if true found invalidated check
-          const username = getUsername(state);
-          const modifiedTimestamp = generateTimestamp();
-          const invalidted = {
-            contextId: selectionsData.contextId,
-            invalidated: true,
-            userName: username,
-            modifiedTimestamp: modifiedTimestamp,
-            gatewayLanguageCode: selectionsData.gatewayLanguageCode,
-            gatewayLanguageQuote: selectionsData.gatewayLanguageQuote
-          };
-          const newFilename = modifiedTimestamp + '.json';
-          const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bibleId, chapter.toString(), verse.toString());
-          fs.outputJSONSync(path.join(invalidatedCheckPath, newFilename.replace(/[:"]/g, '_')), invalidted);
-        }
+      if (selectionsChanged) {
+        const username = getUsername(state);
+        const modifiedTimestamp = generateTimestamp();
+        const invalidted = {
+          contextId,
+          invalidated: true,
+          userName: username,
+          modifiedTimestamp: modifiedTimestamp,
+          gatewayLanguageCode,
+          gatewayLanguageQuote
+        };
+        const newFilename = modifiedTimestamp + '.json';
+        const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bookId, chapter.toString(), verse.toString());
+        fs.outputJSONSync(path.join(invalidatedCheckPath, newFilename.replace(/[:"]/g, '_')), invalidted);
       }
     }
-  };
+  }
 };
 
 /**
@@ -203,7 +189,7 @@ export const getGroupDataForVerse = (state, contextId) => {
               }
               filteredGroupData[groupItemKey].push(check);
             }
-          } catch(e) {
+          } catch (e) {
             console.warn(`Corrupt check found in group "${groupItemKey}"`, check);
           }
         }
@@ -247,8 +233,7 @@ export const getSelectionsFromContextId = (contextId, projectSaveLocation) => {
 
 
 export const getSelectionsFromChapterAndVerseCombo = (bookId, chapter, verse, projectSaveLocation) => {
-  let selectionsArray = [];
-  let selectionsObject;
+  let selectionsObject = {};
   const contextId = {
     reference: {
       bookId,
@@ -267,10 +252,5 @@ export const getSelectionsFromChapterAndVerseCombo = (bookId, chapter, verse, pr
     const filename = sorted[0];
     selectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
   }
-
-  if (selectionsObject) {
-    selectionsArray = selectionsObject.selections;
-  }
-
-  return selectionsArray;
+  return selectionsObject;
 };

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -86,11 +86,11 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
     const state = getState();
     contextId = contextId || state.contextIdReducer.contextId;
     const {projectSaveLocation} = state.projectDetailsReducer;
-    const {bookId, chapter, verse} = contextId.reference;
+    const {bookId, chapter:chapterFromContextId, verse: verseFromContextId} = contextId.reference;
     const selectionsObject = getSelectionsFromChapterAndVerseCombo(
       bookId,
-      chapterNumber || chapter,
-      verseNumber || verse,
+      chapterNumber || chapterFromContextId,
+      verseNumber || verseFromContextId,
       projectSaveLocation
     );
     const {selections, gatewayLanguageCode, gatewayLanguageQuote} = selectionsObject;
@@ -121,7 +121,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
         fs.outputJSONSync(path.join(invalidatedCheckPath, newFilename.replace(/[:"]/g, '_')), invalidted);
       }
     }
-  }
+  };
 };
 
 /**

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -8,6 +8,7 @@ import path from 'path-extra';
 import isEqual from "deep-equal";
 import {getEditedVerse, getProjectSaveLocation} from '../selectors';
 import {generateTimestamp} from "../helpers";
+import * as CheckDataLoadActions from '../actions/CheckDataLoadActions';
 
 const PARENT = path.datadir('translationCore');
 const SETTINGS_DIRECTORY = path.join(PARENT, 'settings.json');
@@ -40,7 +41,9 @@ function saveData(state, checkDataName, payload, modifiedTimestamp) {
     if (savePath !== undefined) {
       // since contextId updates and triggers the rest to load, contextId get's updated and fires this.
       // let's not overwrite files, so check to see if it exists.
-      if (!fs.existsSync(savePath)) {
+      const saveDir = path.parse(savePath).dir;
+      const existingPayload = CheckDataLoadActions.loadCheckData(saveDir, payload.contextId);
+      if (!fs.existsSync(savePath) && !isEqual(existingPayload, payload)) {
         fs.outputJsonSync(savePath, payload, err => {console.log(err)});
       }
     } else {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes tW invalidations not showing up for external edits

#### Please include detailed Test instructions for your pull request:
- Checkout branch `bugfix-jay-5686-2` on tW
- Open any project and make a selection (Not the word and verse you select)
- Export the project to USFM not including the alignment data
- Make edits to the USFM file that wil break the selections.
- Import the USFM file giving it the same translation ID as the original, and choose the Overwrite options
- When the project opens you should see the broken link on the tool card from the verse you invalidated.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5822)
<!-- Reviewable:end -->
