### PR TITLE
Tool Card 100% Complete Bugfix

### DIFF
--- a/__tests__/__snapshots__/GroupsDataActions.test.js.snap
+++ b/__tests__/__snapshots__/GroupsDataActions.test.js.snap
@@ -146,78 +146,6 @@ Array [
 exports[`GroupsDataActions.verifyGroupDataMatchesWithFs should succeed with external verse edits 1`] = `
 Array [
   Object {
-    "boolean": true,
-    "contextId": Object {
-      "groupId": "apostle",
-      "occurrence": 1,
-      "quote": "ἀπόστολος",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G06520",
-      ],
-      "tool": "translationWords",
-    },
-    "type": "SET_INVALIDATION_IN_GROUPDATA",
-  },
-  Object {
-    "boolean": true,
-    "contextId": Object {
-      "groupId": "god",
-      "occurrence": 1,
-      "quote": "Θεοῦ",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G23160",
-      ],
-      "tool": "translationWords",
-    },
-    "type": "SET_INVALIDATION_IN_GROUPDATA",
-  },
-  Object {
-    "contextId": Object {
-      "groupId": "apostle",
-      "occurrence": 1,
-      "quote": "ἀπόστολος",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G06520",
-      ],
-      "tool": "translationWords",
-    },
-    "selections": Array [],
-    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
-  },
-  Object {
-    "contextId": Object {
-      "groupId": "god",
-      "occurrence": 1,
-      "quote": "Θεοῦ",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G23160",
-      ],
-      "tool": "translationWords",
-    },
-    "selections": Array [],
-    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
-  },
-  Object {
     "alertMessage": "loading_verse_edits",
     "loading": true,
     "type": "OPEN_ALERT_DIALOG",
@@ -380,83 +308,83 @@ Array [
   Object {
     "type": "CLOSE_ALERT_DIALOG",
   },
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
 ]
 `;
 
 exports[`GroupsDataActions.verifyGroupDataMatchesWithFs should succeed with multiple external verse edits 1`] = `
 Array [
-  Object {
-    "boolean": true,
-    "contextId": Object {
-      "groupId": "apostle",
-      "occurrence": 1,
-      "quote": "ἀπόστολος",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G06520",
-      ],
-      "tool": "translationWords",
-    },
-    "type": "SET_INVALIDATION_IN_GROUPDATA",
-  },
-  Object {
-    "boolean": true,
-    "contextId": Object {
-      "groupId": "god",
-      "occurrence": 1,
-      "quote": "Θεοῦ",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G23160",
-      ],
-      "tool": "translationWords",
-    },
-    "type": "SET_INVALIDATION_IN_GROUPDATA",
-  },
-  Object {
-    "contextId": Object {
-      "groupId": "apostle",
-      "occurrence": 1,
-      "quote": "ἀπόστολος",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G06520",
-      ],
-      "tool": "translationWords",
-    },
-    "selections": Array [],
-    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
-  },
-  Object {
-    "contextId": Object {
-      "groupId": "god",
-      "occurrence": 1,
-      "quote": "Θεοῦ",
-      "reference": Object {
-        "bookId": "tit",
-        "chapter": 1,
-        "verse": 1,
-      },
-      "strong": Array [
-        "G23160",
-      ],
-      "tool": "translationWords",
-    },
-    "selections": Array [],
-    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
-  },
   Object {
     "alertMessage": "loading_verse_edits",
     "loading": true,
@@ -635,6 +563,78 @@ Array [
   },
   Object {
     "type": "CLOSE_ALERT_DIALOG",
+  },
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "boolean": true,
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "type": "SET_INVALIDATION_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "apostle",
+      "occurrence": 1,
+      "quote": "ἀπόστολος",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G06520",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
+  },
+  Object {
+    "contextId": Object {
+      "groupId": "god",
+      "occurrence": 1,
+      "quote": "Θεοῦ",
+      "reference": Object {
+        "bookId": "tit",
+        "chapter": 1,
+        "verse": 1,
+      },
+      "strong": Array [
+        "G23160",
+      ],
+      "tool": "translationWords",
+    },
+    "selections": Array [],
+    "type": "TOGGLE_SELECTIONS_IN_GROUPDATA",
   },
 ]
 `;

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -34,7 +34,7 @@ export const addGroupData = (groupId, groupsData) => {
  */
 export function verifyGroupDataMatchesWithFs() {
   console.log("verifyGroupDataMatchesWithFs()");
-  return ((dispatch, getState) => {
+  return (async (dispatch, getState) => {
     const state = getState();
     const toolName = getSelectedToolName(state);
     const PROJECT_SAVE_LOCATION = state.projectDetailsReducer.projectSaveLocation;
@@ -101,7 +101,7 @@ export function verifyGroupDataMatchesWithFs() {
         }
       }
       if (Object.keys(checkVerseEdits).length) {
-        dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));
+        await dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));
       }
       // run the batch of queue actions
       if (actionsBatch.length) {

--- a/src/js/actions/ToolActions.js
+++ b/src/js/actions/ToolActions.js
@@ -82,10 +82,10 @@ export const openTool = (name) => (dispatch, getData) => {
       const groupIndex = loadProjectGroupIndex(language, name, projectDir, translate);
       dispatch(loadGroupsIndex(groupIndex));
 
-      dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+      await dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
       dispatch(loadCurrentContextId());
       //TRICKY: need to verify groups data before and after the contextId has been loaded
-      dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+      await dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
       // wait for filesystem calls to finish
       await delay(150);
       dispatch(batchActions([

--- a/src/js/helpers/__tests__/__snapshots__/ResourceHelpers-updateResources.test.js.snap
+++ b/src/js/helpers/__tests__/__snapshots__/ResourceHelpers-updateResources.test.js.snap
@@ -21,7 +21,6 @@ Array [
   "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt",
   "<HOME_DIR>/translationCore/resources/en/bibles/ult",
   "<HOME_DIR>/translationCore/resources/en/bibles/ust",
-  "<HOME_DIR>/translationCore/resources/grc/bibles/ugnt",
   "<HOME_DIR>/translationCore/resources/hbo/bibles/uhb",
 ]
 `;

--- a/src/js/helpers/__tests__/__snapshots__/ResourceHelpers-updateResources.test.js.snap
+++ b/src/js/helpers/__tests__/__snapshots__/ResourceHelpers-updateResources.test.js.snap
@@ -21,6 +21,7 @@ Array [
   "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt",
   "<HOME_DIR>/translationCore/resources/en/bibles/ult",
   "<HOME_DIR>/translationCore/resources/en/bibles/ust",
+  "<HOME_DIR>/translationCore/resources/grc/bibles/ugnt",
   "<HOME_DIR>/translationCore/resources/hbo/bibles/uhb",
 ]
 `;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR is an attempt to fix a race condition with the tool card not showing 100% when it should

#### Please include detailed Test instructions for your pull request:
- Download  the following projects
[43-LUK.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3413069/43-LUK.usfm.zip)
[66-JUD.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3413074/66-JUD.usfm.zip)
- Open them in tC
- Ensure they have 100% on the wA tool card before opening the tool.


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6267)
<!-- Reviewable:end -->
