### PR TITLE
Bugfix 5970/Fix tW crash on imported USFM file

### DIFF
--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -248,9 +248,8 @@ export default class ProjectAPI {
         console.warn(
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
       }
-    } else {
-      return true;
     }
+    return true; // return true if file missing or error
   }
 
   /**
@@ -276,8 +275,9 @@ export default class ProjectAPI {
   /**
    * Removes categories from the currently selected that are not in the loaded array
    * @param {string} toolName - The tool name. This is synonymous with translationHelp name
+   * @param {Object} availableCategories - categories available in resources
    */
-  removeStaleCategoriesFromCurrent(toolName) {
+  removeStaleCategoriesFromCurrent(toolName, availableCategories) {
     const groupsPath = this.getCategoriesDir(toolName);
     const categoriesPath = path.join(groupsPath,
       ".categories");
@@ -297,9 +297,18 @@ export default class ProjectAPI {
             console.log('Could not reset current context id');
           }
         }
+        let loadedSubCategories = rawData.loaded;
+        if (toolName === "translationWords") {
+          // for tW we don't select by subcategories, so need to get subcategories for the available categories
+          loadedSubCategories = [];
+          const keys = Object.keys(availableCategories);
+          for (let i = 0, l = keys.length; i < l; i++) {
+            loadedSubCategories.push.apply(loadedSubCategories,availableCategories[keys[i]]);
+          }
+        }
         const currentGroupsData = fs.readdirSync(groupsPath).filter((name) => name.includes('.json'));
         currentGroupsData.forEach((category) => {
-          if (!rawData.loaded.includes(path.parse(category).name)) {
+          if (!loadedSubCategories.includes(path.parse(category).name)) {
             //removing groups data files that are not in loaded
             fs.removeSync(path.join(groupsPath, category));
           }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix error handling for hasNewGroupsData().
- fix for removeStaleCategoriesFromCurrent() to not wipe out all tW subcategories.
- fix for copyGroupDataToProject() to copy new resources for tW

#### Please include detailed Test instructions for your pull request:
- Import a new USFM project and open in tW
- should not get Error screen

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6033)
<!-- Reviewable:end -->
