### PR TITLE
Bugfix 5832/fix to show invalidations on tool launch

### DIFF
--- a/src/js/components/home/overview/index.js
+++ b/src/js/components/home/overview/index.js
@@ -15,22 +15,26 @@ class OverviewContainer extends Component {
   }
 
   /**
-  * @description generates the launch button
-  * @param {bool} disabled - disable the button
-  * @return {component} - component returned
-  */
+   * @description generates the launch button
+   * @param {bool} disabled - disable the button
+   * @param {String} toolTitle
+   * @return {component} - component returned
+   */
   launchButton(disabled, toolTitle) {
-    const { toggleHomeView, openTool } = this.props.actions;
+    const { toggleHomeView, openTool, warnOnInvalidations } = this.props.actions;
     const {
       translate,
       selectedCategoriesChanged,
       glSelectedChanged,
     } = this.props;
     const onClick = () => {
-      return selectedCategoriesChanged || glSelectedChanged ?
-        openTool(toolTitle) : toggleHomeView(false);
+      if (selectedCategoriesChanged || glSelectedChanged) {
+        openTool(toolTitle);
+      } else {
+        toggleHomeView(false);
+        warnOnInvalidations(toolTitle);
+      }
     };
-
 
     return (
       <button className='btn-prime'

--- a/src/js/components/home/toolsManagement/ToolCard.js
+++ b/src/js/components/home/toolsManagement/ToolCard.js
@@ -120,16 +120,18 @@ class ToolCard extends Component {
       isOLBookVersionMissing,
       toggleHomeView,
       selectedToolName,
-      tool: { name: newSelectedToolName },
+      tool,
+      actions: {warnOnInvalidations}
     } = this.props;
     const { selectedCategoriesChanged, glSelectedChanged } = this.state;
-
+    const newSelectedToolName = tool.name;
     if (isOLBookVersionMissing) {
       // Show dialog with option to download missing resource
       this.props.onMissingResource();
     } else if (selectedToolName && !glSelectedChanged && !selectedCategoriesChanged && (selectedToolName === newSelectedToolName)) {
       // Show tool (Without loading tool data)
       toggleHomeView(false);
+      warnOnInvalidations(newSelectedToolName);
     } else {
       // Load tool data then show tool
       this.handleSelect();
@@ -271,6 +273,7 @@ ToolCard.propTypes = {
     setProjectToolGL: PropTypes.func.isRequired,
     updateSubcategorySelection: PropTypes.func.isRequired,
     updateCategorySelection: PropTypes.func.isRequired,
+    warnOnInvalidations: PropTypes.func.isRequired,
   }),
   selectedCategories: PropTypes.array.isRequired,
   availableCategories: PropTypes.object.isRequired,

--- a/src/js/containers/home/HomeContainer.js
+++ b/src/js/containers/home/HomeContainer.js
@@ -22,7 +22,7 @@ import * as USFMExportActions from '../../actions/USFMExportActions';
 import * as ProjectInformationCheckActions from '../../actions/ProjectInformationCheckActions';
 import * as LocaleActions from '../../actions/LocaleActions';
 import * as ProjectDetailsActions from '../../actions/ProjectDetailsActions';
-import { openTool } from "../../actions/ToolActions";
+import {openTool, warnOnInvalidations} from "../../actions/ToolActions";
 // constants
 import { APP_VERSION } from '../../common/constants';
 
@@ -191,6 +191,9 @@ const mapDispatchToProps = (dispatch) => {
       },
       getProjectProgressForTools: (toolName) => {
         dispatch(ProjectDetailsActions.getProjectProgressForTools(toolName));
+      },
+      warnOnInvalidations: (toolName) => {
+        dispatch(warnOnInvalidations(toolName));
       }
     }
   };

--- a/src/js/containers/home/ToolsManagementContainer.js
+++ b/src/js/containers/home/ToolsManagementContainer.js
@@ -19,6 +19,7 @@ import * as PopoverActions from "../../actions/PopoverActions";
 import * as ProjectDetailsActions from "../../actions/ProjectDetailsActions";
 import { promptUserAboutMissingResource } from '../../actions/SourceContentUpdatesActions';
 import * as BodyUIActions from '../../actions/BodyUIActions';
+import {warnOnInvalidations} from "../../actions/ToolActions";
 
 class ToolsManagementContainer extends Component {
   constructor(props) {
@@ -150,6 +151,9 @@ const mapDispatchToProps = (dispatch) => {
       },
       showPopover: (title, bodyText, positionCoord) => {
         dispatch(PopoverActions.showPopover(title, bodyText, positionCoord));
+      },
+      warnOnInvalidations: (toolName) => {
+        dispatch(warnOnInvalidations(toolName));
       }
     }
   };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix to show invalidations on tool launch

#### Please include detailed Test instructions for your pull request:
- edits in tW and tN should show up immediately in group menu.
- launch various tools that have invalidations shown on toolcard - then you should see an alert with invalidation warnings

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6324)
<!-- Reviewable:end -->
