### PR TITLE
Bugfix 5996/Fix to set default project categories for tW

### DIFF
--- a/src/js/actions/MyProjects/ProjectLoadingActions.js
+++ b/src/js/actions/MyProjects/ProjectLoadingActions.js
@@ -143,9 +143,7 @@ export const openProject = (name, skipValidation=false) => {
 
         // select default categories
         const language = getToolGatewayLanguage(getState(), t.name);
-        if (t.name !== "translationWords") {
-          setDefaultProjectCategories(language, t.name, validProjectDir);
-        }
+        setDefaultProjectCategories(language, t.name, validProjectDir);
 
         // connect tool api
         console.log("openProject() - connect tool api");

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -45,17 +45,19 @@ export function copyGroupDataToProject(gatewayLanguage, toolName, projectDir) {
     }
     const categories = getAvailableCategories(gatewayLanguage, toolName, projectDir);
     const categoryKeys = Object.keys(categories);
-    categoryKeys.forEach((category) => {
+    for (let i = 0, l = categoryKeys.length; i < l; i++) {
+      const category = categoryKeys[i];
       const resourceCategoryDir = path.join(helpDir, category, 'groups', project.getBookId());
       const altResourceCategoryDir = path.join(helpDir, 'groups', project.getBookId());
       let groupsDir = resourceCategoryDir;
       if (!fs.pathExistsSync(resourceCategoryDir)) {
         groupsDir = altResourceCategoryDir;
       }
-      categories[category].forEach((subCategory) => {
+      for (let j = 0, l2 = categories[category].length; j < l2; j++) {
+        const subCategory = categories[category][j];
         const dataPath = path.join(groupsDir, subCategory + '.json');
         project.importCategoryGroupData(toolName, dataPath);
-      });
+      }
       // TRICKY: gives the tool an index of which groups belong to which category
       project.setCategoryGroupIds(toolName, category, categories[category]);
       // loading complete
@@ -63,11 +65,12 @@ export function copyGroupDataToProject(gatewayLanguage, toolName, projectDir) {
         // for tW we don't select by subcategories
         project.setCategoryLoaded(toolName, category);
       } else {
-        categories[category].forEach((subCategory) => {
+        for (let k = 0, l3 = categories[category].length; k < l3; k++) {
+          const subCategory = categories[category][k];
           project.setCategoryLoaded(toolName, subCategory);
-        });
+        }
       }
-    });
+    }
     project.removeStaleCategoriesFromCurrent(toolName, categories);
   } else {
     // generate chapter-based group data
@@ -151,14 +154,20 @@ export function setDefaultProjectCategories(gatewayLanguage, toolName, projectDi
   const helpDir = resources.getLatestTranslationHelp(gatewayLanguage, toolName);
   let categories = [];
   if (helpDir && project.getSelectedCategories(toolName).length === 0) {
-    let parentCategories = fs.readdirSync(helpDir).filter(file => {
-      return fs.lstatSync(path.join(helpDir, file)).isDirectory();
-    });
-    parentCategories.forEach((subCategory) => {
-      categories = categories.concat(project.getCategoryGroupIds(toolName, subCategory));
-    });
-    if (categories.length > 0) {
-      project.setSelectedCategories(toolName, categories);
+    if (toolName === "translationWords") { // for tW we select by parent categories
+      const parentCategories = getAvailableCategories(gatewayLanguage, toolName, projectDir);
+      project.setSelectedCategories(toolName, Object.keys(parentCategories));
+    } else {
+      let parentCategories = fs.readdirSync(helpDir).filter(file => {
+        return fs.lstatSync(path.join(helpDir, file)).isDirectory();
+      });
+      for (let i = 0, l = parentCategories.length; i < l; i++) {
+        const subCategory = parentCategories[i];
+        categories = categories.concat(project.getCategoryGroupIds(toolName, subCategory));
+      }
+      if (categories.length > 0) {
+        project.setSelectedCategories(toolName, categories);
+      }
     }
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes to set default project categories for tW.

#### Please include detailed Test instructions for your pull request:
- checkout branch, do `npm run load-apps`, `npm ci`, `npm start`
- import new USFM project.
- tW toolcard should default to all categories selected.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6052)
<!-- Reviewable:end -->
