### PR TITLE
Now ensuring the imports folder is being cleared on project import

### DIFF
--- a/__tests__/ProjectImportFilesystemActions.test.js
+++ b/__tests__/ProjectImportFilesystemActions.test.js
@@ -13,12 +13,12 @@ describe('ProjectImportFilesystemActions', () => {
   afterAll(() => {
     fs.__resetMockFS();
   });
-  test('deleteProjectFromImportsFolder: should remove the imports folder', () => {
+  test('deleteProjectFromImportsFolder: should remove the imports folder', async () => {
     const pathLocation = path.join(IMPORTS_PATH, 'PROJECT_NAME');
     fs.__resetMockFS();
     fs.ensureDirSync(pathLocation);
     expect(fs.statSync(pathLocation).exists).toBeTruthy();
-    ProjectImportFilesystemHelpers.deleteImportsFolder();
+    await ProjectImportFilesystemHelpers.deleteImportsFolder();
     expect(fs.statSync(pathLocation).exists).toBeFalsy();
   });
 });

--- a/src/js/actions/Import/LocalImportWorkflowActions.js
+++ b/src/js/actions/Import/LocalImportWorkflowActions.js
@@ -48,8 +48,8 @@ export const localImport = () => {
     console.log("localImport() - importing project: " + sourceProjectPath);
     const importProjectPath = path.join(IMPORTS_PATH, selectedProjectFilename);
 
-    deleteImportsFolder();
     try {
+      await deleteImportsFolder();
       // convert file to tC acceptable project format
       console.log("localImport() - converting project");
       const projectInfo = await FileConversionHelpers.convert(sourceProjectPath, selectedProjectFilename);

--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -3,7 +3,7 @@ import path from "path-extra";
 import ospath from "ospath";
 // actions
 import * as ProjectValidationActions from "./ProjectValidationActions";
-import {deleteProjectFromImportsFolder} from "../../helpers/Import/ProjectImportFilesystemHelpers";
+import {deleteImportsFolder, deleteProjectFromImportsFolder} from "../../helpers/Import/ProjectImportFilesystemHelpers";
 import * as AlertModalActions from "../../actions/AlertModalActions";
 import * as OnlineModeConfirmActions
   from "../../actions/OnlineModeConfirmActions";
@@ -28,8 +28,6 @@ import {
   getUsername
 } from "../../selectors";
 import * as FileConversionHelpers from "../../helpers/FileConversionHelpers";
-import * as ProjectFilesystemHelpers
-  from "../../helpers/Import/ProjectImportFilesystemHelpers";
 import * as ProjectDetailsHelpers from "../../helpers/ProjectDetailsHelpers";
 import migrateProject from "../../helpers/ProjectMigration";
 import fs from "fs-extra";
@@ -57,7 +55,7 @@ export const onlineImport = () => {
         let importProjectPath = '';
         let link = '';
         try {
-          ProjectFilesystemHelpers.deleteImportsFolder();
+          await deleteImportsFolder();
           // Must allow online action before starting actions that access the internet
           link = getState().importOnlineReducer.importLink.trim();
           console.log("onlineImport() - link=" + link);

--- a/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
+++ b/src/js/helpers/Import/ProjectImportFilesystemHelpers.js
@@ -114,9 +114,9 @@ export const deleteImportsFolder = () => {
         fs.removeSync(TEMP_DIR);
       }
       resolve();
-    } catch (error) {
-      console.error(error);
-      reject(error);
+    } catch (err) {
+      console.error(err);
+      reject(err);
     }
   });
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Made deleteImportsFolder() an asynchronous promise so that we can await for it to be resolved before doing other stuff. 

#### Please include detailed Test instructions for your pull request:
1. Start an online import
1. End tC (cmd + Q on mac/ quit on windows) before the stepper is engaged
1. Note that the project now exists in the imports folder
1. Restart tC
1. Attempt to import the project again
1. The project should import without any problems and the alert indicating "the project already exists" should not be displayed.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6167)
<!-- Reviewable:end -->
