### PR TITLE
Bugfix 3562/Tweaks to invalidation checking to show busy prompt to user

### DIFF
--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -24,8 +24,8 @@ import {
  * @param {string} before - Previous text version of the verse.
  * @param {string} after - New edited text version of the verse.
  * @param {string[]} tags - Array of tags used for verse Edit check boxes.
- * @param {string} [username=null] - The user's alias. If null the current username will be used.
- * @return {*}
+ * @param {string|null} [username=null] - The user's alias. If null the current username will be used.
+ * @return {Function}
  */
 export const editSelectedTargetVerse = (before, after, tags, username=null) => {
   return (dispatch, getState) => {
@@ -83,7 +83,7 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
     }} verseEdit - record to be saved to file system if in WA tool
  * @param {Object} contextIdWithVerseEdit - contextId of verse being edited
  * @param {Object} currentCheckContextId - contextId of group menu item selected
- * @return {function(*, *): Promise<T | never>}
+ * @return {Function}
  */
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
@@ -263,7 +263,7 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
  * @param {string} modified - the edit timestamp
  * @param {string|null} [glCode=null] - the gateway language code
  * @param {string|null} [glQuote=null] - the gateway language code
- * @return {*}
+ * @return {Object} - record to save to file
  */
 export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tags, username, modified, glCode=null, glQuote=null,
   {reference:{chapter:activeChapter, verse:activeVerse}, quote, groupId, occurrence}) => ({

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -71,7 +71,7 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
  */
 export const backgroundUpdateVerseEditsForChecks = (contextId) => {
   return (dispatch, getState) => {
-    return delay(1000).then( async () => {
+    return delay(1000).then( async () => { // wait till before updating
       console.log("backgroundUpdateVerseEditsForChecks() - starting");
       // in group data reducer set verse edit flag for every check of the verse edited
       const matchedGroupData = getGroupDataForVerse(getState(), contextId);
@@ -127,9 +127,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     const selectedToolName = getSelectedToolName(getState());
-    if (selectedToolName === 'translationWords') {
-      dispatch(backgroundUpdateVerseEditsForChecks(contextIdWithVerseEdit));
-    } else if (selectedToolName === 'wordAlignment') {
+    if (selectedToolName === 'wordAlignment') {
       // since tw group data is not loaded into reducer, need to save verse edit record directly to file system
       dispatch(writeTranslationWordsVerseEditToFile(verseEdit));
       // in group data reducer set verse edit flag for the verse edited
@@ -155,6 +153,9 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
           (verseEdit.activeChapter !== chapterWithVerseEdit || verseEdit.activeVerse !== verseWithVerseEdit)) {
         api.trigger('validateVerse', chapterWithVerseEdit, verseWithVerseEdit);
       }
+    }
+    if (selectedToolName === 'translationWords') {
+      dispatch(backgroundUpdateVerseEditsForChecks(contextIdWithVerseEdit));
     }
   };
 };

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -65,7 +65,8 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
 };
 
 /**
- * after a delay it starts updating the verse edit flags
+ * after a delay it starts updating the verse edit flags.  There are also delays between operations
+ *   so we don't slow down UI interactions of user
  * @param {{
       verseBefore: String,
       verseAfter: String,
@@ -85,11 +86,9 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
  */
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
-  console.log("doBackgroundVerseEditsUpdates()");
   return (dispatch, getState) => {
     return delay(1000).then( async () => { // wait till before updating
 
-      console.log("doBackgroundVerseEditsUpdates() - recordTargetVerseEdit");
       const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
       const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
       dispatch(recordTargetVerseEdit(verseEdit.activeBook, chapterWithVerseEdit, verseWithVerseEdit,
@@ -101,7 +100,6 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
         // in group data reducer set verse edit flag for every check of the verse edited
         const matchedGroupData = getGroupDataForVerse(getState(), contextIdWithVerseEdit);
         const keys = Object.keys(matchedGroupData);
-        console.log("doBackgroundVerseEditsUpdates() - number of tw checks for verse: " + keys.length);
         await delay(200);
         for (let groupItemKey of keys) {
           const groupItem = matchedGroupData[groupItemKey];
@@ -116,7 +114,6 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
           }
         }
       }
-      console.log("doBackgroundVerseEditsUpdates() - finished");
     });
   };
 };
@@ -145,10 +142,8 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
 export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWithVerseEdit,
                                                         currentCheckContextId) => {
   return (dispatch, getState) => {
-    console.log("updateVerseEditStatesAndCheckAlignments()");
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
-    console.log("updateVerseEditStatesAndCheckAlignments() - updateTargetVerse");
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     if (getSelectedToolName(getState()) === 'wordAlignment') {
@@ -198,7 +193,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
  */
 export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before, after, tags, username = null) => {
   return async (dispatch, getState) => {
-    console.log("editTargetVerse()");
     const {
       contextIdReducer
     } = getState();
@@ -241,11 +235,8 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
 
     if (selectionsValidationResults.selectionsChanged) {
       dispatch(showSelectionsInvalidatedWarning(() => {
-        console.log("editTargetVerse() - clicked OK");
         dispatch(clearScreenAndContinue(() => {
-          console.log("editTargetVerse() - processing callback");
           dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit, currentCheckContextId));
-          console.log("editTargetVerse() - DONE processing callback");
         }));
       }));
     } else {

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -144,7 +144,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
                                                         currentCheckContextId, showSelectionInvalidated) => {
   return async (dispatch, getState) => {
     const translate = getTranslate(getState());
-    dispatch(AlertModalActions.openAlertDialog(translate("tools.validating_word_alignments"), true));
+    dispatch(AlertModalActions.openAlertDialog(translate("tools.invalidation_checking"), true));
     await delay(500);
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -88,7 +88,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
   return async(dispatch, getState) => {
     console.log("doBackgroundVerseEditsUpdates()");
-    await delay(500); // wait till before updating
+    await delay(1000); // wait till before updating
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
     dispatch(recordTargetVerseEdit(verseEdit.activeBook, chapterWithVerseEdit, verseWithVerseEdit,
@@ -180,11 +180,11 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
         api.trigger('validateVerse', chapterWithVerseEdit, verseWithVerseEdit);
       }
     }
+    await delay(500);
     dispatch(AlertModalActions.closeAlertDialog());
     if (showSelectionInvalidated) {
-      await delay(500);
       dispatch(showSelectionsInvalidatedWarning());
-      await delay(500);
+      await delay(1000);
     }
     dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
                                            currentCheckContextId));

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -94,13 +94,13 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
       dispatch(recordTargetVerseEdit(verseEdit.activeBook, chapterWithVerseEdit, verseWithVerseEdit,
         verseEdit.verseBefore, verseEdit.verseAfter, verseEdit.tags, verseEdit.userName, generateTimestamp(),
         verseEdit.gatewayLanguageCode, verseEdit.gatewayLanguageQuote, currentCheckContextId));
-      await delay(500);
+      await delay(200);
 
       if (getSelectedToolName(getState()) === 'translationWords') {
         // in group data reducer set verse edit flag for every check of the verse edited
         const matchedGroupData = getGroupDataForVerse(getState(), contextIdWithVerseEdit);
         const keys = Object.keys(matchedGroupData);
-        await delay(500);
+        await delay(200);
         for (let groupItemKey of keys) {
           const groupItem = matchedGroupData[groupItemKey];
           if (groupItem) {
@@ -109,7 +109,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                 type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
                 contextId: check.contextId
               });
-              await delay(500);
+              await delay(200);
             }
           }
         }
@@ -234,9 +234,9 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
     };
 
     if (selectionsValidationResults.selectionsChanged) {
-      dispatch(showSelectionsInvalidatedWarning());
-      delay(500).then(dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit,
-                                                                            currentCheckContextId)));
+      delay(1000).then(dispatch(showSelectionsInvalidatedWarning()));
+      dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit,
+                                                                            currentCheckContextId));
     } else {
       dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit, currentCheckContextId));
     }

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -12,6 +12,7 @@ import {
   getSelectedToolApi,
   getSelectedToolName,
   getSupportingToolApis,
+  getTranslate,
   getUsername
 } from '../selectors';
 
@@ -87,7 +88,6 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
   return async(dispatch, getState) => {
-    console.log("doBackgroundVerseEditsUpdates()");
     await delay(1000); // wait till before updating
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
@@ -115,7 +115,6 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
         }
       }
     }
-    console.log("doBackgroundVerseEditsUpdates() - done");
   };
 };
 
@@ -144,15 +143,14 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
 export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWithVerseEdit,
                                                         currentCheckContextId, showSelectionInvalidated) => {
   return async (dispatch, getState) => {
-    dispatch(AlertModalActions.openAlertDialog("Checking Word Alignments", true));
+    const translate = getTranslate(getState());
+    dispatch(AlertModalActions.openAlertDialog(translate("tools.validating_word_alignments"), true));
     await delay(500);
-    console.log("updateVerseEditStatesAndCheckAlignments() - updateTargetVerse()");
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     if (getSelectedToolName(getState()) === 'wordAlignment') {
-      console.log("updateVerseEditStatesAndCheckAlignments() - writeTranslationWordsVerseEditToFile()");
       // since tw group data is not loaded into reducer, need to save verse edit record directly to file system
       dispatch(writeTranslationWordsVerseEditToFile(verseEdit));
       // in group data reducer set verse edit flag for the verse edited
@@ -167,7 +165,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     // callbacks for editing so that tools can manually perform the edit and
     // trigger validation on the specific verse.
     const newState = getState();
-    console.log("updateVerseEditStatesAndCheckAlignments() - calling WA for checking()");
     const apis = getSupportingToolApis(newState);
     if ('wordAlignment' in apis && apis['wordAlignment'] !== null) {
       // for other tools
@@ -188,7 +185,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     }
     dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
                                            currentCheckContextId));
-    console.log("updateVerseEditStatesAndCheckAlignments() - Finished");
   };
 };
 

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -87,20 +87,20 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
   return (dispatch, getState) => {
-    return delay(1000).then( async () => { // wait till before updating
+    return delay(500).then( async () => { // wait till before updating
 
       const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
       const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
       dispatch(recordTargetVerseEdit(verseEdit.activeBook, chapterWithVerseEdit, verseWithVerseEdit,
         verseEdit.verseBefore, verseEdit.verseAfter, verseEdit.tags, verseEdit.userName, generateTimestamp(),
         verseEdit.gatewayLanguageCode, verseEdit.gatewayLanguageQuote, currentCheckContextId));
-      await delay(200);
+      await delay(500);
 
       if (getSelectedToolName(getState()) === 'translationWords') {
         // in group data reducer set verse edit flag for every check of the verse edited
         const matchedGroupData = getGroupDataForVerse(getState(), contextIdWithVerseEdit);
         const keys = Object.keys(matchedGroupData);
-        await delay(200);
+        await delay(500);
         for (let groupItemKey of keys) {
           const groupItem = matchedGroupData[groupItemKey];
           if (groupItem) {
@@ -109,7 +109,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                 type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
                 contextId: check.contextId
               });
-              await delay(200);
+              await delay(500);
             }
           }
         }

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -180,11 +180,11 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
         api.trigger('validateVerse', chapterWithVerseEdit, verseWithVerseEdit);
       }
     }
-    await delay(500);
-    dispatch(AlertModalActions.closeAlertDialog());
     if (showSelectionInvalidated) {
-      dispatch(showSelectionsInvalidatedWarning());
+      dispatch(showSelectionsInvalidatedWarning()); // no need to close alert, since this replaces it
       await delay(1000);
+    } else {
+      dispatch(AlertModalActions.closeAlertDialog());
     }
     dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
                                            currentCheckContextId));

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -70,6 +70,7 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
  * @return {function(*, *): Promise<T | never>}
  */
 export const backgroundUpdateVerseEditsForChecks = (contextId) => {
+  console.log("backgroundUpdateVerseEditsForChecks()");
   return (dispatch, getState) => {
     return delay(1000).then( async () => { // wait till before updating
       console.log("backgroundUpdateVerseEditsForChecks() - starting");
@@ -119,11 +120,14 @@ export const backgroundUpdateVerseEditsForChecks = (contextId) => {
 export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWithVerseEdit,
                                                         currentCheckContextId) => {
   return (dispatch, getState) => {
+    console.log("updateVerseEditStatesAndCheckAlignments()");
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
+    console.log("updateVerseEditStatesAndCheckAlignments() - recordTargetVerseEdit");
     dispatch(recordTargetVerseEdit(verseEdit.activeBook, chapterWithVerseEdit, verseWithVerseEdit,
         verseEdit.verseBefore, verseEdit.verseAfter, verseEdit.tags, verseEdit.userName, generateTimestamp(),
         verseEdit.gatewayLanguageCode, verseEdit.gatewayLanguageQuote, currentCheckContextId));
+    console.log("updateVerseEditStatesAndCheckAlignments() - updateTargetVerse");
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     const selectedToolName = getSelectedToolName(getState());
@@ -175,6 +179,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
  */
 export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before, after, tags, username = null) => {
   return async (dispatch, getState) => {
+    console.log("editTargetVerse()");
     const {
       contextIdReducer
     } = getState();
@@ -217,8 +222,11 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
 
     if (selectionsValidationResults.selectionsChanged) {
       dispatch(showSelectionsInvalidatedWarning(() => {
+        console.log("editTargetVerse() - clicked OK");
         dispatch(clearScreenAndContinue(() => {
+          console.log("editTargetVerse() - processing callback");
           dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit, currentCheckContextId));
+          console.log("editTargetVerse() - DONE processing callback");
         }));
       }));
     } else {
@@ -231,7 +239,7 @@ export const clearScreenAndContinue = (callback) => {
   return async (dispatch) => {
     await delay(500); // wait for screen to update
     dispatch(AlertModalActions.closeAlertDialog());
-    await delay(1000); // wait for screen to update and close dialog
+    await delay(500); // wait for screen to update and close dialog
     callback();
   };
 };

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -234,25 +234,15 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
     };
 
     if (selectionsValidationResults.selectionsChanged) {
-      dispatch(showSelectionsInvalidatedWarning(() => {
-        dispatch(clearScreenAndContinue(() => {
-          dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit, currentCheckContextId));
-        }));
-      }));
+      dispatch(showSelectionsInvalidatedWarning());
+      delay(500).then(dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit,
+                                                                            currentCheckContextId)));
     } else {
       dispatch(updateVerseEditStatesAndCheckAlignments(verseEdit, contextIdWithVerseEdit, currentCheckContextId));
     }
   };
 };
 
-export const clearScreenAndContinue = (callback) => {
-  return async (dispatch) => {
-    await delay(500); // wait for screen to update
-    dispatch(AlertModalActions.closeAlertDialog());
-    await delay(500); // wait for screen to update and close dialog
-    callback();
-  };
-};
 
 /**
  * Records an edit to a verse in the target language bible.

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -366,7 +366,7 @@
     "no_gl_available": "None available",
     "invalid_checks": "Invalidated checks",
     "invalid_verse_alignments": "Verses with invalidated alignments.",
-    "validating_word_alignments": "Validating Word Alignments"
+    "invalidation_checking": "Doing Invalidation Checking"
   },
   "buttons": {
     "back_button": "Go Back",

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -365,7 +365,8 @@
     "menu": "Menu",
     "no_gl_available": "None available",
     "invalid_checks": "Invalidated checks",
-    "invalid_verse_alignments": "Verses with invalidated alignments."
+    "invalid_verse_alignments": "Verses with invalidated alignments.",
+    "validating_word_alignments": "Validating Word Alignments"
   },
   "buttons": {
     "back_button": "Go Back",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Tweaks to timing so WA tool processing does not block prompt updates
- added busy prompt when doing invalidation checking so users don't think app is hung on slower PCs

#### Please include detailed Test instructions for your pull request:
- do usfm import of project [45-ACT.usfm.txt.zip](https://github.com/unfoldingWord-dev/translationCore/files/2953907/45-ACT.usfm.txt.zip)
- open tw 
- in group die, click on acts 4:2 selection 'the dead` and click save and save next
- open expanded scripture pane and then edit 4:2
- change `dead` to `die`, click next, select reason and click save 
- should see busy prompt that we are validating alignments/selections for a few seconds
- then should see alert selections invalidated overlaying alignments invalidated
- click OK
- then should see selections invalidated alert disappear and alignments invalidated will be visible


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5924)
<!-- Reviewable:end -->
