### PR TITLE
Bugfix 6088/fix external verse edits in TW

### DIFF
--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -7,12 +7,69 @@ import { generateTimestamp } from '../src/js/helpers';
 import * as GroupsDataActions from '../src/js/actions/GroupsDataActions';
 import * as saveMethods from '../src/js/localStorage/saveMethods';
 
+jest.mock('redux-batched-actions', () => ({
+  batchActions: (actionsBatch) => {
+    return (dispatch) => {
+      if (actionsBatch.length) {
+        for (let action of actionsBatch) {
+          dispatch(action);
+        }
+      }
+    };
+  }
+}));
+
 // constants
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 const CHECK_DATA_PATH = path.join(__dirname, 'fixtures', 'checkData');
 const PROJECTS_PATH = path.join(__dirname, 'fixtures', 'project', 'en_tit');
-let mock_addNewBible = jest.fn();
+
+describe('GroupsDataActions.verifyGroupDataMatchesWithFs', () => {
+  let saveOtherContextSpy = null;
+
+  beforeEach(() => {
+    saveOtherContextSpy = jest.spyOn(saveMethods,
+      'saveSelectionsForOtherContext');
+    fs.__resetMockFS();
+    fs.__loadDirIntoMockFs(CHECK_DATA_PATH, CHECK_DATA_PATH);
+    fs.__loadDirIntoMockFs(PROJECTS_PATH, PROJECTS_PATH);
+  });
+
+  afterEach(() => {
+    removeSpy(saveOtherContextSpy);
+  });
+
+  it('should succeed without external verse edits', () => {
+    // given
+    const bookId = 'tit';
+    const groupsDataReducer = fs.readJsonSync(path.join(CHECK_DATA_PATH, 'en_tit', 'groupsDataReducer.json'));
+    const initStore = {
+      groupsDataReducer,
+      toolsReducer: {
+        selectedTool: 'translationWords'
+      },
+      projectDetailsReducer: {
+        manifest: {
+          project: {
+            id: bookId
+          }
+        },
+        projectSaveLocation: PROJECTS_PATH
+      }
+    };
+    const store = mockStore(initStore);
+    const expectedSelectionChanges = 0;
+
+    // when
+    store.dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+
+    // then
+    const actions = store.getActions();
+    expect(cleanOutDates(actions)).toMatchSnapshot();
+    expect(saveOtherContextSpy).toHaveBeenCalledTimes(expectedSelectionChanges);
+  });
+});
 
 describe('GroupsDataActions.validateBookSelections', () => {
   const bookId = 'tit';
@@ -34,6 +91,7 @@ describe('GroupsDataActions.validateBookSelections', () => {
   beforeEach(() => {
     saveOtherContextSpy = jest.spyOn(saveMethods,
       'saveSelectionsForOtherContext');
+    fs.__resetMockFS();
     fs.__loadDirIntoMockFs(CHECK_DATA_PATH, CHECK_DATA_PATH);
     fs.__loadDirIntoMockFs(PROJECTS_PATH, PROJECTS_PATH);
   });

--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -6,6 +6,7 @@ import path from 'path-extra';
 import { generateTimestamp } from '../src/js/helpers';
 import * as GroupsDataActions from '../src/js/actions/GroupsDataActions';
 import * as saveMethods from '../src/js/localStorage/saveMethods';
+import {delay} from "../src/js/helpers/bodyUIHelpers";
 
 jest.mock('redux-batched-actions', () => ({
   batchActions: (actionsBatch) => {
@@ -40,7 +41,7 @@ describe('GroupsDataActions.verifyGroupDataMatchesWithFs', () => {
     removeSpy(saveOtherContextSpy);
   });
 
-  it('should succeed without external verse edits', () => {
+  it('should succeed without external verse edits', async () => {
     // given
     const bookId = 'tit';
     const groupsDataReducer = fs.readJsonSync(path.join(CHECK_DATA_PATH, 'en_tit', 'groupsDataReducer.json'));
@@ -59,17 +60,49 @@ describe('GroupsDataActions.verifyGroupDataMatchesWithFs', () => {
       }
     };
     const store = mockStore(initStore);
-    const expectedSelectionChanges = 0;
 
     // when
     store.dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+    await delay(1000);
 
     // then
     const actions = store.getActions();
     expect(cleanOutDates(actions)).toMatchSnapshot();
-    expect(saveOtherContextSpy).toHaveBeenCalledTimes(expectedSelectionChanges);
   });
-});
+
+  it('should succeed with external verse edits', async () => {
+    // given
+    const bookId = 'tit';
+    const groupsDataReducer = fs.readJsonSync(path.join(CHECK_DATA_PATH, 'en_tit', 'groupsDataReducer.json'));
+    const initStore = {
+      groupsDataReducer,
+      toolsReducer: {
+        selectedTool: 'translationWords'
+      },
+      projectDetailsReducer: {
+        manifest: {
+          project: {
+            id: bookId
+          }
+        },
+        projectSaveLocation: PROJECTS_PATH
+      }
+    };
+    const store = mockStore(initStore);
+    const verseEdit = {"verseBefore":"To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior.\n\\p","verseAfter":"To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior.\n\\p Edit 1:4","tags":["other"],"userName":"photonomad1","activeBook":"tit","activeChapter":1,"activeVerse":1,"modifiedTimestamp":"2019-05-16T12:11:45.970Z","gatewayLanguageCode":"en","gatewayLanguageQuote":"","contextId":{"reference":{"bookId":"tit","chapter":1,"verse":4},"tool":"wordAlignment","groupId":"chapter_1"}};
+    const verseEditPath = path.join(PROJECTS_PATH, ".apps/translationCore/checkData", "verseEdits", bookId, "1", "4");
+    fs.ensureDirSync(verseEditPath);
+    const fileName = generateTimestamp() + ".json";
+    fs.outputJsonSync(path.join(verseEditPath, fileName), verseEdit);
+
+    // when
+    store.dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+    await delay(1000);
+
+    // then
+    const actions = store.getActions();
+    expect(cleanOutDates(actions)).toMatchSnapshot();
+  });});
 
 describe('GroupsDataActions.validateBookSelections', () => {
   const bookId = 'tit';

--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -89,6 +89,7 @@ describe('GroupsDataActions.verifyGroupDataMatchesWithFs', () => {
       }
     };
     const store = mockStore(initStore);
+    // add verse edit
     const verseEdit = {"verseBefore":"To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior.\n\\p","verseAfter":"To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior.\n\\p Edit 1:4","tags":["other"],"userName":"photonomad1","activeBook":"tit","activeChapter":1,"activeVerse":1,"modifiedTimestamp":"2019-05-16T12:11:45.970Z","gatewayLanguageCode":"en","gatewayLanguageQuote":"","contextId":{"reference":{"bookId":"tit","chapter":1,"verse":4},"tool":"wordAlignment","groupId":"chapter_1"}};
     const verseEditPath = path.join(PROJECTS_PATH, ".apps/translationCore/checkData", "verseEdits", bookId, "1", "4");
     fs.ensureDirSync(verseEditPath);

--- a/__tests__/__snapshots__/GroupsDataActions.test.js.snap
+++ b/__tests__/__snapshots__/GroupsDataActions.test.js.snap
@@ -133,3 +133,44 @@ Array [
   },
 ]
 `;
+
+exports[`GroupsDataActions.verifyGroupDataMatchesWithFs should succeed without external verse edits 1`] = `
+Array [
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+]
+`;

--- a/__tests__/__snapshots__/GroupsDataActions.test.js.snap
+++ b/__tests__/__snapshots__/GroupsDataActions.test.js.snap
@@ -134,6 +134,202 @@ Array [
 ]
 `;
 
+exports[`GroupsDataActions.verifyGroupDataMatchesWithFs should succeed with external verse edits 1`] = `
+Array [
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "christ",
+      "occurrence": 1,
+      "quote": "Χριστοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G55470",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "faith",
+      "occurrence": 1,
+      "quote": "πίστιν",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G41020",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "godthefather",
+      "occurrence": 1,
+      "quote": "Θεοῦ Πατρὸς",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G23160",
+        "G39620",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "grace",
+      "occurrence": 1,
+      "quote": "χάρις",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G54850",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "jesus",
+      "occurrence": 1,
+      "quote": "Χριστοῦ Ἰησοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G55470",
+        "G24240",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "savior",
+      "occurrence": 1,
+      "quote": "Σωτῆρος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G49900",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "son",
+      "occurrence": 1,
+      "quote": "τέκνῳ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G50430",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "true",
+      "occurrence": 1,
+      "quote": "γνησίῳ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 4,
+      },
+      "strong": Array [
+        "G11030",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "TOGGLE_VERSE_EDITS_IN_GROUPDATA",
+  },
+]
+`;
+
 exports[`GroupsDataActions.verifyGroupDataMatchesWithFs should succeed without external verse edits 1`] = `
 Array [
   Object {

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -8,7 +8,7 @@ import path from 'path-extra';
 import {showSelectionsInvalidatedWarning, validateAllSelectionsForVerse} from "./SelectionsActions";
 import { getSelectedToolName } from "../selectors";
 import { readLatestChecks } from "../helpers/groupDataHelpers";
-import {setCheckVerseEditsInGroupDataFromArray} from "./VerseEditActions";
+import {ensureCheckVerseEditsInGroupData} from "./VerseEditActions";
 // consts declaration
 const CHECKDATA_DIRECTORY = path.join('.apps', 'translationCore', 'checkData');
 
@@ -96,7 +96,7 @@ export function verifyGroupDataMatchesWithFs() {
         }
       }
       if (checkVerseEdits.length) {
-        dispatch(setCheckVerseEditsInGroupDataFromArray(checkVerseEdits));
+        dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));
       }
       // run the batch of queue actions
       if (actionsBatch.length) {

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -95,11 +95,11 @@ export const getCheckVerseEditsInGroupData = (state, contextId, actionsBatch) =>
 };
 
 /**
- * set verse edit flag for all tw checks in verse if not set
- * @param {Array} twVerseEdits - of verse edit contextIds
+ * make sure verse edit flag is set for all tw checks in verses
+ * @param {Array} twVerseEdits - of contextIds for each verse edit
  * @return {Function}
  */
-export const setCheckVerseEditsInGroupDataFromArray = (twVerseEdits) => {
+export const ensureCheckVerseEditsInGroupData = (twVerseEdits) => {
   return async (dispatch, getState) => {
     if (twVerseEdits && twVerseEdits.length) {
       const state = getState();

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -4,6 +4,7 @@ import types from './ActionTypes';
 // actions
 import {getGroupDataForVerse, showSelectionsInvalidatedWarning, validateSelections} from "./SelectionsActions";
 import * as AlertModalActions from "./AlertModalActions";
+import {batchActions} from "redux-batched-actions";
 // helpers
 import {generateTimestamp} from '../helpers/index';
 import * as gatewayLanguageHelpers from '../helpers/gatewayLanguageHelpers';
@@ -62,6 +63,56 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit) => {
       verseEdit.contextId.reference.verse.toString());
     fs.ensureDirSync(verseEditsPath);
     fs.outputJSONSync(path.join(verseEditsPath, newFilename.replace(/[:"]/g, '_')), verseEdit);
+  };
+};
+
+/**
+ * batch setting verse edit flags for all tw checks in verse if not set
+ * @param {Object} state - current state
+ * @param {Object} contextId - of verse edit
+ * @param {Array} actionsBatch - array append with verse edits to be batched
+ */
+export const getCheckVerseEditsInGroupData = (state, contextId, actionsBatch) => {
+  // in group data reducer set verse edit flag for every check of the verse edited
+  const matchedGroupData = getGroupDataForVerse(state, contextId);
+  const keys = Object.keys(matchedGroupData);
+  if (keys.length) {
+    for (let i = 0, l = keys.length; i < l; i++) {
+      const groupItem = matchedGroupData[keys[i]];
+      if (groupItem) {
+        for (let j = 0, lenGI = groupItem.length; j < lenGI; j++) {
+          const check = groupItem[j];
+          if (!check.verseEdits) { // only set if not yet set
+            actionsBatch.push({
+              type: types.TOGGLE_VERSE_EDITS_IN_GROUPDATA,
+              contextId: check.contextId
+            });
+          }
+        }
+      }
+    }
+  }
+};
+
+/**
+ * set verse edit flag for all tw checks in verse if not set
+ * @param {Array} twVerseEdits - of verse edit contextIds
+ * @return {Function}
+ */
+export const setCheckVerseEditsInGroupDataFromArray = (twVerseEdits) => {
+  return async (dispatch, getState) => {
+    if (twVerseEdits && twVerseEdits.length) {
+      const state = getState();
+      const actionsBatch = [];
+      for (let i = 0, lenVE = twVerseEdits.length; i < lenVE; i++) {
+        const contextId = twVerseEdits[i];
+        getCheckVerseEditsInGroupData(state, contextId, actionsBatch);
+      }
+      if (actionsBatch.length) {
+        await delay(500);
+        dispatch(batchActions(actionsBatch));
+      }
+    }
   };
 };
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- copy fixes in develop branch to fix problem that external verse edits not showing up in tW.  This had already been fixed in 1.2.0.

#### Please include detailed Test instructions for your pull request:
- checkout branch, do `npm run load-apps`, `npm ci`, `npm start`
- follow steps in issue https://github.com/unfoldingWord-dev/translationCore/issues/6088 and external verse edits should show up.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6090)
<!-- Reviewable:end -->
