### PR TITLE
Bugfix 6424/Fix verse edits made in one tool not updating group menu state in other tools

### DIFF
--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -174,18 +174,24 @@ export function loadCurrentContextId() {
         let loadPath = getContextIdPathFromIndex(projectSaveLocation, toolName, bookId);
 
         if (fs.existsSync(loadPath)) {
-          contextId = fs.readJsonSync(loadPath);
-          const contextIdExistInGroups = groupsIndex.filter(({ id }) => id === contextId.groupId).length > 0;
+          try {
+            contextId = fs.readJsonSync(loadPath);
+            const contextIdExistInGroups = groupsIndex.filter(({ id }) => id === contextId.groupId).length > 0;
 
-          if (contextId && contextIdExistInGroups) {
-            return dispatch(changeCurrentContextId(contextId));
+            if (contextId && contextIdExistInGroups) {
+              return dispatch(changeCurrentContextId(contextId));
+            }
+          } catch (err) {
+            // The object is undefined because the file wasn't found in the directory
+            console.warn('loadCurrentContextId() error reading contextId', err);
           }
         }
+        // if we could not read contextId default to first
         contextId = firstContextId(state);
         dispatch(changeCurrentContextId(contextId));
       } catch (err) {
         // The object is undefined because the file wasn't found in the directory
-        console.warn(err);
+        console.warn('loadCurrentContextId() error loading contextId', err);
       }
     }
   };

--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -190,7 +190,7 @@ export function loadCurrentContextId() {
         contextId = firstContextId(state);
         dispatch(changeCurrentContextId(contextId));
       } catch (err) {
-        // The object is undefined because the file wasn't found in the directory
+        // The object is undefined because the file wasn't found in the directory or other error
         console.warn('loadCurrentContextId() error loading contextId', err);
       }
     }

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -139,8 +139,8 @@ export const getGroupDataForGroupIdChapterVerse = (groupsDataReducer, groupId, c
     for (let i = 0, l = groupData.length; i < l; i++) {
       const groupObject = groupData[i];
 
-      if (isEqual(groupObject.contextId.reference.chapter, chapterNumber) &&
-        isEqual(groupObject.contextId.reference.verse, verseNumber)) {
+      if ((groupObject.contextId.reference.chapter === chapterNumber) &&
+        (groupObject.contextId.reference.verse === verseNumber)) {
         matchedGroupData.push(groupObject);
       }
     }
@@ -378,7 +378,8 @@ export const getGroupDataForVerse = (state, contextId) => {
  */
 export const sameContext = (contextId1, contextId2) => {
   if (!!contextId1 && !!contextId2) {
-    return isEqual(contextId1.reference, contextId2.reference)
+    return (contextId1.reference.chapter === contextId2.reference.chapter) &&
+      (contextId1.reference.verse === contextId2.reference.verse)
       && (contextId1.groupId === contextId2.groupId)
       && (contextId1.occurrence === contextId2.occurrence);
   }

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -378,10 +378,9 @@ export const getGroupDataForVerse = (state, contextId) => {
  */
 export const sameContext = (contextId1, contextId2) => {
   if (contextId1 && contextId2) {
-    return (contextId1.reference.chapter === contextId2.reference.chapter) &&
-      (contextId1.reference.verse === contextId2.reference.verse)
-      && (contextId1.groupId === contextId2.groupId)
-      && (contextId1.occurrence === contextId2.occurrence);
+    return isEqual(contextId1.reference, contextId2.reference) &&
+      (contextId1.groupId === contextId2.groupId) &&
+      (contextId1.occurrence === contextId2.occurrence);
   }
   return false;
 };

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -377,11 +377,10 @@ export const getGroupDataForVerse = (state, contextId) => {
  * @return {boolean}
  */
 export const sameContext = (contextId1, contextId2) => {
-  if (!!contextId1 && !!contextId2) {
-    return (contextId1.reference.chapter === contextId2.reference.chapter) &&
-      (contextId1.reference.verse === contextId2.reference.verse)
-      && (contextId1.groupId === contextId2.groupId)
-      && (contextId1.occurrence === contextId2.occurrence);
+  if (contextId1 && contextId2) {
+    return isSameVerse(contextId1, contextId2) &&
+      (contextId1.groupId === contextId2.groupId) &&
+      (contextId1.occurrence === contextId2.occurrence);
   }
   return false;
 };

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -4,7 +4,6 @@ import fs from 'fs-extra';
 import usfm from 'usfm-js';
 import { checkSelectionOccurrences } from 'selections';
 import { batchActions } from 'redux-batched-actions';
-// actions
 // helpers
 import {
   getTranslate, getUsername, getSelectedToolName,
@@ -15,9 +14,11 @@ import * as saveMethods from '../localStorage/saveMethods';
 import {
   WORD_ALIGNMENT, TRANSLATION_WORDS, TRANSLATION_NOTES,
 } from '../common/constants';
+// actions
 import * as CheckDataLoadActions from './CheckDataLoadActions';
 import * as InvalidatedActions from './InvalidatedActions';
 import * as AlertActions from './AlertActions';
+import { isSameVerse } from './GroupsDataActions';
 import types from './ActionTypes';
 export const ALERT_ALIGNMENTS_RESET_ID = 'alignments_reset';
 export const ALERT_SELECTIONS_INVALIDATED_ID = 'selections_invalidated';
@@ -353,7 +354,7 @@ export const getGroupDataForVerse = (state, contextId) => {
           const check = groupItem[j];
 
           try {
-            if (isEqual(check.contextId.reference, contextId.reference)) {
+            if (isSameVerse(check.contextId, contextId)) {
               if (!filteredGroupData[groupItemKey]) {
                 filteredGroupData[groupItemKey] = [];
               }

--- a/src/js/actions/SelectionsActions.js
+++ b/src/js/actions/SelectionsActions.js
@@ -378,9 +378,10 @@ export const getGroupDataForVerse = (state, contextId) => {
  */
 export const sameContext = (contextId1, contextId2) => {
   if (contextId1 && contextId2) {
-    return isSameVerse(contextId1, contextId2) &&
-      (contextId1.groupId === contextId2.groupId) &&
-      (contextId1.occurrence === contextId2.occurrence);
+    return (contextId1.reference.chapter === contextId2.reference.chapter) &&
+      (contextId1.reference.verse === contextId2.reference.verse)
+      && (contextId1.groupId === contextId2.groupId)
+      && (contextId1.occurrence === contextId2.occurrence);
   }
   return false;
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- clears caching problems in group menu:
  - fix for finding group data item with quote arrays when syncing external edits.
  - make sure wA group menu reducer is cleared when WA is launched.
- performance optimizations - minimize isEqual in deeply nested loops, optimize order of comparisons in loop

#### Please include detailed Test instructions for your pull request:
- use attached build at bottom of PR.
- follow steps in https://github.com/unfoldingword-dev/translationcore/issues/6424
- make sure check mark is cleared on group menu for verse.
- then test edits in the other direction:
  - in TN tool edit a different verse in chapter 2
  - go back to WA and make sure edited verse shows both edit and invalidated on group menu

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6468)
<!-- Reviewable:end -->
