### PR TITLE
bugfix 6328/Fix to prevent multiple clicks on Overwrite Project

### DIFF
--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -412,7 +412,7 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
           </div>
         );
       }
-      let hasRunOnce = false;
+      let hasRunOnce = false; // to prevent multiple click responses
       dispatch(
         AlertModalActions.openOptionDialog(overwriteMessage,
           (result) => {

--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -19,6 +19,7 @@ import * as ProjectDetailsHelpers from '../helpers/ProjectDetailsHelpers';
 import * as ProjectOverwriteHelpers from "../helpers/ProjectOverwriteHelpers";
 import * as GogsApiHelpers from "../helpers/GogsApiHelpers";
 import * as ResourcesHelpers from "../helpers/ResourcesHelpers";
+import {delay} from "../common/utils";
 //reducers
 import Repo from '../helpers/Repo.js';
 import ProjectAPI from "../helpers/ProjectAPI";
@@ -411,18 +412,24 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
           </div>
         );
       }
+      let hasRunOnce = false;
       dispatch(
         AlertModalActions.openOptionDialog(overwriteMessage,
           (result) => {
             if (result === confirmText) {
               dispatch(AlertModalActions.closeAlertDialog());
-              const oldProjectPath = path.join(PROJECTS_PATH, projectName);
-              console.log('handleOverwriteWarning() - doing overwrite/merge');
-              ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath, getUsername(getState()), dispatch);
-              fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
-              fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
-              dispatch(setSaveLocation(oldProjectPath));
-              resolve(true);
+              if (!hasRunOnce) {
+                hasRunOnce = true;
+                delay(500).then(() => { // wait for UI to update and alert to close
+                  const oldProjectPath = path.join(PROJECTS_PATH, projectName);
+                  console.log('handleOverwriteWarning() - doing overwrite/merge');
+                  ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath, getUsername(getState()), dispatch);
+                  fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
+                  fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
+                  dispatch(setSaveLocation(oldProjectPath));
+                });
+                resolve(true);
+              }
             } else { // if cancel
               dispatch(AlertModalActions.closeAlertDialog());
               resolve(false);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix to update display so user is not tempted or allowed to click twice on overwrite button.

#### Please include detailed Test instructions for your pull request:
- Download a project from Door43 fully aligned(Import Online Project): https://git.door43.org/lrsallee/en_ult_heb_book
- Export the Project to USFM without alignments.
- Import the Project locally with same translation ID (ult)
- click on overwrite button and wait for alert about overwriting project
- try to click more than once on "Overwrite Project" button.  Alert should start to transition immediately and if you are able to click more than once, it should not corrupt the project.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6337)
<!-- Reviewable:end -->
