### PR TITLE
Bugfix For Opening Projects With Missing Verese

### DIFF
--- a/src/js/actions/Import/__tests__/__snapshots__/OnlineImportWorkflowActions.test.js.snap
+++ b/src/js/actions/Import/__tests__/__snapshots__/OnlineImportWorkflowActions.test.js.snap
@@ -33,6 +33,9 @@ Array [
     "type": "GET_MY_PROJECTS",
   },
   Object {
+    "type": "END_PROJECT_LOADING",
+  },
+  Object {
     "type": "LOADED_ONLINE_FAILED",
   },
 ]

--- a/src/js/actions/ProjectImportStepperActions.js
+++ b/src/js/actions/ProjectImportStepperActions.js
@@ -177,6 +177,7 @@ export function cancelProjectValidationStepper() {
     dispatch(MyProjectsActions.getMyProjects());
     const projectName = getState().localImportReducer.selectedProjectFilename;
     deleteProjectFromImportsFolder(projectName);
+    dispatch({ type: consts.END_PROJECT_LOADING});
   });
 }
 

--- a/src/js/actions/__tests__/__snapshots__/ProjectLoadingActions.test.js.snap
+++ b/src/js/actions/__tests__/__snapshots__/ProjectLoadingActions.test.js.snap
@@ -1174,6 +1174,9 @@ Array [
     ],
     "type": "GET_MY_PROJECTS",
   },
+  Object {
+    "type": "END_PROJECT_LOADING",
+  },
 ]
 `;
 
@@ -1520,6 +1523,9 @@ Array [
       },
     ],
     "type": "GET_MY_PROJECTS",
+  },
+  Object {
+    "type": "END_PROJECT_LOADING",
   },
 ]
 `;

--- a/src/js/containers/StatusBarContainer.js
+++ b/src/js/containers/StatusBarContainer.js
@@ -13,6 +13,7 @@ import {
   getProjectNickname,
   getUsername
 } from "../selectors";
+import {withLocale} from './Locale';
 
 class StatusBarContainer extends React.Component {
 
@@ -94,7 +95,7 @@ const mapDispatchToProps = {
   toggleHomeView: BodyUIActions.toggleHomeView
 };
 
-export default connect(
+export default withLocale(connect(
   mapStateToProps,
   mapDispatchToProps
-)(StatusBarContainer);
+)(StatusBarContainer));

--- a/src/js/containers/projectValidation/ProjectValidationContainer.js
+++ b/src/js/containers/projectValidation/ProjectValidationContainer.js
@@ -20,13 +20,19 @@ import MergeConflictsCheck from '../../components/projectValidation/MergeConflic
 import MissingVersesCheck from '../../components/projectValidation/MissingVersesCheck';
 import ProjectValidationNavigation from '../../components/projectValidation/ProjectValidationNavigation';
 import {withLocale} from '../Locale';
+import {isEqual} from 'lodash';
 
 class ProjectValidationContainer extends Component {
   shouldComponentUpdate(nextProps) {
     const {loadingProject} = nextProps.reducers.homeScreenReducer;
+    const { showProjectValidationStepper } = nextProps.reducers.projectValidationReducer;
+    const { showProjectValidationStepper: currentShowProjectValidationStepper } = this.props.reducers.projectValidationReducer;
+    if (!isEqual(showProjectValidationStepper, currentShowProjectValidationStepper)) {
+      return true;
+    }
     if (loadingProject === true) {
       return false;
-    } else return true;
+    }  else return true;
   }
   render() {
     let { stepIndex } = this.props.reducers.projectValidationReducer.stepper;

--- a/src/js/containers/projectValidation/ProjectValidationContainer.js
+++ b/src/js/containers/projectValidation/ProjectValidationContainer.js
@@ -20,14 +20,12 @@ import MergeConflictsCheck from '../../components/projectValidation/MergeConflic
 import MissingVersesCheck from '../../components/projectValidation/MissingVersesCheck';
 import ProjectValidationNavigation from '../../components/projectValidation/ProjectValidationNavigation';
 import {withLocale} from '../Locale';
-import {isEqual} from 'lodash';
 
 class ProjectValidationContainer extends Component {
   shouldComponentUpdate(nextProps) {
     const {loadingProject} = nextProps.reducers.homeScreenReducer;
     const { showProjectValidationStepper } = nextProps.reducers.projectValidationReducer;
-    const { showProjectValidationStepper: currentShowProjectValidationStepper } = this.props.reducers.projectValidationReducer;
-    if (!isEqual(showProjectValidationStepper, currentShowProjectValidationStepper)) {
+    if (showProjectValidationStepper === true) {
       return true;
     }
     if (loadingProject === true) {

--- a/src/js/containers/projectValidation/ProjectValidationContainer.js
+++ b/src/js/containers/projectValidation/ProjectValidationContainer.js
@@ -30,7 +30,7 @@ class ProjectValidationContainer extends Component {
     }
     if (loadingProject === true) {
       return false;
-    }  else return true;
+    } else return true;
   }
   render() {
     let { stepIndex } = this.props.reducers.projectValidationReducer.stepper;

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -23,7 +23,6 @@ import { loadLocalization, APP_LOCALE_SETTING } from '../actions/LocaleActions';
 import {getLocaleLoaded, getSetting} from '../selectors';
 import {loadTools} from "../actions/ToolActions";
 import packageJson from '../../../package.json';
-import { withLocale } from '../containers/Locale';
 import { injectFileLogging } from "../helpers/logger";
 //consts
 import { LOG_FILES_PATH } from "../common/constants";
@@ -33,7 +32,7 @@ injectFileLogging(LOG_FILES_PATH, version);
 
 class Main extends Component {
 
-    shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps) {
     const {loadingProject} = nextProps.reducers.homeScreenReducer;
     if (loadingProject === true) {
       return false;
@@ -76,7 +75,6 @@ class Main extends Component {
   render() {
     const {isLocaleLoaded} = this.props;
     if(isLocaleLoaded) {
-      const LocalizedStatusBarContainer = withLocale(StatusBarContainer);
       return (
         <MuiThemeProvider>
           <div className="fill-height">
@@ -88,7 +86,7 @@ class Main extends Component {
             <PopoverContainer/>
             <Grid fluid style={{padding: 0, display:'flex', flexDirection:'column', height:'100%'}}>
               <Row style={{margin: 0}}>
-                <LocalizedStatusBarContainer/>
+                <StatusBarContainer/>
               </Row>
               <BodyContainer/>
             </Grid>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- This PR addresses and issue where the ProjectValidationsContainer would not be shown when it needs to

#### Please include detailed Test instructions for your pull request:
- Test the project here and ensure it opens
[41-MAT.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/3478898/41-MAT.usfm.zip)
- Also, test canceling the stepper and starting over


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6343)
<!-- Reviewable:end -->
