### PR TITLE
Bugfix 5832/fix for when recorded check data has minor differences from contextIds in updated resources

### DIFF
--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -123,7 +123,10 @@ export function verifyGroupDataMatchesWithFs() {
                     const objectValue = object[folderName] || false;
                     const oldValue = oldGroupObject[folderName] || false;
                     if (!isEqual(oldValue, objectValue)) {
-                      let action = toggleGroupDataItems(folderName, object);
+                      // TRICKY: we are using the oldGroupObject here because it has the exact contextId. Sometimes
+                      //            there are slight differences in the contextIds of the checkData due to build
+                      //            changes (such as quoteString) and toggleGroupDataItems() requires exact match
+                      let action = toggleGroupDataItems(folderName, oldGroupObject);
                       if (action) actionsBatch.push(action);
                     }
                   }

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -123,10 +123,11 @@ export function verifyGroupDataMatchesWithFs() {
                     const objectValue = object[folderName] || false;
                     const oldValue = oldGroupObject[folderName] || false;
                     if (!isEqual(oldValue, objectValue)) {
-                      // TRICKY: we are using the oldGroupObject here because it has the exact contextId. Sometimes
-                      //            there are slight differences in the contextIds of the checkData due to build
-                      //            changes (such as quoteString) and toggleGroupDataItems() requires exact match
-                      let action = toggleGroupDataItems(folderName, oldGroupObject);
+                      // TRICKY: we are using the contextId of oldGroupObject here because sometimes
+                      //            there are slight differences with the contextIds of the checkData due to build
+                      //            changes (such as quoteString) and getToggledGroupData() requires exact match
+                      object.contextId = oldGroupObject.contextId;
+                      const action = toggleGroupDataItems(folderName, object);
                       if (action) actionsBatch.push(action);
                     }
                   }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for when recorded check data has minor differences from contextIds in updated resources.

#### Please include detailed Test instructions for your pull request:
- follow steps in https://github.com/unfoldingword-dev/translationcore/issues/5832 to try to reproduce issue E.  Should be working.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6362)
<!-- Reviewable:end -->
