### PR TITLE
QA Fix - #6250 - fix tW missing checks by reverting category loading funcion

### DIFF
--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -13,8 +13,6 @@ import {
 } from '../common/constants';
 import { getOrigLangforBook } from "./bibleHelpers";
 
-const toolCategoryMapping = {};
-
 /**
  * Provides an interface with which tools can interact with a project.
  */
@@ -455,24 +453,22 @@ export default class ProjectAPI {
    * @returns {object}
    */
   getAllCategoryMapping(toolName) {
-    if (toolCategoryMapping[toolName] == undefined) {
-      toolCategoryMapping[toolName] = {};
-      const indexPath = path.join(this.getCategoriesDir(toolName), ".categoryIndex");
-      if (fs.pathExistsSync(indexPath)) {
-        try {
-          const parentCategoryFiles = fs.readdirSync(indexPath);
-          parentCategoryFiles.forEach((parentCategoryFile) => {
-            const parentCategoryPath = path.join(indexPath, parentCategoryFile);
-            const parentCategory = path.parse(parentCategoryFile).name;
-            toolCategoryMapping[toolName][parentCategory] = fs.readJsonSync(parentCategoryPath);
-          });
-        } catch (e) {
-          console.error(`Failed to read the category index at ${indexPath}`, e);
-        }
+    const parentCategoriesObject = {};
+    const indexPath = path.join(this.getCategoriesDir(toolName),
+      ".categoryIndex");
+    if (fs.pathExistsSync(indexPath)) {
+      try {
+        const parentCategories = fs.readdirSync(indexPath).map((fileName) => path.parse(fileName).name);
+        parentCategories.forEach((category) => {
+          const subCategoryPath = path.join(this.getCategoriesDir(toolName),
+            ".categoryIndex", `${category}.json`);
+          parentCategoriesObject[category] = fs.readJsonSync(subCategoryPath);
+        });
+      } catch (e) {
+        console.error(`Failed to read the category index at ${indexPath}`, e);
       }
     }
-
-    return toolCategoryMapping[toolName];
+    return parentCategoriesObject;
   }
 
   /**

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -449,19 +449,17 @@ export default class ProjectAPI {
    * Gets the category mapping for a tool in the project's .categoryIndex's directory
    * This gets cached in toolCategoryMapping by toolName
    * Keyed by toolName & parent category, value is an array of the subcategories
-   * @param toolName
+   * @param {string} toolName
    * @returns {object}
    */
   getAllCategoryMapping(toolName) {
     const parentCategoriesObject = {};
-    const indexPath = path.join(this.getCategoriesDir(toolName),
-      ".categoryIndex");
+    const indexPath = path.join(this.getCategoriesDir(toolName), ".categoryIndex");
     if (fs.pathExistsSync(indexPath)) {
       try {
         const parentCategories = fs.readdirSync(indexPath).map((fileName) => path.parse(fileName).name);
         parentCategories.forEach((category) => {
-          const subCategoryPath = path.join(this.getCategoriesDir(toolName),
-            ".categoryIndex", `${category}.json`);
+          const subCategoryPath = path.join(this.getCategoriesDir(toolName), ".categoryIndex", `${category}.json`);
           parentCategoriesObject[category] = fs.readJsonSync(subCategoryPath);
         });
       } catch (e) {
@@ -473,20 +471,20 @@ export default class ProjectAPI {
 
   /**
    * Returns an array of categories that have been selected for the given tool.
-   * @param toolName - The tool name. This is synonymous with translationHelp name
+   * @param {string} toolName - The tool name. This is synonymous with translationHelp name
+   * @param {boolean} withParent
    * @return {string[]} an array of category names
    */
   getSelectedCategories(toolName, withParent = false) {
-    const categoriesPath = path.join(this.getCategoriesDir(toolName),
-      ".categories");
+    const categoriesPath = path.join(this.getCategoriesDir(toolName), ".categories");
     if (fs.pathExistsSync(categoriesPath)) {
       try {
         const data = fs.readJsonSync(categoriesPath);
         if (withParent) {
           let objectWithParentCategories = {};
           const subCategories = data.current;
+          const parentCategoryMapping = this.getAllCategoryMapping(toolName);
           subCategories.forEach((subCategory) => {
-            const parentCategoryMapping = this.getAllCategoryMapping(toolName);
             Object.keys(parentCategoryMapping).forEach((categoryName) => {
               if (parentCategoryMapping[categoryName].includes(subCategory)) {
                 // Subcategory name is contained in this parent

--- a/src/js/helpers/ProjectAPI.js
+++ b/src/js/helpers/ProjectAPI.js
@@ -447,8 +447,6 @@ export default class ProjectAPI {
 
   /**
    * Gets the category mapping for a tool in the project's .categoryIndex's directory
-   * This gets cached in toolCategoryMapping by toolName
-   * Keyed by toolName & parent category, value is an array of the subcategories
    * @param {string} toolName
    * @returns {object}
    */


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fixes QA Fail #6250 
- Fixed by reverting some code I myself am the one who made, but didn't allow for different book projects. Not worth caching anyway. Moved the call to that function outside of a loop so it wasn't called for every category as that wasn't needed.

#### Please include detailed Test instructions for your pull request:
- Follow the instructions in the issue using the build generated by this PR

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6268)
<!-- Reviewable:end -->
