### PR TITLE
 Now displaying "Preparing project data" alert for projects with lots of edits and missing verses

### DIFF
--- a/src/js/actions/Import/ProjectImportFilesystemActions.js
+++ b/src/js/actions/Import/ProjectImportFilesystemActions.js
@@ -4,8 +4,10 @@ import ospath from 'ospath';
 import { getTranslate } from '../../selectors';
 // helpers
 import * as ProjectImportFilesystemHelpers from '../../helpers/Import/ProjectImportFilesystemHelpers';
-//actions
+import {delay} from "../../helpers/bodyUIHelpers";
+// actions
 import * as ProjectDetailsActions from '../ProjectDetailsActions';
+import * as AlertModalActions from '../AlertModalActions';
 // constants
 const IMPORTS_PATH = path.join(ospath.home(), 'translationCore', 'imports');
 
@@ -16,6 +18,8 @@ export const move = () => {
   return ((dispatch, getState) => {
     return new Promise(async(resolve, reject) => {
       const translate = getTranslate(getState());
+      dispatch(AlertModalActions.openAlertDialog(translate("projects.preparing_project_alert"), true));
+      await delay(200);
       try {
         const projectName = getState().localImportReducer.selectedProjectFilename;
         console.log("ProjectImportFilesystemActions.move() - moving project from import folder");
@@ -23,6 +27,7 @@ export const move = () => {
         console.log("ProjectImportFilesystemActions.move() - moving project from import folder to: " + projectPath);
         dispatch(ProjectDetailsActions.setSaveLocation(projectPath));
         fs.removeSync(path.join(IMPORTS_PATH, projectName));
+        dispatch(AlertModalActions.closeAlertDialog());
         resolve();
       } catch (error) {
         if (error && error.message && error.data) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Import the following project https://git.door43.org/tc01/en_ult_mat_book
- When Continue is clicked on the Missing verses page, the "Preparing project data" alert should show up.


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6115)
<!-- Reviewable:end -->
