### PR TITLE
Fixes broken script by reverting constant to string

### DIFF
--- a/scripts/resources/updateResources.js
+++ b/scripts/resources/updateResources.js
@@ -4,7 +4,6 @@
  */
 require("babel-polyfill"); // required for async/await
 const fs = require('fs-extra');
-const path = require('path-extra');
 const sourceContentUpdater = require('tc-source-content-updater').default;
 const updateResourcesHelpers = require('./updateResourcesHelpers');
 const zipResourcesContent = require('./zipHelpers').zipResourcesContent;

--- a/scripts/resources/updateResourcesHelpers.js
+++ b/scripts/resources/updateResourcesHelpers.js
@@ -52,7 +52,7 @@ const getLocalResourceList = resourcesPath => {
     for (let i = 0; i < resourceLanguages.length; i++) {
       const languageId = resourceLanguages[i];
       const biblesPath = path.join(resourcesPath, languageId, 'bibles');
-      const tHelpsPath = path.join(resourcesPath, languageId, TRANSLATION_HELPS);
+      const tHelpsPath = path.join(resourcesPath, languageId, 'translationHelps');
       const bibleIds = cleanReaddirSync(biblesPath);
       const tHelpsResources = cleanReaddirSync(tHelpsPath);
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Running `npm run update-resources` was broken. Fixes the string used.

#### Please include detailed Test instructions for your pull request:
- Should be able to run `npm run update-resources` now.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6316)
<!-- Reviewable:end -->
