### PR TITLE
Bugfix 6050/Fix bug that tN selection prompt was sometimes in English.

### DIFF
--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -226,11 +226,12 @@ export const loadBiblesByLanguageId = (languageId) => {
     const bibles = getBibles(getState());
     // check if the languae id is already included in the bibles object.
     const isIncluded = Object.keys(bibles).includes(languageId);
-
-    if (!isIncluded && fs.existsSync(bibleFolderPath) && bookId) {
+    if (fs.existsSync(bibleFolderPath) && bookId) {
       const bibleIds = fs.readdirSync(bibleFolderPath).filter(file => file !== ".DS_Store");
       bibleIds.forEach(bibleId => {
-        dispatch(loadBibleBook(bibleId, bookId, languageId));
+        if (!isIncluded || !bibles[languageId][bibleId]) { //TRICKY: just because we have the language loaded does not mean we have all the bibles loaded
+          dispatch(loadBibleBook(bibleId, bookId, languageId));
+        }
       });
     }
   };

--- a/src/js/actions/ResourcesActions.js
+++ b/src/js/actions/ResourcesActions.js
@@ -229,7 +229,7 @@ export const loadBiblesByLanguageId = (languageId) => {
     if (fs.existsSync(bibleFolderPath) && bookId) {
       const bibleIds = fs.readdirSync(bibleFolderPath).filter(file => file !== ".DS_Store");
       bibleIds.forEach(bibleId => {
-        if (!isIncluded || !bibles[languageId][bibleId]) { //TRICKY: just because we have the language loaded does not mean we have all the bibles loaded
+        if (!isIncluded || !bibles[languageId][bibleId]) { //TRICKY: just because we have a bible in the language loaded does not mean we have all the bibles loaded
           dispatch(loadBibleBook(bibleId, bookId, languageId));
         }
       });


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixed bug in loadBiblesByLanguageId() that would not load hi_irv if there were already hi bibles loaded.  Sometimes it would just have hi_ulb loaded which does not have alignments.

#### Please include detailed Test instructions for your pull request:
1. in tCore, update to latest en and hi resources.
2. import [58-PHM-hi.usfm.txt](https://github.com/unfoldingWord-dev/translationCore/files/3383567/58-PHM-hi.usfm.txt), select en GL for tN, and launch.  Then change tN GL to hi and launch.  should see selection prompts in hi and not en.
3. select a different project, set GL for tN to en and launch.
4. reselect project from step 2, select en GL for tN, and launch.  Then change tN GL to hi and launch.  should see selection prompts in hi and not en.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6269)
<!-- Reviewable:end -->
