### PR TITLE
Fix For Verse Edits Not Saving

### DIFF
--- a/__tests__/SelectionsActions.test.js
+++ b/__tests__/SelectionsActions.test.js
@@ -6,6 +6,7 @@ import fs from "fs-extra";
 import {generateTimestamp} from "../src/js/helpers";
 import * as SelectionsActions from '../src/js/actions/SelectionsActions';
 import * as saveMethods from "../src/js/localStorage/saveMethods";
+import * as selections from 'selections';
 // constants
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -136,6 +137,25 @@ describe('SelectionsActions.validateSelections', () => {
     const actions = store.getActions();
     expect(actions.length).toEqual(0);
     expect(saveOtherContextSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('No previous selection changes', () => {
+    // given
+    const targetVerse = "A verse";
+    const projectPath = path.join(PROJECTS_PATH, 'en_tit');
+    const initialState = getInitialStateData(bookId, projectPath);
+    initialState.contextIdReducer.contextId.reference.verse = 15;
+    initialState.contextIdReducer.contextId.groupId = 'believe';
+    const store = mockStore(initialState);
+    const checkSelectionOccurrencesSpy = jest.spyOn(selections, 'checkSelectionOccurrences');
+
+    // when
+    store.dispatch(SelectionsActions.validateSelections(targetVerse));
+
+    // then
+    const actions = store.getActions();
+    expect(actions.length).toEqual(0);
+    expect(checkSelectionOccurrencesSpy).toHaveBeenCalledWith('A verse', expect.any(Array));
   });
 
   it('apostle selection edited', () => {

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -93,7 +93,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
       verseNumber || verseFromContextId,
       projectSaveLocation
     );
-    const {selections, gatewayLanguageCode, gatewayLanguageQuote} = selectionsObject;
+    const {selections = [], gatewayLanguageCode, gatewayLanguageQuote} = selectionsObject;
     const validSelections = checkSelectionOccurrences(targetVerse, selections);
     const selectionsChanged = !isEqual(selections, validSelections);
     if (getSelectedToolName(state) === 'translationWords') {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR fixes an issue related to verse edits failing if there were no previous selections on that verse.

#### Please include detailed Test instructions for your pull request:
- Open a fresh project
- Make a edit in the tW verse edit area, and the expanded scripture pane in both tools
- Ensure verse edits appear after reloading tC
- Ensure that verse edits appear in usfm export

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5840)
<!-- Reviewable:end -->
