### PR TITLE
Bugfix 6174/ add unsupported message if no GLs with aligned books 

### DIFF
--- a/__tests__/gatewayLanguageHelpers.test.js
+++ b/__tests__/gatewayLanguageHelpers.test.js
@@ -7,7 +7,13 @@ import ResourceAPI from "../src/js/helpers/ResourceAPI";
 import * as gatewayLanguageHelpers from "../src/js/helpers/gatewayLanguageHelpers";
 import * as ResourcesHelpers from "../src/js/helpers/ResourcesHelpers";
 // constants
-import { USER_RESOURCES_PATH, WORD_ALIGNMENT, TRANSLATION_WORDS } from '../src/js/common/constants';
+import {
+  USER_RESOURCES_PATH,
+  WORD_ALIGNMENT,
+  TRANSLATION_WORDS,
+  TRANSLATION_NOTES,
+  TRANSLATION_ACADEMY
+} from '../src/js/common/constants';
 const testResourcePath = path.join(__dirname, 'fixtures/resources');
 
 describe('Test getGatewayLanguageList() for TW',()=>{
@@ -60,7 +66,7 @@ describe('Test getGatewayLanguageList() for TW',()=>{
       // fake the book of joel
       fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1'), 'tit', 'jol');
       fakeHelpsBookByCopying('hbo', 'tit', 'jol');
-        // fake a hindi bible
+      // fake a hindi bible
       fakeResourceByCopying(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1', 'hi/bibles/irv/v12.1');
       fs.outputJsonSync(path.join(USER_RESOURCES_PATH, 'hi/bibles/irv/v12.1/jol/1.json'), {}); // remove alignments
 
@@ -69,7 +75,7 @@ describe('Test getGatewayLanguageList() for TW',()=>{
       expect(languages.length).toEqual(1);
     });
 
-    test('should return nothing for Joel without hbo helps', () => {
+    test('should return nothing for Joel without hbo tWords', () => {
       const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'hbo/bibles/uhb'];
       fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
 
@@ -123,6 +129,127 @@ describe('Test getGatewayLanguageList() for TW',()=>{
       setCheckingLevel(path.join(ugntVersionPath, 'manifest.json'), 1);
 
       const languages = gatewayLanguageHelpers.getGatewayLanguageList('tit', toolName);
+      expect(languages.length).toEqual(0);
+    });
+  });
+
+  describe('original language tests',()=> {
+    beforeEach(() => {
+      // reset mock filesystem data
+      fs.__resetMockFS();
+      fs.__setMockFS({}); // initialize to empty
+    });
+    afterEach(() => {
+      // reset mock filesystem data
+      fs.__resetMockFS();
+    });
+
+    test('should return an empty list for Genesis (OT, no ULT)', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'hbo/bibles/uhb'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('gen');
+      expect(languages.length).toEqual(0);
+    });
+
+    test('should return an empty list for Luke (NT, no ULT)', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps/translationWords', 'el-x-koine/bibles/ugnt'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('luk', toolName);
+      expect(languages.length).toEqual(0);
+    });
+  });
+});
+
+describe('Test getGatewayLanguageList() for TN',()=>{
+  const toolName = TRANSLATION_NOTES;
+
+  describe('general tests',()=> {
+    beforeEach(() => {
+      // reset mock filesystem data
+      fs.__resetMockFS();
+      fs.__setMockFS({}); // initialize to empty
+    });
+    afterEach(() => {
+      // reset mock filesystem data
+      fs.__resetMockFS();
+    });
+
+    test('should return English & Hindi for Titus', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps', 'el-x-koine'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+
+      // fake a hindi bible
+      fakeResourceByCopying(USER_RESOURCES_PATH, 'en/bibles/ult', 'hi/bibles/ulb');
+      fakeResourceByCopying(USER_RESOURCES_PATH, 'en/translationHelps', 'hi/translationHelps');
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('tit', toolName);
+      expect(languages[0].name).toEqual('English');
+      expect(languages[1].lc).toEqual('hi');
+      expect(languages.length).toEqual(2);
+    });
+
+    test('should return English for Joel', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps', 'hbo/bibles/uhb', 'el-x-koine'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+      fakeHelpsByCopying('el-x-koine', 'hbo');
+
+      // fake the book of Joel
+      fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1'), 'tit', 'jol');
+      fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'hbo/translationHelps/translationWords/v8/kt/groups'), 'tit', 'jol');
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('jol', toolName);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
+    });
+
+    test('should return English for Joel with unaligned hi', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps', 'hbo/bibles/uhb', 'el-x-koine'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+      fakeHelpsByCopying('el-x-koine', 'hbo');
+
+      // fake the book of joel
+      fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1'), 'tit', 'jol');
+      fakeHelpsBookByCopying('hbo', 'tit', 'jol');
+      // fake a hindi bible
+      fakeResourceByCopying(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1', 'hi/bibles/irv/v12.1');
+      fs.outputJsonSync(path.join(USER_RESOURCES_PATH, 'hi/bibles/irv/v12.1/jol/1.json'), {}); // remove alignments
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('jol', toolName);
+      expect(languages[0].name).toEqual('English');
+      expect(languages.length).toEqual(1);
+    });
+
+    test('should return nothing for Joel without en TA', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps', 'hbo/bibles/uhb'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+      fs.removeSync(path.join(USER_RESOURCES_PATH, 'en/translationHelps', TRANSLATION_ACADEMY));
+
+      // fake the book of joel
+      fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1'), 'tit', 'jol');
+      fakeHelpsBookByCopying('hbo', 'tit', 'jol');
+      // fake a hindi bible
+      fakeResourceByCopying(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1', 'hi/bibles/irv/v12.1');
+      fs.outputJsonSync(path.join(USER_RESOURCES_PATH, 'hi/bibles/irv/v12.1/jol/1.json'), {}); // remove alignments
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('jol', toolName);
+      expect(languages.length).toEqual(0);
+    });
+
+    test('should return nothing for Joel without en TN', () => {
+      const copyFiles = ['en/bibles/ult/v12.1', 'en/translationHelps', 'hbo/bibles/uhb'];
+      fs.__loadFilesIntoMockFs(copyFiles, testResourcePath, USER_RESOURCES_PATH);
+      fs.removeSync(path.join(USER_RESOURCES_PATH, 'en/translationHelps', TRANSLATION_NOTES));
+
+      // fake the book of joel
+      fakeResourceByCopying(path.join(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1'), 'tit', 'jol');
+      fakeHelpsBookByCopying('hbo', 'tit', 'jol');
+      // fake a hindi bible
+      fakeResourceByCopying(USER_RESOURCES_PATH, 'en/bibles/ult/v12.1', 'hi/bibles/irv/v12.1');
+      fs.outputJsonSync(path.join(USER_RESOURCES_PATH, 'hi/bibles/irv/v12.1/jol/1.json'), {}); // remove alignments
+
+      const languages = gatewayLanguageHelpers.getGatewayLanguageList('jol', toolName);
       expect(languages.length).toEqual(0);
     });
   });

--- a/src/js/helpers/gatewayLanguageHelpers.js
+++ b/src/js/helpers/gatewayLanguageHelpers.js
@@ -48,7 +48,7 @@ export const getGatewayLanguageCodeAndQuote = (state, contextId = null) => {
  *           ol: {alignedBookRequired: Boolean, minimumCheckingLevel: Number, helpsChecks: Array.<Object>}}}
  */
 export function getGlRequirementsForTool(toolName) {
-  const requirements = {
+  const requirements = { // init to default values
     gl: {
       alignedBookRequired: false,
       minimumCheckingLevel: 3,
@@ -84,6 +84,7 @@ export function getGlRequirementsForTool(toolName) {
       ];
       break;
     case TRANSLATION_NOTES:
+      requirements.gl.alignedBookRequired = true;
       requirements.gl.helpsChecks = [
         {
           path: path.join(TRANSLATION_HELPS, TRANSLATION_ACADEMY)


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- for tN tool launch added requirement that we must have an aligned GL book.

#### Please include detailed Test instructions for your pull request:
- start tC, run source content updater to make sure greek and english resources are up to date.
- open an Old testament project like Judges that doesn't have alignments in the English ult.  I think Ruth is currently the only OT book with alignments so should be able to use any OT book but Ruth.
- both the TN and TW tool cards should show "Book not supported" when you hover over the launch buttons.
- open a Ruth project

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6218)
<!-- Reviewable:end -->
