### PR TITLE
Changed the "other term" category label to "other" for tN tool card

### DIFF
--- a/src/js/components/home/toolsManagement/ToolCardBoxes.js
+++ b/src/js/components/home/toolsManagement/ToolCardBoxes.js
@@ -30,13 +30,14 @@ const styles = {
 const toolCardCategories = {
   'kt': 'Key Terms',
   'names': 'Names',
-  'other': 'Other Terms',
+  'other_terms': 'Other Terms',
 
   'culture': 'Culture',
   'figures': 'Figures of Speech',
   'numbers': 'Numbers',
   'discourse': 'Discourse',
-  'grammar': 'Grammar'
+  'grammar': 'Grammar',
+  'other': 'Other'
 };
 
 /**
@@ -159,8 +160,10 @@ class ToolCardBoxes extends React.Component {
         {
           Object.keys(availableCategories).map((parentCategory, index) => {
             const subcategories = availableCategories[parentCategory];
+            parentCategory = parentCategory === 'other' && toolName == 'translationWords' ?
+              'other_terms' : parentCategory;
             return subcategories.length > 0 &&
-              tNotesCategories[parentCategory] || toolName == 'translationWords' ?
+              tNotesCategories[parentCategory] || toolName === 'translationWords' ?
               (
                 <div style={{display: 'flex', flexWrap: 'wrap', margin: '0 0 5 0', width: '100%'}} key={index}>
                   <div style={{display: 'flex', width: '92%'}}>

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -411,9 +411,10 @@
     "retry": "Retry"
   },
   "tool_card_categories": {
-    "kt":       "Key Terms",
-    "names":    "Names",
-    "other":    "Other Terms",
+    "kt": "Key Terms",
+    "names": "Names",
+    "other_terms": "Other Terms",
+    "other": "Other",
     "translate-manuscripts": "Original Manuscripts",
     "guidelines-sonofgodprinciples": "Translating Son and Father",
     "translate-textvariants": "Textual Variants",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Open a project that includes the other category for tN (Like an acts project for example)
- You should see the other category label as just "other" instead of "other terms" for the tN tool card

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6053)
<!-- Reviewable:end -->
