### PR TITLE
Bugfix 6093/Fix missing complete indications in tw group menu

### DIFF
--- a/__tests__/__snapshots__/GroupsDataActions.test.js.snap
+++ b/__tests__/__snapshots__/GroupsDataActions.test.js.snap
@@ -155,6 +155,24 @@ Array [
     "type": "SET_INVALIDATION_IN_GROUPDATA",
   },
   Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
     "contextId": Object {
       "groupId": "apostle",
       "occurrence": 1,
@@ -166,6 +184,24 @@ Array [
       },
       "strong": Array [
         "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
       ],
       "tool": "translationWords",
     },
@@ -351,6 +387,24 @@ Array [
     "type": "SET_INVALIDATION_IN_GROUPDATA",
   },
   Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
     "contextId": Object {
       "groupId": "apostle",
       "occurrence": 1,
@@ -362,6 +416,24 @@ Array [
       },
       "strong": Array [
         "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
       ],
       "tool": "translationWords",
     },

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -274,8 +274,9 @@ export const getGroupDataForVerse = (state, contextId) => {
  */
 export const sameContext = (contextId1, contextId2) => {
   if (!!contextId1 && !!contextId2) {
-    return isEqual(contextId1.reference, contextId2.reference) &&
-      (contextId1.groupId === contextId2.groupId);
+    return isEqual(contextId1.reference, contextId2.reference)
+      && (contextId1.groupId === contextId2.groupId)
+      && (contextId1.occurrence === contextId2.occurrence);
   }
   return false;
 };

--- a/src/js/actions/ToolActions.js
+++ b/src/js/actions/ToolActions.js
@@ -72,10 +72,12 @@ export const openTool = (name) => (dispatch, getData) => {
       const groupIndex = loadProjectGroupIndex(language, name, projectDir, translate);
       dispatch(loadGroupsIndex(groupIndex));
 
-      // verify stuff. TODO: why do we need this?
+      dispatch(loadCurrentContextId());
+
+      // verify stuff. We need this to pick up external edits and when checks data is updated.
+      // TRICKY: this must be after loadCurrentContextId() for group data changes to be saved to file
       dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
 
-      dispatch(loadCurrentContextId());
       dispatch({type: types.TOGGLE_LOADER_MODAL, show: false});
       dispatch(BodyUIActions.toggleHomeView(false));
     } catch (e) {

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -145,15 +145,18 @@ export default class ProjectAPI {
    * Group data that already exists will not be overwritten.
    * @param {string} toolName - the name of the tool that the categories belong to
    * @param {string} dataPath - the path to the group data file
+   * @param {string} parentCategory - parent category
    * @returns {boolean} true if the group data was imported. false if already imported.
    */
-  importCategoryGroupData(toolName, dataPath) {
+  importCategoryGroupData(toolName, dataPath, parentCategory) {
     const destDir = this.getCategoriesDir(toolName);
     const groupName = path.basename(dataPath);
     const destFile = path.join(destDir, groupName);
     const groupsDataLoaded = this.getLoadedCategories(toolName);
     const subCategory = path.parse(dataPath).name;
-    if (!groupsDataLoaded.includes(subCategory)) {
+    // TRICKY: this change is for v1.1.4 only, 1.2.0 handles categories differently
+    const category = (toolName === "translationWords") ? parentCategory : subCategory;
+    if (!groupsDataLoaded.includes(category)) {
       fs.copySync(dataPath, destFile);
       return true;
     }

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -290,7 +290,9 @@ export default class ProjectAPI {
           try {
             const currentContextId = fs.readJSONSync(contextIdPath);
             const currentContextIdGroup = currentContextId.groupId;
-            if (!rawData.loaded.includes(currentContextIdGroup)) {
+            // TRICKY: this is for 1.1.4 only, in 1.2.0 it is all changed
+            const parentCategory = Object.keys(availableCategories).find(key => (availableCategories[key].includes(currentContextIdGroup)));
+            if (!rawData.loaded.includes(parentCategory)) {
               fs.removeSync(contextIdPath);
             }
           } catch (e) {

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -59,7 +59,7 @@ export function copyGroupDataToProject(gatewayLanguage, toolName, projectDir) {
       for (let j = 0, l2 = categories[category].length; j < l2; j++) {
         const subCategory = categories[category][j];
         const dataPath = path.join(groupsDir, subCategory + '.json');
-        project.importCategoryGroupData(toolName, dataPath);
+        project.importCategoryGroupData(toolName, dataPath, category);
       }
       // TRICKY: gives the tool an index of which groups belong to which category
       project.setCategoryGroupIds(toolName, category, categories[category]);

--- a/src/js/helpers/__tests__/ResourceHelpers.test.js
+++ b/src/js/helpers/__tests__/ResourceHelpers.test.js
@@ -36,8 +36,8 @@ describe("copy group data", () => {
     fs.readdirSync.mockReturnValueOnce(["apostle.json", "authority.json"]);
     copyGroupDataToProject("lang", "tool", "project/");
     const groupPath =  path.join("", "help", "dir", "names", "groups", "tit");
-    expect(mockImportCategoryGroupData).toBeCalledWith("tool", path.join(groupPath, "authority.json"));
-    expect(mockImportCategoryGroupData).toBeCalledWith("tool", path.join(groupPath, "apostle.json"));
+    expect(mockImportCategoryGroupData).toBeCalledWith("tool", path.join(groupPath, "authority.json"), "names");
+    expect(mockImportCategoryGroupData).toBeCalledWith("tool", path.join(groupPath, "apostle.json"), "names");
     expect(mockImportCategoryGroupData.mock.calls.length).toBe(2);
     expect(mockSetCategoryLoaded).toBeCalledWith("tool", "authority");
     expect(mockSetCategoryLoaded).toBeCalledWith("tool", "apostle");

--- a/src/js/helpers/__tests__/groupDataHelpers.test.js
+++ b/src/js/helpers/__tests__/groupDataHelpers.test.js
@@ -2,9 +2,12 @@ import {isCheckUnique} from "../groupDataHelpers";
 
 describe('Evaluate check uniqueness', () => {
   it('evaluates the first check', () => {
-    const check = {
-      groupId: "id",
-      quote: "quote"
+    const check =  {
+      contextId: {
+        groupId: "id",
+        occurrence: 1,
+        quote: "quote"
+      }
     };
     const checks = [];
     expect(isCheckUnique(check, checks)).toBe(true);
@@ -12,55 +15,97 @@ describe('Evaluate check uniqueness', () => {
 
   it('evaluates a revision of an already added check', () => {
     const check = {
-      groupId: "id",
-      quote: "quote"
-    };
-    const checks = [
-      {
+      contextId: {
         groupId: "id",
+        occurrence: 1,
         quote: "quote"
       }
+    };
+    const checks = [
+      {contextId: {
+        groupId: "id",
+        occurrence: 1,
+        quote: "quote"
+      }}
     ];
     expect(isCheckUnique(check, checks)).toBe(false);
   });
 
   it('evaluates a different check', () => {
-    const check = {
-      groupId: "id",
-      quote: "quote"
+    const check =  {
+      contextId: {
+        groupId: "id",
+        occurrence: 1,
+        quote: "quote"
+      }
     };
     const checks = [
       {
-        groupId: "hello",
-        quote: "world"
+        contextId: {
+          groupId: "hello",
+          occurrence: 1,
+          quote: "world"
+        }
       }
     ];
     expect(isCheckUnique(check, checks)).toBe(true);
   });
 
   it('evaluates a check with just a different quote id', () => {
-    const check = {
-      groupId: "id",
-      quote: "quote"
+    const check =  {
+      contextId: {
+        groupId: "id",
+        occurrence: 1,
+        quote: "quote"
+      }
     };
     const checks = [
       {
-        groupId: "id",
-        quote: "different"
+        contextId: {
+          groupId: "id",
+          occurrence: 1,
+          quote: "different"
+        }
       }
     ];
     expect(isCheckUnique(check, checks)).toBe(true);
   });
 
   it('evaluates a check with just a different group id', () => {
-    const check = {
-      groupId: "id",
-      quote: "quote"
+    const check =  {
+      contextId: {
+        groupId: "id",
+        occurrence: 1,
+        quote: "quote"
+      }
     };
     const checks = [
       {
-        groupId: "different",
+        contextId: {
+          groupId: "different",
+          occurrence: 1,
+          quote: "quote"
+        }
+      }
+    ];
+    expect(isCheckUnique(check, checks)).toBe(true);
+  });
+
+  it('\'evaluates a check with just a different occurrence id', () => {
+    const check =  {
+      contextId: {
+        groupId: "id",
+        occurrence: 1,
         quote: "quote"
+      }
+    };
+    const checks = [
+      {
+        contextId: {
+          groupId: "id",
+          occurrence: 2,
+          quote: "quote"
+        }
       }
     ];
     expect(isCheckUnique(check, checks)).toBe(true);

--- a/src/js/helpers/groupDataHelpers.js
+++ b/src/js/helpers/groupDataHelpers.js
@@ -2,7 +2,6 @@ import fs from "fs-extra";
 import path from "path-extra";
 import { getTranslation } from "./localizationHelpers";
 import ResourceAPI from "./ResourceAPI";
-import isEqual from "deep-equal";
 
 export const STATIC_RESOURCES_PATH = path.join(__dirname,
   "../../../tcResources");
@@ -104,8 +103,10 @@ export function isCheckUnique(checkData, loadedChecks) {
   const checkContextId = checkData.contextId;
   if (checkContextId) {
     for (const check of loadedChecks) {
-      if (check.contextId && isEqual(check.contextId, checkContextId)) {
-         return false;
+      if (check.contextId && check.contextId.groupId === checkContextId.groupId
+        && check.contextId.quote === checkContextId.quote
+        && check.contextId.occurrence === checkContextId.occurrence) {
+          return false;
       }
     }
   }

--- a/src/js/helpers/groupDataHelpers.js
+++ b/src/js/helpers/groupDataHelpers.js
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path-extra";
 import { getTranslation } from "./localizationHelpers";
 import ResourceAPI from "./ResourceAPI";
+import isEqual from "deep-equal";
 
 export const STATIC_RESOURCES_PATH = path.join(__dirname,
   "../../../tcResources");
@@ -73,7 +74,7 @@ export function readLatestChecks(dir) {
   let checks = [];
   if (!fs.existsSync(dir)) return [];
 
-  // list sorted json files
+  // list sorted json files - most recents are in front of list
   const files = fs.readdirSync(dir).filter(file => {
     return path.extname(file) === ".json";
   }).sort().reverse();
@@ -100,9 +101,12 @@ export function readLatestChecks(dir) {
  * @returns {boolean} - true if the check has not been loaded yet.
  */
 export function isCheckUnique(checkData, loadedChecks) {
-  for(const check of loadedChecks) {
-    if(check.groupId === checkData.groupId && check.quote === checkData.quote) {
-      return false;
+  const checkContextId = checkData.contextId;
+  if (checkContextId) {
+    for (const check of loadedChecks) {
+      if (check.contextId && isEqual(check.contextId, checkContextId)) {
+         return false;
+      }
     }
   }
   return true;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes for loading latest checks.
- fix for persisting external changes
- fix for tW current context getting clobbered on project selection.
- fix for tW group data getting reset on project selection.

#### Please include detailed Test instructions for your pull request:
- checkout branch, do `npm run load-apps`, `npm ci`, `npm start`
- follow steps in https://github.com/unfoldingword-dev/translationcore/issues/6093
- should see all selection checkmarks on group menu and in tW should return to last check.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6094)
<!-- Reviewable:end -->
