### PR TITLE
Bugfix 6062/Fix problem that resources that were not updated were replaced with empty zip

### DIFF
--- a/__tests__/zipHelpers.test.js
+++ b/__tests__/zipHelpers.test.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+
+import * as zipHelpers from '../scripts/resources/zipHelpers';
+import path from 'path-extra';
+import ospath from 'ospath';
+import fs from "fs-extra";
+import AdmZip from 'adm-zip';
+
+const RESOURCES_PATH = path.join(ospath.home(), 'translationCore', 'resources');
+
+describe('zipHelpers.zipResourcesContent', () => {
+  const jsonStuff = { stuff: "stuff"};
+
+  beforeEach(() => {
+    // reset mock filesystem data
+    fs.__resetMockFS();
+  });
+
+  it('should zip bible', async () => {
+    // given
+    const languageId = "el-x-koine";
+    const version = "0.5";
+    const bibleId = "ugnt";
+    const contentType = "bibles";
+    const resourcePath = path.join(RESOURCES_PATH, languageId, contentType, bibleId, version);
+    fs.ensureDirSync(resourcePath);
+    fs.outputJsonSync(path.join(resourcePath, "index.json"), jsonStuff);
+    fs.outputJsonSync(path.join(resourcePath, "manifest.json"), jsonStuff);
+    const bookPath = path.join(resourcePath, 'tit');
+    fs.outputJsonSync(path.join(bookPath, "1.json"), jsonStuff);
+
+    // when
+    await zipHelpers.zipResourcesContent(RESOURCES_PATH, languageId);
+
+    // then
+    expect(true).toEqual(false);
+  });
+});
+

--- a/__tests__/zipHelpers.test.js
+++ b/__tests__/zipHelpers.test.js
@@ -4,7 +4,17 @@ import * as zipHelpers from '../scripts/resources/zipHelpers';
 import path from 'path-extra';
 import ospath from 'ospath';
 import fs from "fs-extra";
-import AdmZip from 'adm-zip';
+
+const mockAddLocalFolder = jest.fn();
+const mockWriteZip = jest.fn();
+jest.mock('adm-zip', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      addLocalFolder: mockAddLocalFolder,
+      writeZip: mockWriteZip
+    };
+  });
+});
 
 const RESOURCES_PATH = path.join(ospath.home(), 'translationCore', 'resources');
 
@@ -16,10 +26,16 @@ describe('zipHelpers.zipResourcesContent', () => {
     fs.__resetMockFS();
   });
 
+  afterEach(() => {
+    mockAddLocalFolder.mockClear(); // clear call counts, but leave mock
+    mockWriteZip.mockClear();
+  });
+
   it('should zip bible', async () => {
     // given
+    const expectZip = true;
     const languageId = "el-x-koine";
-    const version = "0.5";
+    const version = "v0.5";
     const bibleId = "ugnt";
     const contentType = "bibles";
     const resourcePath = path.join(RESOURCES_PATH, languageId, contentType, bibleId, version);
@@ -33,7 +49,64 @@ describe('zipHelpers.zipResourcesContent', () => {
     await zipHelpers.zipResourcesContent(RESOURCES_PATH, languageId);
 
     // then
-    expect(true).toEqual(false);
+    expect(mockWriteZip).toHaveBeenCalledTimes(expectZip ? 1 : 0);
+  });
+
+  it('should skip already zipped bible', async () => {
+    // given
+    const expectZip = false;
+    const languageId = "el-x-koine";
+    const version = "v0.5";
+    const bibleId = "ugnt";
+    const contentType = "bibles";
+    const resourcePath = path.join(RESOURCES_PATH, languageId, contentType, bibleId, version);
+    fs.ensureDirSync(resourcePath);
+    fs.outputJsonSync(path.join(resourcePath, "index.json"), jsonStuff);
+    fs.outputJsonSync(path.join(resourcePath, "manifest.json"), jsonStuff);
+    fs.outputJsonSync(path.join(resourcePath, "books.zip"), jsonStuff);
+
+    // when
+    await zipHelpers.zipResourcesContent(RESOURCES_PATH, languageId);
+
+    // then
+    expect(mockWriteZip).toHaveBeenCalledTimes(expectZip ? 1 : 0);
+  });
+
+  it('should zip content', async () => {
+    // given
+    const expectZip = true;
+    const languageId = "el-x-koine";
+    const version = "v0.5";
+    const contentType = "translationWords";
+    const resourcePath = path.join(RESOURCES_PATH, languageId, 'translationHelps', contentType, version);
+    fs.ensureDirSync(resourcePath);
+    fs.outputJsonSync(path.join(resourcePath, "index.json"), jsonStuff);
+    fs.outputJsonSync(path.join(resourcePath, "manifest.json"), jsonStuff);
+    const contentPath = path.join(resourcePath, 'kt/groups/tit');
+    fs.outputJsonSync(path.join(contentPath, "apostle.json"), jsonStuff);
+
+    // when
+    await zipHelpers.zipResourcesContent(RESOURCES_PATH, languageId);
+
+    // then
+    expect(mockWriteZip).toHaveBeenCalledTimes(expectZip ? 1 : 0);
+  });
+
+  it('should skip already zipped content', async () => {
+    // given
+    const expectZip = false;
+    const languageId = "el-x-koine";
+    const version = "v0.5";
+    const contentType = "translationWords";
+    const resourcePath = path.join(RESOURCES_PATH, languageId, 'translationHelps', contentType, version);
+    fs.ensureDirSync(resourcePath);
+    fs.outputJsonSync(path.join(resourcePath, "contents.zip"), jsonStuff);
+
+    // when
+    await zipHelpers.zipResourcesContent(RESOURCES_PATH, languageId);
+
+    // then
+    expect(mockWriteZip).toHaveBeenCalledTimes(expectZip ? 1 : 0);
   });
 });
 

--- a/scripts/resources/zipHelpers.js
+++ b/scripts/resources/zipHelpers.js
@@ -22,10 +22,14 @@ const zipResourcesContent = async (resourcesRootPath, languageId) => {
       try {
         const resourceIdPath = path.join(resourcesPath, resourceId);
         const resourcesContentPath = updateResourcesHelpers.getLatestVersionInPath(resourceIdPath);
+        const contentType = resourceType === 'bibles' ? 'books' : 'contents';
+        if (fs.existsSync(path.join(resourcesContentPath, contentType + '.zip'))) {
+          console.log(`Resource was not updated, skipping: ${languageId} ${resourceId}`);
+          return;
+        }
         const excludedItems = ['index.json', 'manifest.json', 'books', 'books.zip', 'contents.zip', '.DS_Store'];
         const resources = fs.readdirSync(resourcesContentPath)
           .filter(item => !excludedItems.includes(item));
-        const contentType = resourceType === 'bibles' ? 'books' : 'contents';
         fs.ensureDirSync(path.join(resourcesContentPath, contentType));
         const resourcessPath = path.join(resourcesContentPath, contentType);
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added check to zipResourcesContent() so make sure we don't try to recompress resources that have not been updated.

#### Please include detailed Test instructions for your pull request:
- checkout branch, do `npm run load-apps`, `npm ci`
- do `npm run update-resources` as of 5/10/2019 should see:
  - el-x-koine ugnt updated from 0.5 to 0.6
  - el-x-koine translationWords updated from 0.5 to 0.6
  - en t2t added
  - en_udb not updated
  - en_ulb not updated
  - en_ult updated to v3
  - en_ust not updated
  - hbo uhb not updated
  - hbo tw not updated
  - hi irv updated to v3
  - hi udb updated to v5.7
  - hi ulb not updated
  - hi ta installs v10.3
  - hi tn installs to v13.5
  - hi tw not updated
- check that resources that were not updated do not have an empty book.zip or content.zip file (size of empty zip would be under 100 bytes).


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6074)
<!-- Reviewable:end -->
