### PR TITLE
bugfix 6153/Fix to upload/export book with disputed verse alignment

### DIFF
--- a/__tests__/UsfmExportActions.test.js
+++ b/__tests__/UsfmExportActions.test.js
@@ -391,10 +391,10 @@ describe('USFMExportActions.exportToUSFM', () => {
     { "type": "CLOSE_ALERT_DIALOG" },
     { "bool": true, "type": "SHOW_DIMMED_SCREEN" },
     { "alertMessage": "projects.exporting_file_alert", "loading": true, "type": "OPEN_ALERT_DIALOG" },
-    { "bool": false, "type": "SHOW_DIMMED_SCREEN" },
     { "type": "CLOSE_ALERT_DIALOG" },
     { "type": "SET_USFM_SAVE_LOCATION", "usfmSaveLocation": "/" },
-    { "alertMessage": "projects.exported_alert", "loading": false, "type": "OPEN_ALERT_DIALOG" }];
+    { "alertMessage": "projects.exported_alert", "loading": false, "type": "OPEN_ALERT_DIALOG" },
+    { "bool": false, "type": "SHOW_DIMMED_SCREEN" }];
     const projectSaveLocation = path.join(PROJECTS_PATH, projectName);
     const usfmExportType = 'usfm3';
     const initialState = {

--- a/src/js/helpers/WordAlignmentHelpers.js
+++ b/src/js/helpers/WordAlignmentHelpers.js
@@ -196,8 +196,11 @@ export const convertAlignmentDataToUSFM = (wordAlignmentDataPath, projectTargetL
       for (let verseNumber in chapterAlignmentJSON) {
         if (!parseInt(verseNumber)) continue; // only import integer based verses
         const verseAlignments = chapterAlignmentJSON[verseNumber];
-        const verseString = UsfmFileConversionHelpers.cleanAlignmentMarkersFromString(
-                                targetLanguageChapterJSON[verseNumber]);
+        const targetVerse = targetLanguageChapterJSON[verseNumber];
+        if (targetVerse === undefined) {
+          continue; // skip if no target verse
+        }
+        const verseString = UsfmFileConversionHelpers.cleanAlignmentMarkersFromString(targetVerse);
         let verseObjects;
         try {
           verseObjects = wordaligner.merge(


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes for USFM conversion error handling in USFM export and upload.
- fix that merge will not try to merge alignments with target verse if target verse is not present.  This was caused by past versions of tCore creating blank alignments for disputed verses.

#### Please include detailed Test instructions for your pull request:
- use project in https://github.com/unfoldingword-dev/translationcore/issues/6153
- should be able to export USFM with alignments without error
- should be able to upload to D43 without error

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6190)
<!-- Reviewable:end -->
