### PR TITLE
Bugfix 5755/Fix spacing for tN toolcard sub-categories

### DIFF
--- a/src/js/components/home/toolsManagement/ToolCardBoxes.js
+++ b/src/js/components/home/toolsManagement/ToolCardBoxes.js
@@ -198,13 +198,13 @@ class ToolCardBoxes extends React.Component {
                           return 0;
                         }).map((subcategory, index) => (
                           <div style={{display: 'flex', width: '48%'}} key={index} >
-                            <div style={{marginLeft: '36px', width: '38px'}}>
+                            <div style={{marginLeft: '36px', marginRight: '10px'}}>
                               {localCheckBox(classes, selectedCategories, subcategory, toolName, onChecked)}
                             </div>
                             <Hint position={((index % 2) === 1) ? 'top-left' : 'top-right'} label={this.getArticleText(subcategory)} size={'large'}>
-                              <span style={{cursor: "pointer"}} >
+                              <div style={{cursor: "pointer"}} >
                                 {translate(lookupNames[subcategory])}
-                              </span>
+                              </div>
                             </Hint>
                           </div>
                         ))


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix alignment issues for tN toolcard sub-categories that were looking like this:

![Screen Shot 2019-05-06 at 7 47 42 AM](https://user-images.githubusercontent.com/14238574/57249656-83d56280-7013-11e9-9919-bf2656b03413.png)


#### Please include detailed Test instructions for your pull request:
- open any project and on tN toolcard expand categories.  Spacing between checkbox and text should be consistent, such as:

![Screen Shot 2019-05-06 at 3 28 55 PM](https://user-images.githubusercontent.com/14238574/57249848-03fbc800-7014-11e9-8842-993d8135685d.png)


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6049)
<!-- Reviewable:end -->
