### PR TITLE
Enhancement mcleanb 5941

### DIFF
--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -8,6 +8,18 @@ import * as GroupsDataActions from '../src/js/actions/GroupsDataActions';
 import * as saveMethods from '../src/js/localStorage/saveMethods';
 import * as VerseEditActions from "../src/js/actions/VerseEditActions";
 
+jest.mock('redux-batched-actions', () => ({
+  batchActions: (actionsBatch) => {
+    return (dispatch) => {
+      if (actionsBatch.length) {
+        for (let action of actionsBatch) {
+          dispatch(action);
+        }
+      }
+    };
+  }
+}));
+
 // constants
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/__tests__/SelectionsActions.test.js
+++ b/__tests__/SelectionsActions.test.js
@@ -20,6 +20,18 @@ jest.mock('../src/js/helpers/gatewayLanguageHelpers', () => ({
   }
 }));
 
+jest.mock('redux-batched-actions', () => ({
+  batchActions: (actionsBatch) => {
+    return (dispatch) => {
+      if (actionsBatch.length) {
+        for (let action of actionsBatch) {
+          dispatch(action);
+        }
+      }
+    };
+  }
+}));
+
 const PROJECTS_PATH = path.join(__dirname, 'fixtures', 'checkData');
 
 fs.__loadDirIntoMockFs(PROJECTS_PATH, PROJECTS_PATH);

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -75,6 +75,29 @@ export const showSelectionsInvalidatedWarning = (callback = null) => {
 };
 
 /**
+ * displays warning that selections, alignments, or both have been invalidated
+ * @param {boolean} showSelectionInvalidated
+ * @param {boolean} showALignmentsInvalidated
+ * @param {Function|Null} callback - optional callback after OK button clicked
+ * @return {Function}
+ */
+export const showInvalidatedWarnings = (showSelectionInvalidated, showALignmentsInvalidated,
+                                        callback = null) => {
+  return (dispatch, getState) => {
+    let message = null;
+    if (showSelectionInvalidated && showALignmentsInvalidated) {
+      message = 'tools.invalid_verse_alignments_and_selections';
+    } else if (showSelectionInvalidated) {
+      message = 'tools.selections_invalidated';
+    } else { // (showALignmentsInvalidated)
+      message = 'tools.alignments_reset_wa_tool';
+    }
+    const translate = getTranslate(getState());
+    dispatch(AlertModalActions.openOptionDialog(translate(message), callback));
+  };
+};
+
+/**
  * populates groupData with all groupData entries for groupId and chapter/verse
  * @param {Object} groupsDataReducer
  * @param {String} groupId

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -7,13 +7,13 @@ import {checkSelectionOccurrences} from 'selections';
 import * as AlertModalActions from './AlertModalActions';
 import * as InvalidatedActions from './InvalidatedActions';
 import * as CheckDataLoadActions from './CheckDataLoadActions';
+import {batchActions} from "redux-batched-actions";
 // helpers
 import {getTranslate, getUsername, getSelectedToolName} from '../selectors';
 import {generateTimestamp} from '../helpers/index';
 import * as gatewayLanguageHelpers from '../helpers/gatewayLanguageHelpers';
 import * as saveMethods from "../localStorage/saveMethods";
 import usfm from "usfm-js";
-import {processGroupDataBatch} from "./VerseEditActions";
 
 /**
  * This method adds a selection array to the selections reducer.
@@ -63,7 +63,7 @@ export const changeSelections = (selections, userName, invalidated = false, cont
         boolean: invalidated
       });
       if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
-        dispatch(processGroupDataBatch(actionsBatch));
+        dispatch(batchActions(actionsBatch));
       }
     }
   });
@@ -216,7 +216,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
       }
     }
     if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
-      dispatch(processGroupDataBatch(actionsBatch));
+      dispatch(batchActions(actionsBatch));
     }
     results.selectionsChanged = selectionInvalidated;
     if (showInvalidation && selectionInvalidated) {
@@ -271,7 +271,7 @@ export const validateAllSelectionsForVerse = (targetVerse, results, skipCurrent 
     }
 
     if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
-      dispatch(processGroupDataBatch(actionsBatch));
+      dispatch(batchActions(actionsBatch));
     }
     if (warnOnError && (initialSelectionsChanged || results.selectionsChanged)) {
       dispatch(showSelectionsInvalidatedWarning());

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -51,7 +51,7 @@ export const changeSelections = (selections, userName, invalidated = false, cont
         saveMethods.saveSelectionsForOtherContext(getState(), gatewayLanguageCode, gatewayLanguageQuote, selections, invalidated, userName, contextId);
       }
 
-      const actionsBatch = batchGroupData || [];
+      const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData  : []; // if batch array passed in then use it, otherwise create new array
       actionsBatch.push({
         type: types.TOGGLE_SELECTIONS_IN_GROUPDATA,
         contextId,
@@ -62,7 +62,7 @@ export const changeSelections = (selections, userName, invalidated = false, cont
         contextId,
         boolean: invalidated
       });
-      if (!batchGroupData) { // if we are not returning batch, then process actions now
+      if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
         dispatch(processGroupDataBatch(actionsBatch));
       }
     }
@@ -150,7 +150,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
     chapterNumber = chapterNumber || chapter;
     verseNumber = verseNumber || verse;
     let selectionInvalidated = false;
-    const actionsBatch = batchGroupData || [];
+    const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData  : []; // if batch array passed in then use it, otherwise create new array
 
     if (getSelectedToolName(state) === 'translationWords') {
       const username = getUsername(state);
@@ -167,7 +167,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
         selectionInvalidated = selectionInvalidated || selectionsChanged;
       }
       const results_ = {selectionsChanged: selectionInvalidated};
-      dispatch(validateAllSelectionsForVerse(targetVerse, results_, true, contextId, false));
+      dispatch(validateAllSelectionsForVerse(targetVerse, results_, true, contextId, false, actionsBatch));
       selectionInvalidated = selectionInvalidated || results_.selectionsChanged; // if new selections invalidated
     } else if (getSelectedToolName(state) === 'wordAlignment') {
       const bibleId = project.id;
@@ -215,7 +215,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber,
         }
       }
     }
-    if (!batchGroupData) { // if we are not returning batch, then process actions now
+    if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
       dispatch(processGroupDataBatch(actionsBatch));
     }
     results.selectionsChanged = selectionInvalidated;
@@ -245,7 +245,7 @@ export const validateAllSelectionsForVerse = (targetVerse, results, skipCurrent 
     const groupsDataForVerse = getGroupDataForVerse(state, contextId);
     let filtered = null;
     results.selectionsChanged = false;
-    const actionsBatch = batchGroupData || [];
+    const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData  : []; // if batch array passed in then use it, otherwise create new array
 
     const groupsDataKeys = Object.keys(groupsDataForVerse);
     for (let i = 0, l = groupsDataKeys.length; i < l; i++) {
@@ -270,7 +270,7 @@ export const validateAllSelectionsForVerse = (targetVerse, results, skipCurrent 
       }
     }
 
-    if (!batchGroupData) { // if we are not returning batch, then process actions now
+    if (!Array.isArray(batchGroupData)) { // if we are not returning batch, then process actions now
       dispatch(processGroupDataBatch(actionsBatch));
     }
     if (warnOnError && (initialSelectionsChanged || results.selectionsChanged)) {

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -16,7 +16,6 @@ import {
   getUsername
 } from '../selectors';
 import {batchActions} from "redux-batched-actions";
-import {saveGroupsData} from "../localStorage/saveMethods";
 
 /**
  * Records an edit to the currently selected verse in the target bible.

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -76,7 +76,6 @@ export const getVerseEditsInTwGroupData = (state, contextId, actionsBatch) => {
   // in group data reducer set verse edit flag for every check of the verse edited
   const matchedGroupData = getGroupDataForVerse(state, contextId);
   const keys = Object.keys(matchedGroupData);
-  let changedCount = 0;
   if (keys.length) {
     for (let i = 0, l = keys.length; i < l; i++) {
       const groupItem = matchedGroupData[keys[i]];
@@ -88,13 +87,9 @@ export const getVerseEditsInTwGroupData = (state, contextId, actionsBatch) => {
               type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
               contextId: check.contextId
             });
-            changedCount++;
           }
         }
       }
-    }
-    if (changedCount) {
-      console.log(`getVerseEditsInTwGroupData() chapter=${contextId.reference.chapter}, verse=${contextId.reference.verse}, keys=${keys.length}, changedCount=${changedCount}`);
     }
   }
 };
@@ -145,7 +140,6 @@ export const setVerseEditsInTwGroupDataFromArray = (twVerseEdits) => {
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId, batchGroupData) => {
   return async(dispatch, getState) => {
-    console.log("doBackgroundVerseEditsUpdates() - recordTargetVerseEdit");
     await delay(1000); // wait till before updating
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
@@ -161,7 +155,6 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
     }
     await delay(500);
     dispatch(batchActions(actionsBatch));
-    console.log("doBackgroundVerseEditsUpdates() - getVerseEditsInTwGroupData() is finished");
   };
 };
 
@@ -198,7 +191,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     await delay(500);
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
-    console.log("updateVerseEditStatesAndCheckAlignments() - calling updateTargetVerse");
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     if (getSelectedToolName(getState()) === 'wordAlignment') {
@@ -218,7 +210,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     // trigger validation on the specific verse.
     const newState = getState();
     const apis = getSupportingToolApis(newState);
-    console.log("updateVerseEditStatesAndCheckAlignments() - calling api.validateVerse");
     if ('wordAlignment' in apis && apis['wordAlignment'] !== null) {
       // for other tools
       showAlignmentsInvalidated = !apis['wordAlignment'].trigger('validateVerse',
@@ -231,7 +222,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
                                                   chapterWithVerseEdit, verseWithVerseEdit, true);
       }
     }
-    console.log("updateVerseEditStatesAndCheckAlignments() - api.validateVerse - done");
     if (showSelectionInvalidated || showAlignmentsInvalidated) {
       dispatch(showInvalidatedWarnings(showSelectionInvalidated, showAlignmentsInvalidated)); // no need to close alert, since this replaces it
       await delay(1000);
@@ -279,11 +269,9 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
       userAlias = getUsername(getState());
     }
     const selectionsValidationResults = {};
-    console.log("editTargetVerse() - calling validateSelections()");
     const actionsBatch = [];
     dispatch(validateSelections(after, contextIdWithVerseEdit, chapterWithVerseEdit, verseWithVerseEdit,
       false, selectionsValidationResults, actionsBatch));
-    console.log("editTargetVerse() - validateSelections() - done");
 
     // create verse edit record to write to file system
     const modifiedTimestamp = generateTimestamp();

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -72,10 +72,9 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
  * @return {Function}
  */
 export const processGroupDataBatch = (actionsBatch) => {
-  return async (dispatch) => {
+  return (dispatch) => {
     if (actionsBatch.length) {
       console.log(`processGroupDataBatch() processing group batch, count=${actionsBatch.length}`);
-      await delay(500);
       dispatch(batchActions(actionsBatch));
       console.log(`processGroupDataBatch() finished group batch, saving`);
     }
@@ -130,6 +129,7 @@ export const setVerseEditsInTwGroupDataFromArray = (twVerseEdits) => {
         getVerseEditsInTwGroupData(state, contextId, actionsBatch);
       }
       if (actionsBatch.length) {
+        await delay(500);
         dispatch(processGroupDataBatch(actionsBatch));
       }
     }
@@ -174,6 +174,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
     if (getSelectedToolName(state) === 'translationWords') {
       getVerseEditsInTwGroupData(state, contextIdWithVerseEdit, actionsBatch);
     }
+    await delay(500);
     dispatch(processGroupDataBatch(actionsBatch));
     console.log("doBackgroundVerseEditsUpdates() - getVerseEditsInTwGroupData() is finished");
   };

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -169,7 +169,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
       verseEdit.gatewayLanguageCode, verseEdit.gatewayLanguageQuote, currentCheckContextId));
     await delay(200);
 
-    const actionsBatch = batchGroupData || [];
+    const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData  : []; // if batch array passed in then use it, otherwise create new array
     const state = getState();
     if (getSelectedToolName(state) === 'translationWords') {
       getVerseEditsInTwGroupData(state, contextIdWithVerseEdit, actionsBatch);
@@ -207,7 +207,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
                                                         batchGroupData = null) => {
   return async (dispatch, getState) => {
     const translate = getTranslate(getState());
-    const actionsBatch = batchGroupData || [];
+    const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData  : []; // if batch array passed in then use it, otherwise create new array
     dispatch(AlertModalActions.openAlertDialog(translate("tools.invalidation_checking"), true));
     await delay(500);
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -72,6 +72,7 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
  */
 export const setVerseEditsInTwGroupData = (contextId) => {
   return async (dispatch, getState) => {
+    console.log("setVerseEditsInTwGroupData()");
     // in group data reducer set verse edit flag for every check of the verse edited
     const matchedGroupData = getGroupDataForVerse(getState(), contextId);
     const keys = Object.keys(matchedGroupData);
@@ -83,6 +84,7 @@ export const setVerseEditsInTwGroupData = (contextId) => {
           for (let j = 0, lenGI = groupItem.length; j < lenGI; j++) {
             const check = groupItem[j];
             if (!check.verseEdits) { // only set if not yet set
+              console.log("setVerseEditsInTwGroupData() - TOGGLE_VERSE_EDITS_IN_GROUPDATA");
               dispatch({
                 type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
                 contextId: check.contextId
@@ -135,6 +137,7 @@ export const setVerseEditsInTwGroupDataFromArray = (twVerseEdits) => {
 export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
                                               currentCheckContextId) => {
   return async(dispatch, getState) => {
+    console.log("doBackgroundVerseEditsUpdates() - recordTargetVerseEdit");
     await delay(1000); // wait till before updating
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
@@ -145,6 +148,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
 
     if (getSelectedToolName(getState()) === 'translationWords') {
       await dispatch(setVerseEditsInTwGroupData(contextIdWithVerseEdit));
+      console.log("doBackgroundVerseEditsUpdates() - setVerseEditsInTwGroupData() is finished");
     }
   };
 };
@@ -179,6 +183,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     await delay(500);
     const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
     const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
+    console.log("updateVerseEditStatesAndCheckAlignments() - calling updateTargetVerse");
     dispatch(updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter));
 
     if (getSelectedToolName(getState()) === 'wordAlignment') {
@@ -197,6 +202,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     // trigger validation on the specific verse.
     const newState = getState();
     const apis = getSupportingToolApis(newState);
+    console.log("updateVerseEditStatesAndCheckAlignments() - calling api.validateVerse");
     if ('wordAlignment' in apis && apis['wordAlignment'] !== null) {
       // for other tools
       apis['wordAlignment'].trigger('validateVerse', chapterWithVerseEdit, verseWithVerseEdit);
@@ -208,6 +214,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
         api.trigger('validateVerse', chapterWithVerseEdit, verseWithVerseEdit);
       }
     }
+    console.log("updateVerseEditStatesAndCheckAlignments() - api.validateVerse - done");
     if (showSelectionInvalidated) {
       dispatch(showSelectionsInvalidatedWarning()); // no need to close alert, since this replaces it
       await delay(1000);
@@ -255,8 +262,10 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
       userAlias = getUsername(getState());
     }
     const selectionsValidationResults = {};
+    console.log("editTargetVerse() - calling validateSelections()");
     dispatch(validateSelections(after, contextIdWithVerseEdit, chapterWithVerseEdit, verseWithVerseEdit,
       false, selectionsValidationResults));
+    console.log("editTargetVerse() - validateSelections() - done");
 
     // create verse edit record to write to file system
     const modifiedTimestamp = generateTimestamp();

--- a/src/js/helpers/getToggledGroupData.js
+++ b/src/js/helpers/getToggledGroupData.js
@@ -6,8 +6,7 @@ import isEqual from 'deep-equal';
  * @param {string} key - object key. ex. "comments", "reminders", "selections" or "verseEdits".
  * @return {object} returns the group data object which the key boolean toggled.
  */
-export const getToggledGroupData = (old_state, action, key) => {
-  const state = JSON.parse(JSON.stringify(old_state));
+export const getToggledGroupData = (state, action, key) => {
   let groupData = state.groupsData[action.contextId.groupId];
   if (groupData == undefined) return groupData;
   const index = groupData.findIndex(groupObject => {

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -366,7 +366,9 @@
     "no_gl_available": "None available",
     "invalid_checks": "Invalidated checks",
     "invalid_verse_alignments": "Verses with invalidated alignments.",
-    "invalidation_checking": "Doing Invalidation Checking"
+    "invalidation_checking": "Checking if this edit conflicts with saved selections and alignments...",
+    "alignments_reset_wa_tool": "Changes have been detected in your project which have invalidated some of your alignments.\nThese verses display an icon of a broken chain next to the reference in the side menu.",
+    "invalid_verse_alignments_and_selections": "Changes have been detected in your project which have invalidated some selections and some alignments. These verses display an icon of a broken chain next to the reference in the side menu."
   },
   "buttons": {
     "back_button": "Go Back",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- consolidate to single prompt when both alignments and selections are invalidated.
- batched group data actions so tools don't get continual notifications that properties are changing.
- updated WA to support a silent validation and fixed to return results.

#### Please include detailed Test instructions for your pull request:
- test with https://github.com/translationCoreApps/wordAlignment/pull/173
- import this USFM project [45-ACT.usfm3.txt.zip](https://github.com/unfoldingWord-dev/translationCore/files/3059172/45-ACT.usfm3.txt.zip)
- open tW tool, navigate to Apostles, and verse 1:2
- make selection `apostles` and click `save` and `save & continue` buttons
- open expanded scripture pane, and edit 1:2.  Modify word `apostles` and then click `Next`, select reason and click `save`.
- should momentarily see the Checking Prompt and then should see combined prompt for both alignments and selections invalidated.
- click OK and close  expanded scripture pane.
-  navigate to Apostles, and verse 1:25, select `apostleship` and `save`
- open WA tool, navigate to verse 1:25
- open expanded scripture pane, and edit 1:25.  Modify word `apostleship` and then click `Next`, select reason and click `save`.
- should momentarily see the Checking Prompt and then should see combined prompt for both alignments and selections invalidated.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/5962)
<!-- Reviewable:end -->
