### PR TITLE
Now closing the "Preparing your project data" alert appropriately 

### DIFF
--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -58,7 +58,7 @@ export const onlineImport = () => {
         try {
           ProjectFilesystemHelpers.deleteImportsFolder();
           // Must allow online action before starting actions that access the internet
-          link = getState().importOnlineReducer.importLink;
+          link = getState().importOnlineReducer.importLink.trim();
           console.log("onlineImport() - link=" + link);
 
           dispatch(clearLink());

--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -114,6 +114,7 @@ export function finalize() {
         dispatch(ProjectImportStepperActions.removeProjectValidationStep(PROJECT_INFORMATION_CHECK_NAMESPACE));
         dispatch(ProjectImportStepperActions.updateStepperIndex());
         dispatch(MissingVersesActions.validate());
+        dispatch(AlertModalActions.closeAlertDialog());
       } catch (error) {
         dispatch(AlertModalActions.openAlertDialog(error));
         dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Also, fixed bug with online project import. Links with spaces at the beginning or at the end would not download.

#### Please include detailed Test instructions for your pull request:
- Import this project https://git.door43.org/lrsallee/en_ult_mat_book
- Should see a loading alert dialog after clicking continue in the project details page (on the project validation stepper)
- Import the following projects and the "Preparing your project data" alert should only show up when clicking continue on the project details page and close when prompted with the missing verses step/screen or the merge conflicts step/screen

   - This project is missing verse 1:1
[php_usfm_NoVerse1.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3228574/php_usfm_NoVerse1.usfm.zip)

   - This project has merge conflicts:
[en-x-demo1_php_text_ulb_mc.tstudio.zip](https://github.com/unfoldingWord-dev/translationCore/files/3228576/en-x-demo1_php_text_ulb_mc.tstudio.zip)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6111)
<!-- Reviewable:end -->
