### PR TITLE
Bugfix 5710/Fixes for Edits on verses with multiple checks on verse

### DIFF
--- a/src/js/actions/CheckDataLoadActions.js
+++ b/src/js/actions/CheckDataLoadActions.js
@@ -60,32 +60,25 @@ export function loadCheckData(loadPath, contextId) {
     files = files.filter(file => { // filter the filenames to only use .json
       return path.extname(file) === '.json';
     });
-    let sorted = files.sort().reverse(); // sort the files to use latest
-    let checkDataObjects = [];
+    let sorted = files.sort().reverse(); // sort the files to put latest first
 
     for (let i = 0, len = sorted.length; i < len; i++) {
       const file = sorted[i];
-      // get the json of all files to later filter by contextId
+      // check each file for contextId
       try {
         let readPath = path.join(loadPath, file);
         let _checkDataObject = fs.readJsonSync(readPath);
-        checkDataObjects.push(_checkDataObject);
+        if(_checkDataObject &&
+          _checkDataObject.contextId.groupId === contextId.groupId &&
+          _checkDataObject.contextId.quote === contextId.quote &&
+          _checkDataObject.contextId.occurrence === contextId.occurrence) {
+          checkDataObject = _checkDataObject; // return the first match since it is the latest modified one
+          break;
+        }
       } catch (err) {
         console.warn('File exists but could not be loaded \n', err);
-        checkDataObjects.push(undefined);
       }
     }
-
-    checkDataObjects = checkDataObjects.filter(_checkDataObject => {
-      // filter the checkDataObjects to only use the ones that match the current contextId
-      let keep = _checkDataObject &&
-                _checkDataObject.contextId.groupId === contextId.groupId &&
-                _checkDataObject.contextId.quote === contextId.quote &&
-                _checkDataObject.contextId.occurrence === contextId.occurrence;
-      return keep;
-    });
-    // return the first one since it is the latest modified one
-    checkDataObject = checkDataObjects[0];
   }
   /**
   * @description Will return undefined if checkDataObject was not populated

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -82,7 +82,7 @@ export const showSelectionsInvalidatedWarning = () => {
  * @param {Number} verseNumber - optional verse number of verse text being edited
  * @return {Array} - group data items that match
  */
-export const getGroupDataForGroupChapterVerse = (groupsDataReducer, groupId, chapterNumber, verseNumber) => {
+export const getGroupDataForGroupIdChapterVerse = (groupsDataReducer, groupId, chapterNumber, verseNumber) => {
   const matchedGroupData = [];
   const groupData = groupId &&
     groupsDataReducer && groupsDataReducer.groupsData &&
@@ -119,7 +119,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
       let verseSelectionsChanged = false;
       const username = getUsername(state);
       // for this groupId, find every check for this chapter/verse
-      const matchedGroupData = getGroupDataForGroupChapterVerse(state.groupsDataReducer, contextId.groupId, chapterNumber, verseNumber);
+      const matchedGroupData = getGroupDataForGroupIdChapterVerse(state.groupsDataReducer, contextId.groupId, chapterNumber, verseNumber);
       for (let i = 0, l = matchedGroupData.length; i < l; i++) {
         const groupObject = matchedGroupData[i];
         const selections = getSelectionsForContextID(projectSaveLocation, groupObject.contextId);

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -2,14 +2,14 @@ import types from './ActionTypes';
 import isEqual from 'deep-equal';
 import path from 'path-extra';
 import fs from 'fs-extra';
-import { checkSelectionOccurrences } from 'selections';
+import {checkSelectionOccurrences} from 'selections';
 // actions
 import * as AlertModalActions from './AlertModalActions';
 import * as InvalidatedActions from './InvalidatedActions';
 import * as CheckDataLoadActions from './CheckDataLoadActions';
 // helpers
-import {getTranslate, getUsername, getSelectedToolName} from '../selectors';
-import { generateTimestamp } from '../helpers/index';
+import {getSelectedToolName, getTranslate, getUsername} from '../selectors';
+import {generateTimestamp} from '../helpers/index';
 import * as gatewayLanguageHelpers from '../helpers/gatewayLanguageHelpers';
 import * as saveMethods from "../localStorage/saveMethods";
 import usfm from "usfm-js";
@@ -34,7 +34,7 @@ export const changeSelections = (selections, userName, invalidated = false, cont
         gatewayLanguageQuote
       } = gatewayLanguageHelpers.getGatewayLanguageCodeAndQuote(getState(), contextId);
       if (sameContext(currentContextId, contextId)) { // see if we need to update current selection
-        const modifiedTimestamp = generateTimestamp();       
+        const modifiedTimestamp = generateTimestamp();
         dispatch({
           type: types.CHANGE_SELECTIONS,
           modifiedTimestamp: modifiedTimestamp,
@@ -75,11 +75,36 @@ export const showSelectionsInvalidatedWarning = () => {
 };
 
 /**
+ * populates groupData with all groupData entries for groupId and chapter/verse
+ * @param {Object} groupsDataReducer
+ * @param {String} groupId
+ * @param {Number} chapterNumber - optional chapter number of verse text being edited
+ * @param {Number} verseNumber - optional verse number of verse text being edited
+ * @return {Array} - group data items that match
+ */
+export const getGroupDataForGroupChapterVerse = (groupsDataReducer, groupId, chapterNumber, verseNumber) => {
+  const matchedGroupData = [];
+  const groupData = groupId &&
+    groupsDataReducer && groupsDataReducer.groupsData &&
+    groupsDataReducer.groupsData[groupId];
+  if (groupData && groupData.length) {
+    for (let i = 0, l = groupData.length; i < l; i++) {
+      const groupObject = groupData[i];
+      if (isEqual(groupObject.contextId.reference.chapter, chapterNumber) &&
+        isEqual(groupObject.contextId.reference.verse, verseNumber)) {
+        matchedGroupData.push(groupObject);
+      }
+    }
+  }
+  return matchedGroupData;
+};
+
+/**
  * @description This method validates the current selections to see if they are still valid.
  * @param {String} targetVerse - target bible verse.
  * @param {Object} contextId - optional contextId to use, otherwise will use current
- * @param {String} chapterNumber - chapter number of verse text being edited
- * @param {String} verseNumber - verse number of verse text being edited
+ * @param {Number} chapterNumber - optional chapter number of verse text being edited, if not given will use contextId
+ * @param {Number} verseNumber - optional verse number of verse text being edited, if not given will use contextId
  * @return {Object} - dispatches the changeSelections action.
  */
 export const validateSelections = (targetVerse, contextId = null, chapterNumber, verseNumber) => {
@@ -87,22 +112,25 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
     const state = getState();
     contextId = contextId || state.contextIdReducer.contextId;
     const { projectSaveLocation, manifest: { project } } = state.projectDetailsReducer;
-    const { bookId, chapter, verse } = contextId.reference;
+    chapterNumber = chapterNumber || contextId.reference.chapter;
+    verseNumber = verseNumber || contextId.reference.verse;
 
     if (getSelectedToolName(state) === 'translationWords') {
+      let verseSelectionsChanged = false;
       const username = getUsername(state);
-      const selections = getSelectionsFromChapterAndVerseCombo(
-        bookId,
-        chapterNumber || chapter,
-        verseNumber || verse,
-        projectSaveLocation
-      );
-      const validSelections = checkSelectionOccurrences(targetVerse, selections);
-      const selectionsChanged = (selections.length !== validSelections.length);
-      if (selectionsChanged) {
-        dispatch(changeSelections([], username, true, contextId)); // clear selections
+      // for this groupId, find every check for this chapter/verse
+      const matchedGroupData = getGroupDataForGroupChapterVerse(state.groupsDataReducer, contextId.groupId, chapterNumber, verseNumber);
+      for (let i = 0, l = matchedGroupData.length; i < l; i++) {
+        const groupObject = matchedGroupData[i];
+        const selections = getSelectionsForContextID(projectSaveLocation, groupObject.contextId);
+        const validSelections = checkSelectionOccurrences(targetVerse, selections);
+        const selectionsChanged = (selections.length !== validSelections.length);
+        if (selectionsChanged) {
+          dispatch(changeSelections([], username, true, groupObject.contextId)); // clear selections
+        }
+        verseSelectionsChanged = verseSelectionsChanged || selectionsChanged;
       }
-      const results = {selectionsChanged: selectionsChanged};
+      const results = {selectionsChanged: verseSelectionsChanged};
       dispatch(validateAllSelectionsForVerse(targetVerse, results, true, contextId, true));
     } else if (getSelectedToolName(state) === 'wordAlignment') {
       const bibleId = project.id;
@@ -183,7 +211,7 @@ export const validateAllSelectionsForVerse = (targetVerse, results, skipCurrent 
 };
 
 /**
- * @description gets the group data for the current verse from groupsDataReducer
+ * @description gets the group data for the verse reference in contextId from groupsDataReducer
  * @param {Object} state
  * @param {Object} contextId
  * @return {object} group data object.
@@ -227,50 +255,36 @@ export const sameContext = (contextId1, contextId2) => {
   return false;
 };
 
-//  TODO: this is not an action and should be moved elsewhere
-export const getSelectionsFromContextId = (contextId, projectSaveLocation) => {
+/**
+ * get selections for context ID
+ * @param {Object} contextId - contextId to use in lookup
+ * @param {String} projectSaveLocation
+ * @return {Array} - selections
+ */
+export const getSelectionsForContextID = (projectSaveLocation, contextId) => {
+  let selections = [];
   let loadPath = CheckDataLoadActions.generateLoadPath({projectSaveLocation}, {contextId}, 'selections');
   let selectionsObject = CheckDataLoadActions.loadCheckData(loadPath, contextId);
-  let selectionsArray = [];
-
   if (selectionsObject) {
-    const selections = selectionsObject.selections;
-
-    for (let i = 0, len = selections.length; i < len; i++) {
-      const selection = selections[i];
-      selectionsArray.push(selection.text);
-    }
+    selections = selectionsObject.selections;
   }
+  return selections;
+};
 
+/**
+ * get selections for context ID and return as string
+ * @param {Object} contextId - contextId to use in lookup
+ * @param {String} projectSaveLocation
+ * @return {string}
+ */
+//  TODO: this is not an action and should be moved elsewhere
+export const getSelectionsFromContextId = (contextId, projectSaveLocation) => {
+  const selections = getSelectionsForContextID(projectSaveLocation, contextId);
+  const selectionsArray = [];
+  for (let i = 0, len = selections.length; i < len; i++) {
+    const selection = selections[i];
+    selectionsArray.push(selection.text);
+  }
   return selectionsArray.join(" ");
 };
 
-
-export const getSelectionsFromChapterAndVerseCombo = (bookId, chapter, verse, projectSaveLocation) => {
-  let selectionsArray = [];
-  let selectionsObject;
-  const contextId = {
-    reference: {
-      bookId,
-      chapter,
-      verse
-    }
-  };
-  const selectionsPath = CheckDataLoadActions.generateLoadPath({projectSaveLocation}, {contextId}, 'selections');
-
-  if (fs.existsSync(selectionsPath)) {
-    let files = fs.readdirSync(selectionsPath);
-    files = files.filter(file => { // filter the filenames to only use .json
-      return path.extname(file) === '.json';
-    });
-    const sorted = files.sort().reverse(); // sort the files to use latest
-    const filename = sorted[0];
-    selectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
-  }
-
-  if (selectionsObject) {
-    selectionsArray = selectionsObject.selections;
-  }
-
-  return selectionsArray;
-};

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -112,8 +112,9 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
     const state = getState();
     contextId = contextId || state.contextIdReducer.contextId;
     const { projectSaveLocation, manifest: { project } } = state.projectDetailsReducer;
-    chapterNumber = chapterNumber || contextId.reference.chapter;
-    verseNumber = verseNumber || contextId.reference.verse;
+    const { chapter, verse } = contextId.reference;
+    chapterNumber = chapterNumber || chapter;
+    verseNumber = verseNumber || verse;
 
     if (getSelectedToolName(state) === 'translationWords') {
       let verseSelectionsChanged = false;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- this is addressing issue #6 in https://github.com/unfoldingword-dev/translationcore/issues/5710
- fixes for Edits in Expanded ScripturePane on verses that have multiple checks under the same groupId.  There were a few problems:
  - after the edit, the selected verse was flagged as edited, but not the edited verse
  - selection was not being reset on edited verse (until you later select it)
  - after the edit, all of the checks for the edited verse should be marked as edited, but none were.

- fixes made for problems in tW with verse edits in Expanded ScripturePane:
  - now set edited flag for edited verse instead of selected verse.
  - change to iterate through ALL the checks for edited verse and set edited flag.
  - change to iterate through ALL the checks for edited verse in current groupId and check for selections that have changed.

#### Please include detailed Test instructions for your pull request:
- Here are Kos's steps using [46-ROM.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/2933488/46-ROM.usfm.zip)
1. Import the file and load in tW
2. Open the 'disobey' group
3. Click on verse 11:30 (the second instance)
4. Select 'disobedience'
5. Click Save
6. Click Save & Continue
7. Select 'have been disobedient' 
8. Click Save
9. Click Save & Continue
10. Select 'disobedience'
11. Click Save and should see:
![screen shot 2019-03-08 at 6 43 09 am](https://user-images.githubusercontent.com/14238574/54026886-74e64700-416d-11e9-8303-04dc140456c6.png)

12. Open the expanded scripture pane
13. Open verse 11:30 for editing
14. Change the word 'disobedience' to 'unobedience'
15. Click Next
16. Choose a reason code
17. Click Save
18. Click Close and should see:
![screen shot 2019-03-08 at 6 44 24 am](https://user-images.githubusercontent.com/14238574/54026952-b24ad480-416d-11e9-9e55-f682b8b66524.png)
#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5891)
<!-- Reviewable:end -->
