### PR TITLE
WIP: changed verifyGroupDataMatchesWithFs to be non-blocking.

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -44,6 +44,10 @@ function readdirSync(directoryPath) {
   return [];
 }
 
+function readdir(directoryPath) {
+  return Promise.resolve(readdirSync(directoryPath));
+}
+
 function writeFileSync(filePath, data) {
   addFileToParentDirectory(filePath);
   mockFS[filePath] = data;
@@ -101,6 +105,10 @@ function readJsonSync(filePath) {
   // clone data so changes to object do not affect object in file system
   const clonedData = JSON.parse(typeof data === 'string' ? data : JSON.stringify(data));
   return clonedData;
+}
+
+function readJson(filePath) {
+  return Promise.resolve(readJsonSync(filePath));
 }
 
 function existsSync(path) {
@@ -268,6 +276,7 @@ fs.__loadFilesIntoMockFs = __loadFilesIntoMockFs;
 fs.__correctSeparatorsFromLinux = __correctSeparatorsFromLinux;
 fs.__loadDirIntoMockFs = __loadDirIntoMockFs;
 fs.readdirSync = jest.fn(readdirSync);
+fs.readdir = readdir;
 fs.writeFileSync = writeFileSync;
 fs.readFileSync = jest.fn(readFileSync);
 fs.writeJSONSync = outputJsonSync;
@@ -275,6 +284,8 @@ fs.outputJsonSync = jest.fn(outputJsonSync);
 fs.outputJSONSync = jest.fn(outputJsonSync);
 fs.readJsonSync = jest.fn(readJsonSync);
 fs.readJSONSync = readJsonSync;
+fs.readJson = readJson;
+fs.readJSON = readJson;
 fs.existsSync = jest.fn(existsSync);
 fs.exists = exists;
 fs.pathExists = exists;

--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -87,7 +87,7 @@ describe('GroupsDataActions.verifyGroupDataMatchesWithFs', () => {
     fs.outputJsonSync(path.join(verseEditPath, fileName), verseEdit);
 
     // when
-    await store.dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs(initStore.toolsReducer.selectedTool));
+    await store.dispatch(GroupsDataActions.verifyGroupDataMatchesWithFsNonBlocking(initStore.toolsReducer.selectedTool));
 
     // then
     const actions = store.getActions();

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -204,27 +204,26 @@ export function verifyGroupDataMatchesWithFsNonBlocking() {
       let folders = rawFolders.filter(folder => folder !== '.DS_Store');
       const isCheckTool = (toolName === TRANSLATION_WORDS || toolName === TRANSLATION_NOTES);
 
-      for ( let i = 0, lenF = folders.length; i < lenF; i++) {
-        const folderName = folders[i];
+      await Promise.all(folders.map( async (folderName) => {
         const isCheckVerseEdit = isCheckTool && (folderName === 'verseEdits');
         let dataPath = generatePathToDataItems(state, PROJECT_SAVE_LOCATION, folderName);
 
-        if (!fs.existsSync(dataPath)) {
+        if (!await fs.exists(dataPath)) {
           return;
         }
 
-        let chapters = fs.readdirSync(dataPath);
+        let chapters = await fs.readdir(dataPath);
         chapters = filterAndSort(chapters);
 
         for ( let j = 0, lenC = chapters.length; j < lenC; j++) {
           const chapterFolder = chapters[j];
           const chapterDir = path.join(dataPath, chapterFolder);
 
-          if (!fs.existsSync(chapterDir)) {
+          if (!await fs.exists(chapterDir)) {
             continue;
           }
 
-          let verses = fs.readdirSync(chapterDir);
+          let verses = await fs.readdir(chapterDir);
           verses = filterAndSort(verses);
 
           for ( let k = 0, lenV = verses.length; k < lenV; k++) {
@@ -286,7 +285,7 @@ export function verifyGroupDataMatchesWithFsNonBlocking() {
             }
           }
         }
-      }
+      }));
 
       if (Object.keys(checkVerseEdits).length) {
         await dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import path from 'path-extra';
 import isEqual from 'deep-equal';
 import { getSelectedToolName } from '../selectors';
-import { readLatestChecks } from '../helpers/groupDataHelpers';
+import { readLatestChecksNonBlock } from '../helpers/groupDataHelpers';
 import { TRANSLATION_WORDS, TRANSLATION_NOTES } from '../common/constants';
 import consts from './ActionTypes';
 import { showSelectionsInvalidatedWarning, validateAllSelectionsForVerse } from './SelectionsActions';
@@ -73,37 +73,37 @@ export function verifyGroupDataMatchesWithFs() {
     // build the batch
     let actionsBatch = [];
 
-    if (fs.existsSync(checkDataPath)) {
-      let folders = fs.readdirSync(checkDataPath).filter(folder => folder !== '.DS_Store');
+    if (await fs.exists(checkDataPath)) {
+      const rawFolders = await fs.readdir(checkDataPath);
+      let folders = rawFolders.filter(folder => folder !== '.DS_Store');
       const isCheckTool = (toolName === TRANSLATION_WORDS || toolName === TRANSLATION_NOTES);
 
-      for ( let i = 0, lenF = folders.length; i < lenF; i++) {
-        const folderName = folders[i];
+      await Promise.all(folders.map( async (folderName) => {
         const isCheckVerseEdit = isCheckTool && (folderName === 'verseEdits');
         let dataPath = generatePathToDataItems(state, PROJECT_SAVE_LOCATION, folderName);
 
-        if (!fs.existsSync(dataPath)) {
-          continue;
+        if (!await fs.exists(dataPath)) {
+          return;
         }
 
-        let chapters = fs.readdirSync(dataPath);
+        let chapters = await fs.readdir(dataPath);
         chapters = filterAndSort(chapters);
 
         for ( let j = 0, lenC = chapters.length; j < lenC; j++) {
           const chapterFolder = chapters[j];
           const chapterDir = path.join(dataPath, chapterFolder);
 
-          if (!fs.existsSync(chapterDir)) {
+          if (!await fs.exists(chapterDir)) {
             continue;
           }
 
-          let verses = fs.readdirSync(chapterDir);
+          let verses = await fs.readdir(chapterDir);
           verses = filterAndSort(verses);
 
           for ( let k = 0, lenV = verses.length; k < lenV; k++) {
             const verseFolder = verses[k];
             let filePath = path.join(dataPath, chapterFolder, verseFolder);
-            let latestObjects = readLatestChecks(filePath);
+            let latestObjects = await readLatestChecksNonBlock(filePath);
 
             for ( let l = 0, lenO = latestObjects.length; l < lenO; l++) {
               const object = latestObjects[l];
@@ -159,7 +159,7 @@ export function verifyGroupDataMatchesWithFs() {
             }
           }
         }
-      }
+      }));
 
       if (Object.keys(checkVerseEdits).length) {
         await dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -204,26 +204,27 @@ export function verifyGroupDataMatchesWithFsNonBlocking() {
       let folders = rawFolders.filter(folder => folder !== '.DS_Store');
       const isCheckTool = (toolName === TRANSLATION_WORDS || toolName === TRANSLATION_NOTES);
 
-      await Promise.all(folders.map( async (folderName) => {
+      for ( let i = 0, lenF = folders.length; i < lenF; i++) {
+        const folderName = folders[i];
         const isCheckVerseEdit = isCheckTool && (folderName === 'verseEdits');
         let dataPath = generatePathToDataItems(state, PROJECT_SAVE_LOCATION, folderName);
 
-        if (!await fs.exists(dataPath)) {
+        if (!fs.existsSync(dataPath)) {
           return;
         }
 
-        let chapters = await fs.readdir(dataPath);
+        let chapters = fs.readdirSync(dataPath);
         chapters = filterAndSort(chapters);
 
         for ( let j = 0, lenC = chapters.length; j < lenC; j++) {
           const chapterFolder = chapters[j];
           const chapterDir = path.join(dataPath, chapterFolder);
 
-          if (!await fs.exists(chapterDir)) {
+          if (!fs.existsSync(chapterDir)) {
             continue;
           }
 
-          let verses = await fs.readdir(chapterDir);
+          let verses = fs.readdirSync(chapterDir);
           verses = filterAndSort(verses);
 
           for ( let k = 0, lenV = verses.length; k < lenV; k++) {
@@ -285,7 +286,7 @@ export function verifyGroupDataMatchesWithFsNonBlocking() {
             }
           }
         }
-      }));
+      }
 
       if (Object.keys(checkVerseEdits).length) {
         await dispatch(ensureCheckVerseEditsInGroupData(checkVerseEdits));

--- a/src/js/actions/ToolActions.js
+++ b/src/js/actions/ToolActions.js
@@ -91,10 +91,10 @@ export const openTool = (name) => (dispatch, getData) => new Promise(async (reso
     dispatch(loadCurrentContextId());
     let start = performance.now();
     //TRICKY: need to verify groups data after the contextId has been loaded, or changes are not saved
-    await dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
+    await dispatch(GroupsDataActions.verifyGroupDataMatchesWithFsNonBlocking());
     let end = performance.now();
     const elapsed = end - start;
-    console.log(`GroupsDataActions.verifyGroupDataMatchesWithFs(${projectDir}) took ${elapsed}ms`);
+    console.log(`GroupsDataActions.verifyGroupDataMatchesWithFsNonBlocking(${name}, ${projectDir}) took ${elapsed}ms`);
 
     dispatch(batchActions([
       closeAlertDialog(),

--- a/src/js/actions/ToolActions.js
+++ b/src/js/actions/ToolActions.js
@@ -89,10 +89,13 @@ export const openTool = (name) => (dispatch, getData) => new Promise(async (reso
     dispatch(loadGroupsIndex(groupIndex));
 
     dispatch(loadCurrentContextId());
+    let start = performance.now();
     //TRICKY: need to verify groups data after the contextId has been loaded, or changes are not saved
     await dispatch(GroupsDataActions.verifyGroupDataMatchesWithFs());
-    // wait for filesystem calls to finish
-    await delay(150);
+    let end = performance.now();
+    const elapsed = end - start;
+    console.log(`GroupsDataActions.verifyGroupDataMatchesWithFs(${projectDir}) took ${elapsed}ms`);
+
     dispatch(batchActions([
       closeAlertDialog(),
       BodyUIActions.toggleHomeView(false),

--- a/src/js/actions/ToolActions.js
+++ b/src/js/actions/ToolActions.js
@@ -58,6 +58,7 @@ export const loadTools = (toolsDir) => (dispatch) => {
  */
 export const openTool = (name) => (dispatch, getData) => new Promise(async (resolve, reject) => {
   console.log('openTool(' + name + ')');
+  let startTool = performance.now();
   const translate = getTranslate(getData());
   dispatch(ModalActions.showModalContainer(false));
   dispatch(openAlertDialog(translate('tools.loading_tool_data'), true));
@@ -106,6 +107,11 @@ export const openTool = (name) => (dispatch, getData) => new Promise(async (reso
     dispatch(openAlertDialog(translate('projects.error_setting_up_project', { email: translate('_.help_desk_email') })));
     reject(e);
   }
+
+  let endTool = performance.now();
+  const elapsed = endTool - startTool;
+  console.log(`openTool(${name}) took ${elapsed}ms`);
+
   resolve();
 });
 

--- a/src/js/actions/VerseEditActions.js
+++ b/src/js/actions/VerseEditActions.js
@@ -142,7 +142,6 @@ export const editChecksToBatch = (editedChecks, actionBatch) => {
  * @return {Function}
  */
 export const ensureCheckVerseEditsInGroupData = (twVerseEdits) => async (dispatch, getState) => {
-  await delay(400);
   const versesEdited = Object.keys(twVerseEdits);
 
   if (versesEdited && versesEdited.length) {

--- a/src/js/helpers/groupDataHelpers.js
+++ b/src/js/helpers/groupDataHelpers.js
@@ -110,22 +110,16 @@ export async function readLatestChecksNonBlock(dir) {
   // list sorted json files - most recents are in front of list
   const rawFiles = await fs.readdir(dir);
   const files = rawFiles.filter(file => path.extname(file) === '.json').sort().reverse();
-  const reads = new Array(files.length);
-
-  for (let i = 0, len = files.length; i < len; i ++) {
-    reads[i] = new Promise(resolve => {
-      const checkPath = path.join(dir, files[i]);
+  const fileData = await Promise.all(
+    files.map( async (file) => {
+      const checkPath = path.join(dir, file);
 
       try {
-        resolve(fs.readJson(checkPath));
+        return await fs.readJson(checkPath);
       } catch (err) {
         console.error(`Check data could not be loaded from ${checkPath}`, err);
-        resolve(null);
       }
-    });
-  }
-
-  const fileData = await Promise.all(reads);
+    }));
 
   for (let i = 0, len = files.length; i < len; i ++) {
     const data = fileData[i];

--- a/src/js/helpers/groupDataHelpers.js
+++ b/src/js/helpers/groupDataHelpers.js
@@ -123,6 +123,7 @@ export async function readLatestChecksNonBlock(dir) {
 
   for (let i = 0, len = files.length; i < len; i ++) {
     const data = fileData[i];
+
     if (data) {
       if (isCheckUnique(data, checks)) {
         checks.push(data);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- changed verifyGroupDataMatchesWithFs to be non-blocking.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6442)
<!-- Reviewable:end -->
