### PR TITLE
Bugfix 6072/Fix for migrating checks from 1.1.4 to 1.2.0

### DIFF
--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -243,7 +243,7 @@ export default class ProjectAPI {
         }
         const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
         const {modified: lastTimeDataDownloaded} = fs.readJSONSync(sourceContentManifestPath);
-        return new Date(lastTimeDataDownloaded) > new Date(lastTimeDataUpdated);
+        return new Date(lastTimeDataDownloaded) != new Date(lastTimeDataUpdated);
       } catch (e) {
         console.warn(
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
@@ -349,7 +349,9 @@ export default class ProjectAPI {
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
       }
     }
-    data.timestamp = generateTimestamp();
+    const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
+    const {modified: lastTimeDataDownloaded} = fs.readJSONSync(sourceContentManifestPath);
+    data.timestamp = lastTimeDataDownloaded;
     fs.outputJsonSync(categoriesPath, data);
   }
 

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -2,11 +2,11 @@ import path from "path-extra";
 import ospath from "ospath";
 import fs from "fs-extra";
 import {generateTimestamp} from "./TimestampGenerator";
-export const USER_RESOURCES_PATH = path.join(ospath.home(), "translationCore",
-  "resources");
 // actions
 import {loadCheckData} from '../actions/CheckDataLoadActions';
 // constants
+export const USER_RESOURCES_PATH = path.join(ospath.home(), "translationCore",
+  "resources");
 const PROJECT_TC_DIR = path.join('.apps', 'translationCore');
 const CHECKDATA_DIRECTORY = path.join(PROJECT_TC_DIR, 'checkData');
 
@@ -229,7 +229,7 @@ export default class ProjectAPI {
    * Method to check if project groups data is out of date in relation
    * to the last source content update
    * @param {string} toolName - the tool name. This is synonymous with translationHelp name
-   * @returns {Boolean}
+   * @returns {Boolean} returns true if group data needs to be updated
    */
   hasNewGroupsData(toolName) {
     const categoriesPath = path.join(this.getCategoriesDir(toolName),
@@ -242,8 +242,8 @@ export default class ProjectAPI {
           return true;
         }
         const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
-        const {modified: lastTimeDataDownloaded} = fs.readJSONSync(sourceContentManifestPath);
-        return new Date(lastTimeDataDownloaded) != new Date(lastTimeDataUpdated);
+        const {modified: lastTimeDataDownloaded} = fs.readJsonSync(sourceContentManifestPath);
+        return new Date(lastTimeDataDownloaded).getTime() !== new Date(lastTimeDataUpdated).getTime();
       } catch (e) {
         console.warn(
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
@@ -350,7 +350,7 @@ export default class ProjectAPI {
       }
     }
     const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
-    const {modified: lastTimeDataDownloaded} = fs.readJSONSync(sourceContentManifestPath);
+    const {modified: lastTimeDataDownloaded} = fs.readJsonSync(sourceContentManifestPath);
     data.timestamp = lastTimeDataDownloaded;
     fs.outputJsonSync(categoriesPath, data);
   }

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 import {generateTimestamp} from "./TimestampGenerator";
 // actions
 import {loadCheckData} from '../actions/CheckDataLoadActions';
+import {SOURCE_CONTENT_UPDATER_MANIFEST} from '../helpers/ResourcesHelpers';
 // constants
 export const USER_RESOURCES_PATH = path.join(ospath.home(), "translationCore",
   "resources");
@@ -241,7 +242,7 @@ export default class ProjectAPI {
         if (!lastTimeDataUpdated) {
           return true;
         }
-        const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
+        const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, SOURCE_CONTENT_UPDATER_MANIFEST);
         const {modified: lastTimeDataDownloaded} = fs.readJsonSync(sourceContentManifestPath);
         return new Date(lastTimeDataDownloaded).getTime() !== new Date(lastTimeDataUpdated).getTime();
       } catch (e) {
@@ -349,7 +350,7 @@ export default class ProjectAPI {
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
       }
     }
-    const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, 'source-content-updater-manifest.json');
+    const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, SOURCE_CONTENT_UPDATER_MANIFEST);
     const {modified: lastTimeDataDownloaded} = fs.readJsonSync(sourceContentManifestPath);
     data.timestamp = lastTimeDataDownloaded;
     fs.outputJsonSync(categoriesPath, data);

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -29,6 +29,7 @@ export const STATIC_RESOURCES_PATH = path.join(__dirname,
   "../../../tcResources");
 const testResourcesPath = path.join('__tests__', 'fixtures', 'resources');
 export const TC_VERSION = "tc_version";
+export const SOURCE_CONTENT_UPDATER_MANIFEST = "source-content-updater-manifest.json";
 
 /**
  * Copies all of a tool's group data from the global resources into a project.
@@ -233,8 +234,8 @@ export const updateSourceContentUpdaterManifest = (dateStr = null) => {
       modified: generateTimestamp(dateStr),
       [TC_VERSION]: APP_VERSION
     };
-    const destinationPath = path.join(USER_RESOURCES_PATH,
-      "source-content-updater-manifest.json");
+  const destinationPath = path.join(USER_RESOURCES_PATH,
+      SOURCE_CONTENT_UPDATER_MANIFEST);
     fs.ensureDirSync(USER_RESOURCES_PATH);
     fs.outputJsonSync(destinationPath, manifest);
 };
@@ -244,12 +245,12 @@ export const updateSourceContentUpdaterManifest = (dateStr = null) => {
  */
 export const copySourceContentUpdaterManifest = () => {
   const sourceContentUpdaterManifestPath = path.join(STATIC_RESOURCES_PATH,
-    "source-content-updater-manifest.json");
+    SOURCE_CONTENT_UPDATER_MANIFEST);
   if (fs.existsSync(sourceContentUpdaterManifestPath)) {
     const bundledManifest = fs.readJSONSync(sourceContentUpdaterManifestPath);
     bundledManifest[TC_VERSION] = APP_VERSION; // add app version to resource
     const destinationPath = path.join(USER_RESOURCES_PATH,
-      "source-content-updater-manifest.json");
+      SOURCE_CONTENT_UPDATER_MANIFEST);
     fs.ensureDirSync(USER_RESOURCES_PATH);
     fs.outputJsonSync(destinationPath, bundledManifest);
   }
@@ -261,13 +262,13 @@ export const copySourceContentUpdaterManifest = () => {
  */
 export const areResourcesNewer = () => {
   const userSourceContentUpdaterManifestPath = path.join(USER_RESOURCES_PATH,
-    "source-content-updater-manifest.json");
+    SOURCE_CONTENT_UPDATER_MANIFEST);
   if (!fs.existsSync(userSourceContentUpdaterManifestPath)) {
     return true;
   }
 
   const sourceContentUpdaterManifestPath = path.join(STATIC_RESOURCES_PATH,
-    "source-content-updater-manifest.json");
+    SOURCE_CONTENT_UPDATER_MANIFEST);
   if (!fs.existsSync(sourceContentUpdaterManifestPath)) {
     console.error("sourceContentUpdaterManifest does not exist");
     return false;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- changed category modified time to use modified time in "source-content-updater-manifest.json" so that we can refresh whenever the modified time changes.  Safer then just checking if modified date newer in the case of user upgrading their tCore version.

#### Please include detailed Test instructions for your pull request:
- changing category modified time in "source-content-updater-manifest.json" should cause project checks to be regenerated when project is launched in tW.
- download source content to change the modified time in "source-content-updater-manifest.json"

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6091)
<!-- Reviewable:end -->
