### PR TITLE
Bugfix 5996/Preserve tw categories on upgrade

### DIFF
--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -43,25 +43,33 @@ export function copyGroupDataToProject(gatewayLanguage, toolName, projectDir) {
     if (project.hasNewGroupsData(toolName)) {
       project.resetLoadedCategories(toolName);
     }
-    let categories = getAvailableCategories(gatewayLanguage, toolName, projectDir);
-    Object.keys(categories).forEach((category) => {
-      const resourceCategoryDir = path.join(helpDir, category, 'groups', project.getBookId());
-      const altResourceCategoryDir = path.join(helpDir, 'groups', project.getBookId());
-      let groupsDir = resourceCategoryDir;
-      if (!fs.pathExistsSync(resourceCategoryDir)) {
-        groupsDir = altResourceCategoryDir;
-      }
-      categories[category].forEach((subCategory) => {
-        const dataPath = path.join(groupsDir, subCategory + '.json');
-        project.importCategoryGroupData(toolName, dataPath);
+    const categories = getAvailableCategories(gatewayLanguage, toolName, projectDir);
+    const categoryKeys = Object.keys(categories);
+    if (toolName === "translationWords") {
+      // for tW we don't select by subcategories
+      categoryKeys.forEach((category) => {
+        project.setCategoryLoaded(toolName, category);
       });
-      // TRICKY: gives the tool an index of which groups belong to which category
-      project.setCategoryGroupIds(toolName, category, categories[category]);
-      // loading complete
-      categories[category].forEach((subCategory) => {
-        project.setCategoryLoaded(toolName, subCategory);
+    } else {
+      categoryKeys.forEach((category) => {
+        const resourceCategoryDir = path.join(helpDir, category, 'groups', project.getBookId());
+        const altResourceCategoryDir = path.join(helpDir, 'groups', project.getBookId());
+        let groupsDir = resourceCategoryDir;
+        if (!fs.pathExistsSync(resourceCategoryDir)) {
+          groupsDir = altResourceCategoryDir;
+        }
+        categories[category].forEach((subCategory) => {
+          const dataPath = path.join(groupsDir, subCategory + '.json');
+          project.importCategoryGroupData(toolName, dataPath);
+        });
+        // TRICKY: gives the tool an index of which groups belong to which category
+        project.setCategoryGroupIds(toolName, category, categories[category]);
+        // loading complete
+        categories[category].forEach((subCategory) => {
+          project.setCategoryLoaded(toolName, subCategory);
+        });
       });
-    });
+    }
     project.removeStaleCategoriesFromCurrent(toolName);
   } else {
     // generate chapter-based group data


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix to preserve tw categories on upgrade.

#### Please include detailed Test instructions for your pull request:
- start with tc 1.1.3
- open a project (and remember the project)
- on tw card select all categories
- exit tw
- checkout this branch and do `npm run load-apps`, then `npm ci`, and then `npm start`
- select project used above
- make sure all categories are still selected.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6023)
<!-- Reviewable:end -->
