### PR TITLE
Bugfix 5755/Fix tN category Hovers and MD

### DIFF
--- a/__tests__/ToolCardHelpers.test.js
+++ b/__tests__/ToolCardHelpers.test.js
@@ -156,7 +156,7 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
 
     //when
-    const [title, intro] = ToolCardHelpers.parseArticleAbstract(rawText);
+    const {title, intro} = ToolCardHelpers.parseArticleAbstract(rawText);
     const combined = title + intro;
     //then
     expect(combined).toMatchSnapshot();
@@ -174,7 +174,7 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
 
     //when
-    const [title, intro] = ToolCardHelpers.parseArticleAbstract(rawText);
+    const {title, intro} = ToolCardHelpers.parseArticleAbstract(rawText);
     const combined = title + intro;
     //then
     expect(combined).toMatchSnapshot();
@@ -190,7 +190,7 @@ describe('Test ToolCardHelpers.getToolCardLaunchStatus() for correct launch stat
 
 
     //when
-    const [title, intro] = ToolCardHelpers.parseArticleAbstract(rawText);
+    const {title, intro} = ToolCardHelpers.parseArticleAbstract(rawText);
     const combined = title + intro;
     //then
     expect(combined).toMatchSnapshot();

--- a/__tests__/__snapshots__/ToolCardBoxes.test.js.snap
+++ b/__tests__/__snapshots__/ToolCardBoxes.test.js.snap
@@ -206,16 +206,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: writing-background: Could not find article for writing-background"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.writing-background
-          </span>
+            <span
+              aria-label="Article Not Found: writing-background: Could not find article for writing-background"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.writing-background
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="1"
@@ -252,16 +262,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: writing-endofstory: Could not find article for writing-endofstory"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.writing-endofstory
-          </span>
+            <span
+              aria-label="Article Not Found: writing-endofstory: Could not find article for writing-endofstory"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.writing-endofstory
+              </span>
+            </span>
+          </Hint>
         </div>
       </div>
     </div>
@@ -394,16 +414,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: translate-numbers: Could not find article for translate-numbers"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.numbers
-          </span>
+            <span
+              aria-label="Article Not Found: translate-numbers: Could not find article for translate-numbers"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.numbers
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="1"
@@ -440,16 +470,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: translate-fraction: Could not find article for translate-fraction"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.translate-fraction
-          </span>
+            <span
+              aria-label="Article Not Found: translate-fraction: Could not find article for translate-fraction"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.translate-fraction
+              </span>
+            </span>
+          </Hint>
         </div>
       </div>
     </div>
@@ -582,16 +622,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-idiom: Could not find article for figs-idiom"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-idiom
-          </span>
+            <span
+              aria-label="Article Not Found: figs-idiom: Could not find article for figs-idiom"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-idiom
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="1"
@@ -628,16 +678,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-irony: Could not find article for figs-irony"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-irony
-          </span>
+            <span
+              aria-label="Article Not Found: figs-irony: Could not find article for figs-irony"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-irony
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="2"
@@ -674,16 +734,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-metaphor: Could not find article for figs-metaphor"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-metaphor
-          </span>
+            <span
+              aria-label="Article Not Found: figs-metaphor: Could not find article for figs-metaphor"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-metaphor
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="3"
@@ -720,16 +790,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-rquestion: Could not find article for figs-rquestion"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-rquestion
-          </span>
+            <span
+              aria-label="Article Not Found: figs-rquestion: Could not find article for figs-rquestion"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-rquestion
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="4"
@@ -766,16 +846,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-simile: Could not find article for figs-simile"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-simile
-          </span>
+            <span
+              aria-label="Article Not Found: figs-simile: Could not find article for figs-simile"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-simile
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="5"
@@ -812,16 +902,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-apostrophe: Could not find article for figs-apostrophe"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-apostrophe
-          </span>
+            <span
+              aria-label="Article Not Found: figs-apostrophe: Could not find article for figs-apostrophe"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-apostrophe
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="6"
@@ -858,16 +958,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-euphemism: Could not find article for figs-euphemism"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-euphemism
-          </span>
+            <span
+              aria-label="Article Not Found: figs-euphemism: Could not find article for figs-euphemism"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-euphemism
+              </span>
+            </span>
+          </Hint>
         </div>
       </div>
     </div>
@@ -1083,16 +1193,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-hypo: Could not find article for figs-hypo"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-hypo
-          </span>
+            <span
+              aria-label="Article Not Found: figs-hypo: Could not find article for figs-hypo"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-hypo
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="1"
@@ -1129,16 +1249,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-activepassive: Could not find article for figs-activepassive"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-activepassive
-          </span>
+            <span
+              aria-label="Article Not Found: figs-activepassive: Could not find article for figs-activepassive"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-activepassive
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="2"
@@ -1175,16 +1305,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-gendernotations: Could not find article for figs-gendernotations"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-gendernotations
-          </span>
+            <span
+              aria-label="Article Not Found: figs-gendernotations: Could not find article for figs-gendernotations"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-gendernotations
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="3"
@@ -1221,16 +1361,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-pronouns: Could not find article for figs-pronouns"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-pronouns
-          </span>
+            <span
+              aria-label="Article Not Found: figs-pronouns: Could not find article for figs-pronouns"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-pronouns
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="4"
@@ -1267,16 +1417,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-you: Could not find article for figs-you"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-you
-          </span>
+            <span
+              aria-label="Article Not Found: figs-you: Could not find article for figs-you"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-you
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="5"
@@ -1313,16 +1473,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-123person: Could not find article for figs-123person"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-123person
-          </span>
+            <span
+              aria-label="Article Not Found: figs-123person: Could not find article for figs-123person"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-123person
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="6"
@@ -1359,16 +1529,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-abstractnouns: Could not find article for figs-abstractnouns"
+            position="top-right"
+            size="large"
           >
-            translated: tool_card_categories.figs-abstractnouns
-          </span>
+            <span
+              aria-label="Article Not Found: figs-abstractnouns: Could not find article for figs-abstractnouns"
+              className="hint--top-right hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-abstractnouns
+              </span>
+            </span>
+          </Hint>
         </div>
         <div
           key="7"
@@ -1405,16 +1585,26 @@ exports[`translationNotes should have 4 boxes checked 1`] = `
               }
             />
           </div>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "cursor": "pointer",
-              }
-            }
+          <Hint
+            label="Article Not Found: figs-distinguish: Could not find article for figs-distinguish"
+            position="top-left"
+            size="large"
           >
-            translated: tool_card_categories.figs-distinguish
-          </span>
+            <span
+              aria-label="Article Not Found: figs-distinguish: Could not find article for figs-distinguish"
+              className="hint--top-left hint--large"
+            >
+              <span
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                translated: tool_card_categories.figs-distinguish
+              </span>
+            </span>
+          </Hint>
         </div>
       </div>
     </div>

--- a/src/js/components/home/toolsManagement/ToolCardBoxes.js
+++ b/src/js/components/home/toolsManagement/ToolCardBoxes.js
@@ -5,6 +5,7 @@ import {Glyphicon} from 'react-bootstrap';
 import {tNotesCategories} from "tsv-groupdata-parser";
 import * as ResourcesActions from "../../../actions/ResourcesActions";
 import {parseArticleAbstract} from "../../../helpers/ToolCardHelpers";
+import Hint from "../../Hint";
 /**
 *  Checkboxnames are derived first by what is in Gateway language resource
 *  translation notes FileFolder. This is mapped to the array in
@@ -135,14 +136,11 @@ class ToolCardBoxes extends React.Component {
     });
   }
 
-
-  onWordClick(event, category) {
-    const positionCoord = event.target;
+  getArticleText(category) {
     const fullText = this.state.articles[category];
-    const [title, intro] = parseArticleAbstract(fullText);
-    this.props.showPopover(title, intro, positionCoord);
+    const {title, intro} = parseArticleAbstract(fullText);
+    return title + ": " + intro;
   }
-
 
   render() {
     const {availableCategories = {}, toolName, selectedCategories, onChecked, translate} = this.props;
@@ -164,7 +162,7 @@ class ToolCardBoxes extends React.Component {
                     </div>
                   </div>
                   <React.Fragment>
-                    {toolName != 'translationWords' ? (
+                    {toolName !== 'translationWords' ? (
                       <div style={{alignSelf: 'flex-end'}}>
                         <Glyphicon // ^ or v
                           style={{
@@ -187,10 +185,11 @@ class ToolCardBoxes extends React.Component {
                             <div style={{marginLeft: '36px', width: '38px'}}>
                               {localCheckBox(selectedCategories, subcategory, toolName, onChecked)}
                             </div>
-                            <span onClick={(event) => this.onWordClick(event, subcategory)}
-                                style={{cursor: "pointer"}} >
-                              { translate(lookupNames[postPart(subcategory)]) }
-                            </span>
+                            <Hint position={((index % 2) === 1) ? 'top-left' : 'top-right'} label={this.getArticleText(subcategory)} size={'large'}>
+                              <span style={{cursor: "pointer"}} >
+                                {translate(lookupNames[postPart(subcategory)])}
+                              </span>
+                            </Hint>
                           </div>
                         ))
                         }

--- a/src/js/helpers/ToolCardHelpers.js
+++ b/src/js/helpers/ToolCardHelpers.js
@@ -53,7 +53,7 @@ export function isToolSupported(bookId, developerMode) {
  * adds "..." if longer than MAX_TEXT
  */
 export function parseArticleAbstract(fullText) {
-  const MAX_TEXT = 300;
+  const MAX_TEXT = 350;
 
   // get title from start of text
   const parts = fullText.split("#");
@@ -77,8 +77,22 @@ export function parseArticleAbstract(fullText) {
   }
 
   // remove markup
-  const stripped = partial.replace(/([#*]|<\/?u>)/gm, "").trim();
-  let intro = stripped;
+  let stripped = partial;
+  const replacements = [
+    {
+      match: /([#*]|<\/?u>|<\/?sup>)/gm,
+      replace: ""
+    },
+    {
+      match: /(\n>)|(\n\d.)/gm,
+      replace: "\n"
+    }
+  ];
+  for (let i = 0, l= replacements.length; i < l; i++) {
+    const r = replacements[i];
+    stripped = stripped.replace(r.match, r.replace);
+  }
+  let intro = stripped.trim();
 
   // trucate with ellipsis
   if(stripped.length > MAX_TEXT) {

--- a/src/js/helpers/ToolCardHelpers.js
+++ b/src/js/helpers/ToolCardHelpers.js
@@ -32,20 +32,20 @@ export function isToolSupported(bookId, developerMode) {
 
 /**
  * @Description simplify markdown formatted tA article for uss as an abstract in tN toolcard
- * @param {string} fullText - unparsed text from tA article 
+ * @param {string} fullText - unparsed text from tA article
  * @return {array} [title, intro] - parses out introductory material
- * 
- * tA articles are generally of the form: 
- * 
+ *
+ * tA articles are generally of the form:
+ *
  * <title>
  * [<introductory material>]
  * [Description]
  * <descriptive material>
- * 
+ *
  * where
- *   <variable> 
+ *   <variable>
  *   [optional]
- * 
+ *
  * parser returns introductory material if there is any
  * returns descriptive material if no introductory material
  * removes other markdown notation
@@ -53,8 +53,8 @@ export function isToolSupported(bookId, developerMode) {
  * adds "..." if longer than MAX_TEXT
  */
 export function parseArticleAbstract(fullText) {
-  const MAX_TEXT = 450;
- 
+  const MAX_TEXT = 300;
+
   // get title from start of text
   const parts = fullText.split("#");
   const title = parts[1].trim();
@@ -87,5 +87,5 @@ export function parseArticleAbstract(fullText) {
     intro = truncated.substr(0, MAX_TEXT - (MAX_TEXT - lastSpace)) + "...";
   }
 
-  return [title, intro];
+  return {title, intro};
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix to strip out additional markdown
- fixed hovers for tN toolcard categories

#### Please include detailed Test instructions for your pull request:
- to see the specific failures in issue, can open an acts project
- on the tN toolcard, expand `figures of speech`.  Hover over `hyperbole` and Hint should show without markdown characters.
- on the tN toolcard, expand `numbers`.  Hover over `ordinal numbers` and Hint should show without markdown characters.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6034)
<!-- Reviewable:end -->
