### PR TITLE
Triggering tool data reload when the tool GL is changed

### DIFF
--- a/src/js/components/home/overview/ToolCard.js
+++ b/src/js/components/home/overview/ToolCard.js
@@ -78,7 +78,7 @@ class ToolCard extends Component {
   }
 
   render() {
-    const {translate, currentSelectedGL} = this.props;
+    const {translate} = this.props;
     const emptyMessage = translate('select_tool');
     const emptyButtonLabel = translate('buttons.tool_button');
     const emptyButtonOnClick = () => { this.props.actions.goToStep(3) };
@@ -90,7 +90,6 @@ class ToolCard extends Component {
         emptyButtonLabel={emptyButtonLabel}
         emptyButtonOnClick={emptyButtonOnClick}
         disabled={this.disabled()}
-        currentSelectedGL={currentSelectedGL}
       />
     );
   }
@@ -99,8 +98,7 @@ class ToolCard extends Component {
 ToolCard.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
-  translate: PropTypes.func,
-  currentSelectedGL: PropTypes.string.isRequired,
+  translate: PropTypes.func
 };
 ToolCard.contextTypes = {
   store: PropTypes.any

--- a/src/js/components/home/overview/ToolCard.js
+++ b/src/js/components/home/overview/ToolCard.js
@@ -78,7 +78,7 @@ class ToolCard extends Component {
   }
 
   render() {
-    const {translate} = this.props;
+    const {translate, currentSelectedGL} = this.props;
     const emptyMessage = translate('select_tool');
     const emptyButtonLabel = translate('buttons.tool_button');
     const emptyButtonOnClick = () => { this.props.actions.goToStep(3) };
@@ -90,6 +90,7 @@ class ToolCard extends Component {
         emptyButtonLabel={emptyButtonLabel}
         emptyButtonOnClick={emptyButtonOnClick}
         disabled={this.disabled()}
+        currentSelectedGL={currentSelectedGL}
       />
     );
   }
@@ -98,7 +99,8 @@ class ToolCard extends Component {
 ToolCard.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
-  translate: PropTypes.func
+  translate: PropTypes.func,
+  currentSelectedGL: PropTypes.string.isRequired,
 };
 ToolCard.contextTypes = {
   store: PropTypes.any

--- a/src/js/components/home/overview/index.js
+++ b/src/js/components/home/overview/index.js
@@ -24,9 +24,13 @@ class OverviewContainer extends Component {
     const {
       translate,
       selectedCategoriesChanged,
+      glSelectedChanged,
     } = this.props;
-    const onClick = () =>
-      selectedCategoriesChanged ? openTool(toolTitle) : toggleHomeView(false);
+    const onClick = () => {
+      return selectedCategoriesChanged || glSelectedChanged ?
+        openTool(toolTitle) : toggleHomeView(false);
+    };
+
 
     return (
       <button className='btn-prime'
@@ -77,7 +81,8 @@ OverviewContainer.propTypes = {
   reducers: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
   selectedCategoriesChanged: PropTypes.bool.isRequired,
-  translate: PropTypes.func
+  translate: PropTypes.func,
+  glSelectedChanged: PropTypes.string.isRequired,
 };
 
 OverviewContainer.contextTypes = {

--- a/src/js/components/home/toolsManagement/ToolCard.js
+++ b/src/js/components/home/toolsManagement/ToolCard.js
@@ -36,6 +36,7 @@ class ToolCard extends Component {
       showDescription: false,
       progress: 0,
       selectedCategoriesChanged: false,
+      glSelectedChanged: false,
     };
   }
 
@@ -60,6 +61,8 @@ class ToolCard extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const glSelectedChanged = prevProps.currentSelectedGL !== this.props.currentSelectedGL;
+    if (glSelectedChanged) this.setState({ glSelectedChanged });
     if(!_.isEqual(prevProps.selectedCategories, this.props.selectedCategories)) {
       this.setState({ selectedCategoriesChanged: true });
       this.loadProgress();
@@ -118,12 +121,12 @@ class ToolCard extends Component {
       selectedToolName,
       tool: { name: newSelectedToolName },
     } = this.props;
-    const { selectedCategoriesChanged } = this.state;
+    const { selectedCategoriesChanged, glSelectedChanged } = this.state;
 
     if (isOLBookVersionMissing) {
       // Show dialog with option to download missing resource
       this.props.onMissingResource();
-    } else if (selectedToolName && !selectedCategoriesChanged && (selectedToolName === newSelectedToolName)) {
+    } else if (selectedToolName && !glSelectedChanged && !selectedCategoriesChanged && (selectedToolName === newSelectedToolName)) {
       // Show tool (Without loading tool data)
       toggleHomeView(false);
     } else {
@@ -271,6 +274,7 @@ ToolCard.propTypes = {
     PropTypes.bool
   ]),
   toggleHomeView: PropTypes.func.isRequired,
+  currentSelectedGL: PropTypes.string.isRequired,
 };
 
 ToolCard.contextTypes = {

--- a/src/js/components/home/toolsManagement/ToolsCards.js
+++ b/src/js/components/home/toolsManagement/ToolsCards.js
@@ -113,6 +113,7 @@ const ToolsCards = ({
                   folderName: tool.path,
                   name: tool.name
                 }}
+                currentSelectedGL={currentProjectToolsSelectedGL[tool.name] || ''}
                 isOLBookVersionMissing={!!isOLBookVersionMissing}
                 onMissingResource={() => onMissingResource(missingOLResource)}
                 invalidatedReducer={invalidatedReducer}
@@ -139,6 +140,7 @@ ToolsCards.propTypes = {
   originalLanguageBookManifest: PropTypes.object.isRequired,
   onMissingResource: PropTypes.func.isRequired,
   toggleHomeView: PropTypes.func.isRequired,
+  currentProjectToolsSelectedGL: PropTypes.object.isRequired,
 };
 
 export default ToolsCards;

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -32,34 +32,45 @@ class HomeContainer extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedCategoriesChanged: false
+      selectedCategoriesChanged: false,
+      glSelectedChanged: false,
     };
   }
 
   componentDidUpdate(prevProps) {
     const {
       toolsReducer: { selectedTool },
-      projectDetailsReducer: { toolsCategories }
+      projectDetailsReducer: {
+        toolsCategories,
+        currentProjectToolsSelectedGL,
+      },
     } = this.props.reducers;
     const {
       projectDetailsReducer: {
-        toolsCategories: prevToolsCategories
+        toolsCategories: prevToolsCategories,
+        currentProjectToolsSelectedGL: prevCurrentProjectToolsSelectedGL
       }
     } = prevProps.reducers;
 
+    const currentSelectedGL = currentProjectToolsSelectedGL[selectedTool];
+    const prevCurrentSelectedGL = prevCurrentProjectToolsSelectedGL[selectedTool];
+    const glSelectedChanged = prevCurrentSelectedGL !== currentSelectedGL;
+    if (glSelectedChanged) this.setState({ glSelectedChanged });
     if(!_.isEqual(prevToolsCategories[selectedTool], toolsCategories[selectedTool])) {
       this.setState({ selectedCategoriesChanged: true });
     }
   }
 
   render() {
-    let {
-      stepper: {
-        stepIndex
+    const {
+      homeScreenReducer: {
+        stepper: {
+          stepIndex
+        },
+        showWelcomeSplash,
+        showLicenseModal,
       },
-      showWelcomeSplash,
-      showLicenseModal
-    } = this.props.reducers.homeScreenReducer;
+    } = this.props.reducers;
 
     let displayContainer = <div />;
 
@@ -69,6 +80,7 @@ class HomeContainer extends Component {
           <Overview
             {...this.props}
             selectedCategoriesChanged={this.state.selectedCategoriesChanged}
+            glSelectedChanged={this.state.glSelectedChanged}
           />
         );
         break;

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -163,7 +163,7 @@
     "cancel_import_alert": "Canceling now will abort the import process and the project will need to be re-imported before it can be used.",
     "project_already_identified": "This project has been identified as a ${originalBook} project. Are you sure you want to change it to a ${suggestedBook} project?",
     "loading_project_alert": "Loading project data.",
-    "preparing_project_alert": "Preparing your project data.",
+    "preparing_project_alert": "Preparing project data.",
     "exported_alert": "${project_name} has been successfully exported to ${file_path}.",
     "must_be_logged_in_alert": "You must be logged in with a ${door43} account to upload projects. Please log out and then back in with a ${door43} user account.",
     "uploading_alert": "Uploading ${project_name} to ${door43}. Please wait...",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- Open a Hindi project, with English as GL.
- Go Back to Tools page and select Hindi as GL.
- Note that the left menu bar and the Occurrence Notes are now displaying correctly in Hindi.
- The same should happen vice-versa.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6278)
<!-- Reviewable:end -->
