### PR TITLE
Removed unnecessary reload of tool

### DIFF
--- a/src/js/components/home/overview/index.js
+++ b/src/js/components/home/overview/index.js
@@ -9,7 +9,6 @@ import { connect } from "react-redux";
 import { getSelectedToolTitle } from "../../../selectors";
 
 class OverviewContainer extends Component {
-
   constructor(props) {
     super(props);
     this.launchButton = this.launchButton.bind(this);
@@ -20,13 +19,19 @@ class OverviewContainer extends Component {
   * @param {bool} disabled - disable the button
   * @return {component} - component returned
   */
-  launchButton(disabled) {
-    const {toggleHomeView} = this.props.actions;
-    const {translate} = this.props;
+  launchButton(disabled, toolTitle) {
+    const { toggleHomeView, openTool } = this.props.actions;
+    const {
+      translate,
+      selectedCategoriesChanged,
+    } = this.props;
+    const onClick = () =>
+      selectedCategoriesChanged ? openTool(toolTitle) : toggleHomeView(false);
+
     return (
       <button className='btn-prime'
               disabled={disabled}
-              onClick={() => toggleHomeView()}>
+              onClick={onClick}>
         {translate('buttons.launch_button')}
       </button>
     );
@@ -37,7 +42,6 @@ class OverviewContainer extends Component {
     const {store} = this.context;
     const toolTitle = getSelectedToolTitle(store.getState());
     const launchButtonDisabled = !toolTitle;
-
     const instructions = (
       <div>
         <p>{translate('welcome_to_tc', { 'app': translate('_.app_name')})}
@@ -52,6 +56,7 @@ class OverviewContainer extends Component {
         </ol>
       </div>
     );
+
     return (
       <HomeContainerContentWrapper instructions={instructions}
                                    translate={translate}>
@@ -60,7 +65,7 @@ class OverviewContainer extends Component {
           <ProjectCard {...this.props} />
           <ToolCard {...this.props} />
           <div style={{ textAlign: 'center' }}>
-            {this.launchButton(launchButtonDisabled)}
+            {this.launchButton(launchButtonDisabled, toolTitle)}
           </div>
         </div>
       </HomeContainerContentWrapper>
@@ -71,8 +76,10 @@ class OverviewContainer extends Component {
 OverviewContainer.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
+  selectedCategoriesChanged: PropTypes.bool.isRequired,
   translate: PropTypes.func
 };
+
 OverviewContainer.contextTypes = {
   store: PropTypes.any
 };

--- a/src/js/components/home/toolsManagement/ToolsCards.js
+++ b/src/js/components/home/toolsManagement/ToolsCards.js
@@ -42,6 +42,7 @@ const ToolsCards = ({
   originalLanguageBookManifest,
   currentProjectToolsSelectedGL,
   onMissingResource,
+  toggleHomeView,
 }) => {
   if (!tools || tools.length === 0) {
     return (
@@ -95,12 +96,13 @@ const ToolsCards = ({
 
             return (
               <ToolCard
+                key={i}
                 tool={tool}
                 onSelect={onSelectTool}
+                toggleHomeView={toggleHomeView}
                 availableCategories={availableCategories}
                 selectedCategories={toolsCategories[tool.name] || []}
                 translate={translate}
-                key={i}
                 actions={actions}
                 loggedInUser={loggedInUser}
                 metadata={{
@@ -136,6 +138,7 @@ ToolsCards.propTypes = {
   toolsCategories: PropTypes.object.isRequired,
   originalLanguageBookManifest: PropTypes.object.isRequired,
   onMissingResource: PropTypes.func.isRequired,
+  toggleHomeView: PropTypes.func.isRequired,
 };
 
 export default ToolsCards;

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import _ from "lodash";
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 // components
 import WelcomeSplash from '../../components/home/WelcomeSplash';
@@ -21,12 +22,35 @@ import * as USFMExportActions from '../../actions/USFMExportActions';
 import * as ProjectInformationCheckActions from '../../actions/ProjectInformationCheckActions';
 import * as LocaleActions from '../../actions/LocaleActions';
 import * as ProjectDetailsActions from '../../actions/ProjectDetailsActions';
+import { openTool } from "../../actions/ToolActions";
 // constants
 import { APP_VERSION } from '../../common/constants';
 
 // TRICKY: because this component is heavily coupled with callbacks to set content
 // we need to connect locale state change events.
 class HomeContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedCategoriesChanged: false
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      toolsReducer: { selectedTool },
+      projectDetailsReducer: { toolsCategories }
+    } = this.props.reducers;
+    const {
+      projectDetailsReducer: {
+        toolsCategories: prevToolsCategories
+      }
+    } = prevProps.reducers;
+
+    if(!_.isEqual(prevToolsCategories[selectedTool], toolsCategories[selectedTool])) {
+      this.setState({ selectedCategoriesChanged: true });
+    }
+  }
 
   render() {
     let {
@@ -41,7 +65,12 @@ class HomeContainer extends Component {
 
     switch (stepIndex) {
       case 0:
-        displayContainer = <Overview {...this.props}/>;
+        displayContainer = (
+          <Overview
+            {...this.props}
+            selectedCategoriesChanged={this.state.selectedCategoriesChanged}
+          />
+        );
         break;
       case 1:
         displayContainer = <UsersManagementContainer {...this.props}/>;
@@ -107,6 +136,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     actions: {
+      openTool: name => dispatch(openTool(name)),
       toggleWelcomeSplash: () => {
         dispatch(BodyUIActions.toggleWelcomeSplash());
       },
@@ -122,8 +152,8 @@ const mapDispatchToProps = (dispatch) => {
       goToStep: (stepNumber) => {
         dispatch(BodyUIActions.goToStep(stepNumber));
       },
-      toggleHomeView: () => {
-        dispatch(BodyUIActions.toggleHomeView());
+      toggleHomeView: (value) => {
+        dispatch(BodyUIActions.toggleHomeView(value));
       },
       openLicenseModal: () => {
         dispatch(BodyUIActions.openLicenseModal());

--- a/src/js/containers/home/ToolsManagementContainer.js
+++ b/src/js/containers/home/ToolsManagementContainer.js
@@ -18,6 +18,7 @@ import { openAlertDialog } from "../../actions/AlertModalActions";
 import * as PopoverActions from "../../actions/PopoverActions";
 import * as ProjectDetailsActions from "../../actions/ProjectDetailsActions";
 import { promptUserAboutMissingResource } from '../../actions/SourceContentUpdatesActions';
+import * as BodyUIActions from '../../actions/BodyUIActions';
 
 class ToolsManagementContainer extends Component {
   constructor(props) {
@@ -66,6 +67,7 @@ class ToolsManagementContainer extends Component {
       translate,
       originalLanguageBookManifest,
       onMissingResource,
+      toggleHomeView,
     } = this.props;
 
     const instructions = (
@@ -90,6 +92,7 @@ class ToolsManagementContainer extends Component {
             translate={translate}
             bookName={name}
             loggedInUser={loggedInUser}
+            toggleHomeView={toggleHomeView}
             actions={{ ...this.props.actions }}
             onMissingResource={onMissingResource}
             originalLanguageBookManifest={originalLanguageBookManifest}
@@ -122,6 +125,7 @@ const mapDispatchToProps = (dispatch) => {
     openTool: name => dispatch(openTool(name)),
     openAlertDialog: message => dispatch(openAlertDialog(message)),
     onMissingResource: (resourceDetails) => dispatch(promptUserAboutMissingResource(resourceDetails)),
+    toggleHomeView: (value) => dispatch(BodyUIActions.toggleHomeView(value)),
     actions: {
       loadCurrentCheckCategories: (toolName, projectSaveLocation) => {
         dispatch(ProjectDetailsActions.loadCurrentCheckCategories(toolName, projectSaveLocation));
@@ -157,6 +161,7 @@ ToolsManagementContainer.propTypes = {
   translate: PropTypes.func.isRequired,
   originalLanguageBookManifest: PropTypes.object.isRequired,
   onMissingResource: PropTypes.func.isRequired,
+  toggleHomeView: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/src/js/reducers/__tests__/toolsReducer.test.js
+++ b/src/js/reducers/__tests__/toolsReducer.test.js
@@ -173,7 +173,7 @@ describe("selectors", () => {
       const state = {
         selectedTool: null
       };
-      const expectedResult = undefined;
+      const expectedResult = false;
       const result = fromToolsReducer.getSelectedToolName(state);
       expect(result).toEqual(expectedResult);
     });

--- a/src/js/reducers/projectDetailsReducer.js
+++ b/src/js/reducers/projectDetailsReducer.js
@@ -1,7 +1,6 @@
 import consts from '../actions/ActionTypes';
 import path from 'path-extra';
 
-// TBD ToolsCategories need to go, they are dynamic
 const initialState = {
   projectSaveLocation: '',
   manifest: {

--- a/src/js/reducers/toolsReducer.js
+++ b/src/js/reducers/toolsReducer.js
@@ -116,7 +116,7 @@ export const getSelectedToolName = (state) => {
   if (state && state.selectedTool) {
     return state.selectedTool;
   } else {
-    return undefined;
+    return false;
   }
 };
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Open a project w/ `tN tool`
- Go to the `Home page` and click Launch (Should open the tool instantly without any data reload)
- Go to the `Tool cards page` click Launch on `tN tool` (Should open the tool instantly without any data reload)
- Go back to the `Tool cards page` uncheck a category and click Launch (Should display the loading dialog and then open the tool)
- Go back to the `Tool cards page` again check the category you had uncheck previously, go to the `Home page` and click Launch (Should display the loading dialog and then open the tool)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6230)
<!-- Reviewable:end -->
