### PR TITLE
Fixed project reimport bug that used to overwrite the old projects manifest

### DIFF
--- a/scripts/resources/updateResourcesHelpers.js
+++ b/scripts/resources/updateResourcesHelpers.js
@@ -118,7 +118,7 @@ const updateSourceContentUpdaterManifest = resourcesPath => {
   }
   fs.ensureDirSync(resourcesPath);
   manifest.modified = (new Date()).toJSON();
-  fs.outputJsonSync(sourceContentManifestPath, manifest);
+  fs.outputJsonSync(sourceContentManifestPath, manifest, { spaces: 2 });
 };
 
 module.exports = {

--- a/src/js/actions/MissingVersesActions.js
+++ b/src/js/actions/MissingVersesActions.js
@@ -51,7 +51,7 @@ export function finalize() {
         for (let missingVerse of missingVerses[chapterNum]) {
           chapterJSONObject[missingVerse.toString()] = "";
         }
-        fs.outputJsonSync(chapterPath, chapterJSONObject);
+        fs.outputJsonSync(chapterPath, chapterJSONObject, { spaces: 2 });
       }
     }
     dispatch(ProjectImportStepperActions.removeProjectValidationStep(MISSING_VERSES_NAMESPACE));

--- a/src/js/components/home/toolsManagement/ToolsCards.js
+++ b/src/js/components/home/toolsManagement/ToolsCards.js
@@ -86,7 +86,7 @@ const ToolsCards = ({
               const { tsv_relation } = manifest;
               const tsvOLVersion = getTsvOLVersion(tsv_relation, resourceId);
               const neededOLPath = path.join(USER_RESOURCES_PATH, languageId, 'bibles', resourceId, 'v' + tsvOLVersion);
-              if (neededOLPath) isOLBookVersionMissing = !fs.existsSync(neededOLPath);
+              if (neededOLPath) isOLBookVersionMissing = tsvOLVersion && !fs.existsSync(neededOLPath);
               missingOLResource = {
                 languageId,
                 resourceId,
@@ -113,7 +113,7 @@ const ToolsCards = ({
                   folderName: tool.path,
                   name: tool.name
                 }}
-                isOLBookVersionMissing={isOLBookVersionMissing}
+                isOLBookVersionMissing={!!isOLBookVersionMissing}
                 onMissingResource={() => onMissingResource(missingOLResource)}
                 invalidatedReducer={invalidatedReducer}
               />

--- a/src/js/components/projectValidation/ProjectValidationContentWrapper.js
+++ b/src/js/components/projectValidation/ProjectValidationContentWrapper.js
@@ -33,7 +33,10 @@ const ProjectValidationContentWrapper = ({instructions, translate, children}) =>
 
 ProjectValidationContentWrapper.propTypes = {
   instructions: PropTypes.element.isRequired,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.array
+  ]).isRequired,
   translate: PropTypes.func.isRequired
 };
 

--- a/src/js/helpers/CopyrightCheckHelpers.js
+++ b/src/js/helpers/CopyrightCheckHelpers.js
@@ -40,7 +40,7 @@ export function assignLicenseToOnlineImportedProject(projectPath) {
         if (!manifest.license) {
           manifest.license = 'CC BY-SA 4.0';
           const savePath = path.join(projectPath, 'manifest.json');
-          fs.outputJsonSync(savePath, manifest);
+          fs.outputJsonSync(savePath, manifest, { spaces: 2 });
           // Save LICENSE.md in project folder.
           await saveProjectLicense('CC BY-SA 4.0', projectPath);
         }

--- a/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
+++ b/src/js/helpers/FileConversionHelpers/UsfmFileConversionHelpers.js
@@ -56,7 +56,7 @@ export const generateManifestForUsfm = async (parsedUsfm, sourceProjectPath, sel
     try {
       const manifest = manifestHelpers.generateManifestForUsfmProject(parsedUsfm);
       const manifestPath = path.join(IMPORTS_PATH, selectedProjectFilename, 'manifest.json');
-      fs.outputJsonSync(manifestPath, manifest);
+      fs.outputJsonSync(manifestPath, manifest, { spaces: 2 });
       resolve(manifest);
     } catch (error) {
       console.log(error);
@@ -176,15 +176,15 @@ export const generateTargetLanguageBibleFromUsfm = async (parsedUsfm, manifest, 
         });
         const filename = parseInt(chapter, 10) + '.json';
         const projectBibleDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, filename);
-        fs.outputJsonSync(projectBibleDataPath, bibleChapter);
+        fs.outputJsonSync(projectBibleDataPath, bibleChapter, { spaces: 2 });
 
         if (alignmentData) {
           const alignmentDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, '.apps', 'translationCore', 'alignmentData', bibleDataFolderName, filename);
-          fs.outputJsonSync(alignmentDataPath, chapterAlignments);
+          fs.outputJsonSync(alignmentDataPath, chapterAlignments, { spaces: 2 });
         }
       });
       const projectBibleDataPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, 'headers.json');
-      fs.outputJsonSync(projectBibleDataPath, parsedUsfm.headers);
+      fs.outputJsonSync(projectBibleDataPath, parsedUsfm.headers, { spaces: 2 });
       if (!verseFound) {
         reject(
           <div>
@@ -209,7 +209,7 @@ export const generateTargetLanguageBibleFromUsfm = async (parsedUsfm, manifest, 
         description: "Target Language"
       };
       const projectBibleDataManifestPath = path.join(IMPORTS_PATH, selectedProjectFilename, bibleDataFolderName, "manifest.json");
-      fs.outputJsonSync(projectBibleDataManifestPath, targetLanguageManifest);
+      fs.outputJsonSync(projectBibleDataManifestPath, targetLanguageManifest, { spaces: 2 });
       resolve();
     } catch (error) {
       console.log(error);

--- a/src/js/helpers/Import/importHelpers.js
+++ b/src/js/helpers/Import/importHelpers.js
@@ -24,7 +24,7 @@ export function saveTargetBible(projectPath, manifest, bookData, headers) {
     if (!parseInt(chapter)) continue; // only import integer based data, there are other files
     let fileName = chapter + '.json';
     const targetBiblePath = path.join(projectPath, bookAbbreviation);
-    fs.outputJsonSync(path.join(targetBiblePath, fileName), bookData[chapter]);
+    fs.outputJsonSync(path.join(targetBiblePath, fileName), bookData[chapter], { spaces: 2 });
   }
   saveHeaders(targetBiblePath, headers);
   // generating and saving manifest file for target language bible.
@@ -45,7 +45,7 @@ function saveHeaders (targetBiblePath, headers) {
       headers = json.headers;
     }
     if (headers) {
-      fs.outputJsonSync(path.join(targetBiblePath, 'headers.json'), headers);
+      fs.outputJsonSync(path.join(targetBiblePath, 'headers.json'), headers, { spaces: 2 });
     }
   }
 }
@@ -66,7 +66,7 @@ function generateTartgetLanguageManifest(projectManifest, targetBiblePath) {
   bibleManifest.description = "Target Language";
   // savings target language bible manifest file in project target language bible path.
   let fileName = "manifest.json";
-  fs.outputJsonSync(path.join(targetBiblePath, fileName), bibleManifest);
+  fs.outputJsonSync(path.join(targetBiblePath, fileName), bibleManifest, { spaces: 2 });
 }
 
 /**

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -254,7 +254,7 @@ export default class ProjectAPI {
     fs.outputJsonSync(categoriesPath, {
       current: [],
       loaded: []
-    });
+    }, { spaces: 2 });
 
     return false;
   }
@@ -297,7 +297,7 @@ export default class ProjectAPI {
       try {
         let rawData = fs.readJsonSync(categoriesPath);
         rawData.loaded = [];
-        fs.outputJsonSync(categoriesPath, rawData);
+        fs.outputJsonSync(categoriesPath, rawData, { spaces: 2 });
       } catch (e) {
         console.warn(
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
@@ -323,7 +323,7 @@ export default class ProjectAPI {
             rawData.current.splice(index, 1);
           }
         });
-        fs.outputJsonSync(categoriesPath, rawData);
+        fs.outputJsonSync(categoriesPath, rawData, { spaces: 2 });
         const contextIdPath = path.join(groupsPath, 'currentContextId', 'contextId.json');
         if (fs.existsSync(contextIdPath)) {
           try {
@@ -386,7 +386,7 @@ export default class ProjectAPI {
     const sourceContentManifestPath = path.join(USER_RESOURCES_PATH, SOURCE_CONTENT_UPDATER_MANIFEST);
     const {modified: lastTimeDataDownloaded} = fs.readJsonSync(sourceContentManifestPath);
     data.timestamp = lastTimeDataDownloaded;
-    fs.outputJsonSync(categoriesPath, data);
+    fs.outputJsonSync(categoriesPath, data, { spaces: 2 });
   }
 
   /**
@@ -410,7 +410,7 @@ export default class ProjectAPI {
   setCategoryGroupIds(toolName, category, groups) {
     const indexPath = path.join(this.getCategoriesDir(toolName),
       ".categoryIndex", `${category}.json`);
-    fs.outputJsonSync(indexPath, groups);
+    fs.outputJsonSync(indexPath, groups, { spaces: 2 });
   }
 
   /**
@@ -565,7 +565,7 @@ export default class ProjectAPI {
           `Failed to parse tool categories index at ${categoriesPath}.`, e);
       }
     }
-    fs.outputJsonSync(categoriesPath, data);
+    fs.outputJsonSync(categoriesPath, data, { spaces: 2 });
   }
 
   /**

--- a/src/js/helpers/ProjectMigration/manifestUtils.js
+++ b/src/js/helpers/ProjectMigration/manifestUtils.js
@@ -91,7 +91,7 @@ export function setUpManifest(projectSaveLocation, link, oldManifest) {
     }
 
     manifest = generateManifest(link, oldManifest || {});
-    fs.outputJsonSync(manifestLocation, manifest);
+    fs.outputJsonSync(manifestLocation, manifest, { spaces: 2 });
   } catch (err) {
     console.log(err);
     console.error(err);
@@ -192,7 +192,7 @@ export const saveProjectManifest = (projectPath, manifest) => {
   if (manifest) {
     const validManifestPath = getManifestPath(projectPath);
     if (validManifestPath) {
-      fs.outputJsonSync(validManifestPath, manifest);
+      fs.outputJsonSync(validManifestPath, manifest, { spaces: 2 });
     }
   }
 };

--- a/src/js/helpers/ProjectMigration/migrateToAddTargetLanguageBookName.js
+++ b/src/js/helpers/ProjectMigration/migrateToAddTargetLanguageBookName.js
@@ -41,7 +41,7 @@ const migrateToAddTargetLanguageBookName = (projectPath) => {
 
           manifest.target_language['book'] = { name: targetBookName };
         }
-        fs.outputJsonSync(manifestPath, manifest);
+        fs.outputJsonSync(manifestPath, manifest, { spaces: 2 });
         resolve(manifest); // This is for unit test.
       } else {
         throw new Error("Manifest not found.");

--- a/src/js/helpers/ProjectMigration/migrateToVersion2.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion2.js
@@ -79,7 +79,7 @@ export const updateAlignmentsForFile = function (filePath) {
       modified |= correctOccurrencesInAlignmentWords(foundWords);
     }
     if (modified) {
-      fs.outputJsonSync(filePath, chapter_alignments);
+      fs.outputJsonSync(filePath, chapter_alignments, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());

--- a/src/js/helpers/ProjectMigration/migrateToVersion3.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion3.js
@@ -91,7 +91,7 @@ export const fix_tWords = function (filePath) {
       }
     }
     if (modified) {
-      fs.outputJsonSync(filePath, items);
+      fs.outputJsonSync(filePath, items, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());
@@ -120,7 +120,7 @@ export const fixProjectAlignmentTopWords = function (filePath) {
       }
     }
     if (modified) {
-      fs.outputJsonSync(filePath, chapter_alignments);
+      fs.outputJsonSync(filePath, chapter_alignments, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());

--- a/src/js/helpers/ProjectMigration/migrateToVersion4.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion4.js
@@ -92,7 +92,7 @@ export const fix_tWords = function (filePath) {
       }
     }
     if (modified) {
-      fs.outputJsonSync(filePath, items);
+      fs.outputJsonSync(filePath, items, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());
@@ -127,7 +127,7 @@ export const fixProjectAlignmentTopWords = function (filePath) {
       }
     }
     if (modified) {
-      fs.outputJsonSync(filePath, chapter_alignments);
+      fs.outputJsonSync(filePath, chapter_alignments, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());

--- a/src/js/helpers/ProjectMigration/migrateToVersion5.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion5.js
@@ -86,7 +86,7 @@ export const fixProjectOccurrencesTopWords = function (filePath) {
       }
     }
     if (broken) {
-      fs.outputJsonSync(filePath, chapter_alignments);
+      fs.outputJsonSync(filePath, chapter_alignments, { spaces: 2 });
     }
   } catch (e) {
     console.warn("Error opening chapter alignment '" + filePath + "': " + e.toString());

--- a/src/js/helpers/ProjectMigration/migrateToVersion6.js
+++ b/src/js/helpers/ProjectMigration/migrateToVersion6.js
@@ -54,7 +54,7 @@ const migrateToVersion6 = (projectPath) => {
         findResourceIdAndNickname(manifest);
         if ((manifest.resource.id !== originalResourceId) ||
             (manifest.resource.name !== originalNickname)) { // if new setting found
-          fs.outputJsonSync(manifestPath, manifest);
+          fs.outputJsonSync(manifestPath, manifest, { spaces: 2 });
         }
       }
     } else {

--- a/src/js/helpers/ProjectOverwriteHelpers.js
+++ b/src/js/helpers/ProjectOverwriteHelpers.js
@@ -55,7 +55,6 @@ export const mergeOldProjectToNewProject = (oldProjectPath, newProjectPath, user
     // filter duplicate translators items
     newManifest.translators = newManifest.translators.filter(translator => !oldManifest.translators.includes(translator));
     const mergedManifest = {
-      "mergedManifest": "hello",
       ...oldManifest,
       ...newManifest,
       checkers: [...oldManifest.checkers, ...newManifest.checkers],

--- a/src/js/helpers/ProjectOverwriteHelpers.js
+++ b/src/js/helpers/ProjectOverwriteHelpers.js
@@ -6,6 +6,7 @@ import {checkSelectionOccurrences} from 'selections';
 import isEqual from 'deep-equal';
 import * as AlertActions from '../actions/AlertActions';
 import {generateLoadPath} from '../actions/CheckDataLoadActions';
+import {setProjectManifest} from '../actions/ProjectDetailsActions';
 import {getTranslate, getToolsByKey} from '../selectors';
 import {loadProjectGroupData} from './ResourcesHelpers';
 
@@ -44,6 +45,25 @@ export const mergeOldProjectToNewProject = (oldProjectPath, newProjectPath, user
         }
       }
     }
+    // merge manifest files
+    const oldManifestPath = path.join(oldProjectPath, 'manifest.json');
+    const newManifestPath = path.join(newProjectPath, 'manifest.json');
+    const oldManifest = fs.readJsonSync(oldManifestPath);
+    const newManifest = fs.readJsonSync(newManifestPath);
+    // filter duplicate checkers items
+    newManifest.checkers = newManifest.checkers.filter(checker => !oldManifest.checkers.includes(checker));
+    // filter duplicate translators items
+    newManifest.translators = newManifest.translators.filter(translator => !oldManifest.translators.includes(translator));
+    const mergedManifest = {
+      "mergedManifest": "hello",
+      ...oldManifest,
+      ...newManifest,
+      checkers: [...oldManifest.checkers, ...newManifest.checkers],
+      translators: [...oldManifest.translators, ...newManifest.translators]
+    };
+    // save mergedManifest in newManifestPath
+    dispatch(setProjectManifest(mergedManifest));
+
     // Copy the .git history of the old project into the new if it doesn't have it
     const oldGitPath = path.join(oldProjectPath, '.git');
     const newGitPath = path.join(newProjectPath, '.git');

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -94,7 +94,7 @@ function updateResourcesForFile(filePath, toolName, resourcesPath, bookId, isCon
           if (isContext) {
             data = data.contextId;
           }
-          fs.outputJsonSync(filePath, data);
+          fs.outputJsonSync(filePath, data, { spaces: 2 });
         }
       }
     }
@@ -363,7 +363,7 @@ export const updateSourceContentUpdaterManifest = (dateStr = null) => {
   const destinationPath = path.join(USER_RESOURCES_PATH,
       SOURCE_CONTENT_UPDATER_MANIFEST);
     fs.ensureDirSync(USER_RESOURCES_PATH);
-    fs.outputJsonSync(destinationPath, manifest);
+    fs.outputJsonSync(destinationPath, manifest, { spaces: 2 });
 };
 
 /**
@@ -378,7 +378,7 @@ export const copySourceContentUpdaterManifest = () => {
     const destinationPath = path.join(USER_RESOURCES_PATH,
       SOURCE_CONTENT_UPDATER_MANIFEST);
     fs.ensureDirSync(USER_RESOURCES_PATH);
-    fs.outputJsonSync(destinationPath, bundledManifest);
+    fs.outputJsonSync(destinationPath, bundledManifest, { spaces: 2 });
   }
 };
 

--- a/src/js/helpers/__tests__/ProjectAPI.test.js
+++ b/src/js/helpers/__tests__/ProjectAPI.test.js
@@ -150,7 +150,7 @@ describe('ProjectAPI', () => {
       expect(console.warn).not.toBeCalled();
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": [], "loaded": ["other", "category"], timestamp: manifest.modified});
+        {"current": [], "loaded": ["other", "category"], timestamp: manifest.modified}, { "spaces": 2 });
     });
 
     it('removes loaded', () => {
@@ -164,7 +164,7 @@ describe('ProjectAPI', () => {
       expect(console.warn).not.toBeCalled();
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": [], "loaded": ["other"], timestamp: manifest.modified});
+        {"current": [], "loaded": ["other"], timestamp: manifest.modified}, { "spaces": 2 });
     });
 
     it('rebuilds missing file', () => {
@@ -178,7 +178,7 @@ describe('ProjectAPI', () => {
       expect(console.warn).not.toBeCalled();
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": [], "loaded": ["category"], timestamp: manifest.modified});
+        {"current": [], "loaded": ["category"], timestamp: manifest.modified}, { "spaces": 2 });
     });
 
     it('rebuilds corrupt file', () => {
@@ -196,7 +196,7 @@ describe('ProjectAPI', () => {
       expect(console.warn).toBeCalled();
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": [], "loaded": ["category"], timestamp: manifest.modified});
+        {"current": [], "loaded": ["category"], timestamp: manifest.modified}, { "spaces": 2 });
     });
   });
 
@@ -262,7 +262,8 @@ describe('ProjectAPI', () => {
       p.setSelectedCategories('tool', ["category"]);
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": ["category"], "loaded": []}
+        {"current": ["category"], "loaded": []},
+        { "spaces": 2 }
       );
       expect(console.warn).not.toBeCalled();
     });
@@ -277,7 +278,8 @@ describe('ProjectAPI', () => {
       p.setSelectedCategories('tool', ["category"]);
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": ["category"], "loaded": [], timestamp: expect.any(String)}
+        {"current": ["category"], "loaded": [], timestamp: expect.any(String)},
+        { "spaces": 2 }
       );
       expect(console.warn).not.toBeCalled();
     });
@@ -293,7 +295,8 @@ describe('ProjectAPI', () => {
       p.setSelectedCategories('tool', ["category"]);
       expect(fs.outputJsonSync).toBeCalledWith(
         path.join(path.sep, "root", ".apps", "translationCore", "index", "tool", "book", ".categories"),
-        {"current": ["category"], "loaded": [], timestamp: expect.any(String)}
+        {"current": ["category"], "loaded": [], timestamp: expect.any(String)},
+        { "spaces": 2 }
       );
       expect(console.warn).toBeCalled();
     });

--- a/src/js/helpers/contextIdHelpers.js
+++ b/src/js/helpers/contextIdHelpers.js
@@ -36,7 +36,7 @@ export const saveContextId = (state, contextId) => {
     if (projectSaveLocation && toolName && bookId) {
       let fileName = "contextId.json";
       let savePath = path.join(projectSaveLocation, INDEX_DIRECTORY, toolName, bookId, "currentContextId", fileName);
-      fs.outputJsonSync(savePath, contextId);
+      fs.outputJsonSync(savePath, contextId, { spaces: 2 });
     } else {
       // saveCurrentContextId: missing required data
     }

--- a/src/js/helpers/manifestHelpers.js
+++ b/src/js/helpers/manifestHelpers.js
@@ -71,7 +71,7 @@ export function setUpManifest(projectSaveLocation, oldManifest) {
     } else {
       manifest = template;
     }
-    fs.outputJsonSync(manifestLocation, manifest);
+    fs.outputJsonSync(manifestLocation, manifest, { spaces: 2 });
   } catch (err) {
     console.error(err);
   }

--- a/src/js/helpers/originalLanguageResourcesHelpers.js
+++ b/src/js/helpers/originalLanguageResourcesHelpers.js
@@ -6,10 +6,13 @@
  */
 export function getTsvOLVersion(tsvRelations, resourceId) {
   try {
-    // Get the query string from the tsv_relation array for given resourceId
-    const query = tsvRelations.find((query) => query.includes(resourceId));
-    // Get version number from query
-    const tsvOLVersion = query.split('?v=')[1];
+    let tsvOLVersion = null;
+    if (tsvRelations) {
+      // Get the query string from the tsv_relation array for given resourceId
+      const query = tsvRelations.find((query) => query.includes(resourceId));
+      // Get version number from query
+      tsvOLVersion = query.split('?v=')[1];
+    }
     return tsvOLVersion;
   } catch (error) {
     console.error(error);

--- a/src/js/localStorage/saveMethods.js
+++ b/src/js/localStorage/saveMethods.js
@@ -21,7 +21,7 @@ const INDEX_DIRECTORY = path.join('.apps', 'translationCore', 'index');
  */
 export const saveSettings = state => {
   try {
-    fs.outputJsonSync(SETTINGS_DIRECTORY, state.settingsReducer);
+    fs.outputJsonSync(SETTINGS_DIRECTORY, state.settingsReducer, { spaces: 2 });
   } catch (err) {
     console.warn(err);
   }
@@ -44,7 +44,7 @@ function saveData(state, checkDataName, payload, modifiedTimestamp) {
       const saveDir = path.parse(savePath).dir;
       const existingPayload = CheckDataLoadActions.loadCheckData(saveDir, payload.contextId);
       if (!fs.existsSync(savePath) && !isEqual(existingPayload, payload)) {
-        fs.outputJsonSync(savePath, payload, err => {console.log(err)});
+        fs.outputJsonSync(savePath, payload, { spaces: 2 });
       }
     } else {
       // no savepath
@@ -68,7 +68,7 @@ export const saveTargetLanguage = state => {
         const savePath = path.join(PROJECT_SAVE_LOCATION, bookAbbr, fileName);
         const chapterData = currentTargetLanguageChapters[chapter];
         try {
-          fs.outputJsonSync(savePath, chapterData);
+          fs.outputJsonSync(savePath, chapterData, { spaces: 2 });
         } catch (err) {
           console.warn(err);
         }
@@ -179,7 +179,7 @@ export const saveVerseEdit = state => {
       `${fileName}.json`
     );
     if(!fs.existsSync(savePath)) {
-      fs.outputJsonSync(savePath, verseEditPayload, err => {console.log(err)});
+      fs.outputJsonSync(savePath, verseEditPayload, { spaces: 2 });
     }
   } catch (err) {
     console.warn(err);
@@ -239,7 +239,7 @@ export const saveGroupsData = (state, prevState) => {
         if (groupsData[groupID] && !isEqual(groupsData[groupID], oldGroupsData[groupID])) {
           const fileName = groupID + ".json";
           const savePath = path.join(PROJECT_SAVE_LOCATION, INDEX_DIRECTORY, toolName, bookAbbreviation, fileName);
-          fs.outputJsonSync(savePath, groupsData[groupID]);
+          fs.outputJsonSync(savePath, groupsData[groupID], { spaces: 2 });
         }
       }
     } else {
@@ -266,7 +266,7 @@ export function saveProjectManifest(state) {
   if (projectSaveLocation && manifest && Object.keys(manifest).length > 0) {
     const fileName = 'manifest.json';
     const savePath = path.join(projectSaveLocation, fileName);
-    fs.outputJsonSync(savePath, manifest);
+    fs.outputJsonSync(savePath, manifest, { spaces: 2 });
   }
 }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
1. Import a USFM project. I used this one. [62-2PE.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3392555/62-2PE.usfm.zip)
2. Load the project in tN
3. Export the project to USFM without alignments
4. Import the exported project choosing the Overwrite options on the alerts
5. Attempt to load the project tN
6. It should open again without any issues.


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6257)
<!-- Reviewable:end -->
