### PR TITLE
Bugfix 6487/Fix no selection needed not shown when navigating away and back

### DIFF
--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -342,88 +342,126 @@ describe('GroupsDataActions.isAttributeChanged', () => {
   });
   describe('selections', () => {
     it('new value selection same as old value is unchanged', () => {
-      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = [ { occurrence: 1, occurrences: 2, text: 'Jacob' } ];
+      const newSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = [ { occurrence: 1, occurrences: 2, text: 'Jacob' } ];
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value selection different than old value selection is changed', () => {
-      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = [ { text: 'Jacob', occurrence: 2, occurrences: 2 } ];
+      const newSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = [ { text: 'Jacob', occurrence: 2, occurrences: 2 } ];
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value selection different count than old value selection is changed', () => {
-      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
+      const newSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value selection different order than old value selection is unchanged', () => {
-      const newValue = [ { text: 'son', occurrence: 1, occurrences: 4 }, { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
+      const newSelectValue = [ { text: 'son', occurrence: 1, occurrences: 4 }, { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value selection and old value true is changed', () => {
-      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = true;
+      const newSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = true;
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value selection and old value false is changed', () => {
-      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
-      const oldValue = false;
+      const newSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldSelectValue = false;
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value empty selection and old value false is unchanged', () => {
-      const newValue = [];
-      const oldValue = false;
+      const newSelectValue = [];
+      const oldSelectValue = false;
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value false and old value empty selection is unchanged', () => {
-      const newValue = false;
-      const oldValue = [];
+      const newSelectValue = false;
+      const oldSelectValue = [];
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value empty selection and old value selection is changed', () => {
-      const newValue = [];
-      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const newSelectValue = [];
+      const oldSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value null and old value selection is changed', () => {
-      const newValue = null;
-      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const newSelectValue = null;
+      const oldSelectValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
       const changed = true;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value empty selection and old value empty selection is unchanged', () => {
-      const newValue = [];
-      const oldValue = [];
+      const newSelectValue = [];
+      const oldSelectValue = [];
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value null and old value false is unchanged', () => {
-      const newValue = null;
-      const oldValue = false;
+      const newSelectValue = null;
+      const oldSelectValue = false;
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value undefined and old value false is unchanged', () => {
-      const newValue = undefined;
-      const oldValue = false;
+      const newSelectValue = undefined;
+      const oldSelectValue = false;
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
     });
     it('new value false and old value null is unchanged', () => {
-      const newValue = false;
-      const oldValue = null;
+      const newSelectValue = false;
+      const oldSelectValue = null;
       const changed = false;
-      validateSelectionsChanged(newValue, oldValue, changed);
+      validateSelectionsChanged(newSelectValue, oldSelectValue, changed);
+    });
+  });
+  describe('nothingToSelect', () => {
+    it('new nothingToSelect value true and old value true is unchanged', () => {
+      const newNoSelectValue = true;
+      const oldNoSelectValue = true;
+      const changed = false;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
+    });
+    it('new nothingToSelect value false and old value false is unchanged', () => {
+      const newNoSelectValue = false;
+      const oldNoSelectValue = false;
+      const changed = false;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
+    });
+    it('new nothingToSelect value true and old value false is changed', () => {
+      const newNoSelectValue = true;
+      const oldNoSelectValue = false;
+      const changed = true;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
+    });
+    it('new nothingToSelect value false and old value true is changed', () => {
+      const newNoSelectValue = false;
+      const oldNoSelectValue = true;
+      const changed = true;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
+    });
+    it('new value false and old value null is unchanged', () => {
+      const newNoSelectValue = false;
+      const oldNoSelectValue = null;
+      const changed = false;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
+    });
+    it('new value null and old value false is unchanged', () => {
+      const newNoSelectValue = null;
+      const oldNoSelectValue = false;
+      const changed = false;
+      validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, changed);
     });
   });
   describe('verseEdits', () => {
@@ -448,11 +486,12 @@ describe('GroupsDataActions.isAttributeChanged', () => {
       const newValue = true;
       const oldValue = null;
       const expectChange = false;
-      const checkType = 'unsupported';
-      const object = { [checkType]: newValue };
+      const checkAttr = 'unsupported';
+      const object = { [checkAttr]: newValue };
+      const oldGroupObject = { [checkAttr]: oldValue };
 
       // when
-      const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+      const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
 
       // then
       expect(result === expectChange).toBeTruthy();
@@ -465,39 +504,48 @@ describe('GroupsDataActions.isAttributeChanged', () => {
 //
 
 function validateVerseEdits(oldValue, expectChange) {
-  const checkType = 'verseEdits';
+  const checkAttr = 'verseEdits';
   const object = {};
-  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+  const oldGroupObject = { [checkAttr]: oldValue };
+  const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
   expect(result === expectChange).toBeTruthy();
 }
 
 function validateCommentsChanged(newValue, oldValue, expectChange) {
-  const checkType = 'comments';
+  const checkAttr = 'comments';
   const attr = 'text';
   const object = { [attr]: newValue };
-  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+  const oldGroupObject = { [checkAttr]: oldValue };
+  const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
   expect(result === expectChange).toBeTruthy();
 }
 
 function validateInvalidationChanged(newValue, oldValue, expectChange) {
-  const checkType = 'invalidated';
-  const object = { [checkType]: newValue };
-  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+  const checkAttr = 'invalidated';
+  const object = { [checkAttr]: newValue };
+  const oldGroupObject = { [checkAttr]: oldValue };
+  const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
   expect(result === expectChange).toBeTruthy();
 }
 
-function validateSelectionsChanged(newValue, oldValue, expectChange) {
-  const checkType = 'selections';
-  const object = { [checkType]: newValue };
-  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+function validateSelectionsChanged(newSelectValue, oldSelectValue, expectChange, newNoSelectValue = undefined, oldNoSelectValue= false) {
+  const checkAttr = 'selections';
+  const object = { [checkAttr]: newSelectValue, ['nothingToSelect']: newNoSelectValue };
+  const oldGroupObject = { [checkAttr]: oldSelectValue, ['nothingToSelect']: oldNoSelectValue };
+  const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
   expect(result === expectChange).toBeTruthy();
+}
+
+function validateNothingToSelectChanged(newNoSelectValue, oldNoSelectValue, expectChange) {
+  validateSelectionsChanged(null, false, expectChange, newNoSelectValue, oldNoSelectValue);
 }
 
 function validateRemindersChanged(newValue, oldValue, expectChange) {
-  const checkType = 'reminders';
+  const checkAttr = 'reminders';
   const attr = 'enabled';
   const object = { [attr]: newValue };
-  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+  const oldGroupObject = { [checkAttr]: oldValue };
+  const result = GroupsDataActions.isAttributeChanged(object, checkAttr, oldGroupObject);
   expect(result === expectChange).toBeTruthy();
 }
 

--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable object-curly-newline */
 import fs from 'fs-extra';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -218,9 +219,260 @@ describe('GroupsDataActions.validateBookSelections', () => {
   });
 });
 
+describe('GroupsDataActions.isValueChanged', () => {
+  describe('reminders', () => {
+    it('new value true and old value true is unchanged', () => {
+      const newValue = true;
+      const oldValue = true;
+      const changed = false;
+      validateRemindersChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value false is unchanged', () => {
+      const newValue = false;
+      const oldValue = false;
+      const changed = false;
+      validateRemindersChanged(newValue, oldValue, changed);
+    });
+    it('new value true and old value false is changed', () => {
+      const newValue = true;
+      const oldValue = false;
+      const changed = true;
+      validateRemindersChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value undefined is unchanged', () => {
+      const newValue = false;
+      const oldValue = undefined;
+      const changed = false;
+      validateRemindersChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value null is unchanged', () => {
+      const newValue = false;
+      const oldValue = null;
+      const changed = false;
+      validateRemindersChanged(newValue, oldValue, changed);
+    });
+  });
+  describe('invalidated', () => {
+    it('new value true and old value true is unchanged', () => {
+      const newValue = true;
+      const oldValue = true;
+      const changed = false;
+      validateInvalidationChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value false is unchanged', () => {
+      const newValue = false;
+      const oldValue = false;
+      const changed = false;
+      validateInvalidationChanged(newValue, oldValue, changed);
+    });
+    it('new value true and old value false is changed', () => {
+      const newValue = true;
+      const oldValue = false;
+      const changed = true;
+      validateInvalidationChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value undefined is unchanged', () => {
+      const newValue = false;
+      const oldValue = undefined;
+      const changed = false;
+      validateInvalidationChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value null is unchanged', () => {
+      const newValue = false;
+      const oldValue = null;
+      const changed = false;
+      validateInvalidationChanged(newValue, oldValue, changed);
+    });
+  });
+  describe('comments', () => {
+    it('new value string same as old value is unchanged', () => {
+      const newValue = 'stuff';
+      const oldValue = 'stuff';
+      const changed = false;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value string different than old value string is changed', () => {
+      const newValue = 'stuff';
+      const oldValue = 'stuff2';
+      const changed = true;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value string and old value true is changed', () => {
+      const newValue = 'stuff';
+      const oldValue = true;
+      const changed = true;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value string and old value false is changed', () => {
+      const newValue = 'stuff';
+      const oldValue = false;
+      const changed = true;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty string and old value false is unchanged', () => {
+      const newValue = '';
+      const oldValue = false;
+      const changed = false;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty string and old value string is changed', () => {
+      const newValue = '';
+      const oldValue = 'stuffff';
+      const changed = true;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty string and old value empty string is unchanged', () => {
+      const newValue = '';
+      const oldValue = '';
+      const changed = false;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value null and old value false is unchanged', () => {
+      const newValue = null;
+      const oldValue = false;
+      const changed = false;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value null is unchanged', () => {
+      const newValue = false;
+      const oldValue = null;
+      const changed = false;
+      validateCommentsChanged(newValue, oldValue, changed);
+    });
+  });
+  describe('selections', () => {
+    it('new value selection same as old value is unchanged', () => {
+      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = [ { occurrence: 1, occurrences: 2, text: 'Jacob' } ];
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value selection different than old value selection is changed', () => {
+      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = [ { text: 'Jacob', occurrence: 2, occurrences: 2 } ];
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value selection and old value true is changed', () => {
+      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = true;
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value selection and old value false is changed', () => {
+      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = false;
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty selection and old value false is unchanged', () => {
+      const newValue = [];
+      const oldValue = false;
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value empty selection is unchanged', () => {
+      const newValue = false;
+      const oldValue = [];
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty selection and old value selection is changed', () => {
+      const newValue = [];
+      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value null and old value selection is changed', () => {
+      const newValue = null;
+      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value empty selection and old value empty selection is unchanged', () => {
+      const newValue = [];
+      const oldValue = [];
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value null and old value false is unchanged', () => {
+      const newValue = null;
+      const oldValue = false;
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value undefined and old value false is unchanged', () => {
+      const newValue = undefined;
+      const oldValue = false;
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value false and old value null is unchanged', () => {
+      const newValue = false;
+      const oldValue = null;
+      const changed = false;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+  });
+  describe('verseEdits', () => {
+    it('old value true is unchanged', () => {
+      const oldValue = true;
+      const changed = false;
+      validateVerseEdits(oldValue, changed);
+    });
+    it('old value false is changed', () => {
+      const oldValue = false;
+      const changed = true;
+      validateVerseEdits(oldValue, changed);
+    });
+    it('old value null is changed', () => {
+      const oldValue = null;
+      const changed = true;
+      validateVerseEdits(oldValue, changed);
+    });
+  });
+});
+
 //
 // helpers
 //
+
+function validateVerseEdits(oldValue, expectChange) {
+  const checkType = 'verseEdits';
+  const object = {};
+  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  expect(result === expectChange).toBeTruthy();
+}
+
+function validateCommentsChanged(newValue, oldValue, expectChange) {
+  const checkType = 'comments';
+  const attr = 'text';
+  const object = { [attr]: newValue };
+  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  expect(result === expectChange).toBeTruthy();
+}
+
+function validateInvalidationChanged(newValue, oldValue, expectChange) {
+  const checkType = 'invalidated';
+  const object = { [checkType]: newValue };
+  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  expect(result === expectChange).toBeTruthy();
+}
+
+function validateSelectionsChanged(newValue, oldValue, expectChange) {
+  const checkType = 'selections';
+  const object = { [checkType]: newValue };
+  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  expect(result === expectChange).toBeTruthy();
+}
+
+function validateRemindersChanged(newValue, oldValue, expectChange) {
+  const checkType = 'reminders';
+  const attr = 'enabled';
+  const object = { [attr]: newValue };
+  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  expect(result === expectChange).toBeTruthy();
+}
 
 function cleanOutDates(actions) {
   const cleanedActions = JSON.parse(JSON.stringify(actions));

--- a/__tests__/GroupsDataActions.test.js
+++ b/__tests__/GroupsDataActions.test.js
@@ -219,7 +219,7 @@ describe('GroupsDataActions.validateBookSelections', () => {
   });
 });
 
-describe('GroupsDataActions.isValueChanged', () => {
+describe('GroupsDataActions.isAttributeChanged', () => {
   describe('reminders', () => {
     it('new value true and old value true is unchanged', () => {
       const newValue = true;
@@ -353,6 +353,18 @@ describe('GroupsDataActions.isValueChanged', () => {
       const changed = true;
       validateSelectionsChanged(newValue, oldValue, changed);
     });
+    it('new value selection different count than old value selection is changed', () => {
+      const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
+    it('new value selection different order than old value selection is unchanged', () => {
+      const newValue = [ { text: 'son', occurrence: 1, occurrences: 4 }, { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
+      const oldValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 }, { text: 'son', occurrence: 1, occurrences: 4 } ];
+      const changed = true;
+      validateSelectionsChanged(newValue, oldValue, changed);
+    });
     it('new value selection and old value true is changed', () => {
       const newValue = [ { text: 'Jacob', occurrence: 1, occurrences: 2 } ];
       const oldValue = true;
@@ -431,6 +443,21 @@ describe('GroupsDataActions.isValueChanged', () => {
       validateVerseEdits(oldValue, changed);
     });
   });
+  describe('unsupported', () => {
+    it('unsupported checks are always false', () => {
+      const newValue = true;
+      const oldValue = null;
+      const expectChange = false;
+      const checkType = 'unsupported';
+      const object = { [checkType]: newValue };
+
+      // when
+      const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
+
+      // then
+      expect(result === expectChange).toBeTruthy();
+    });
+  });
 });
 
 //
@@ -440,7 +467,7 @@ describe('GroupsDataActions.isValueChanged', () => {
 function validateVerseEdits(oldValue, expectChange) {
   const checkType = 'verseEdits';
   const object = {};
-  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
   expect(result === expectChange).toBeTruthy();
 }
 
@@ -448,21 +475,21 @@ function validateCommentsChanged(newValue, oldValue, expectChange) {
   const checkType = 'comments';
   const attr = 'text';
   const object = { [attr]: newValue };
-  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
   expect(result === expectChange).toBeTruthy();
 }
 
 function validateInvalidationChanged(newValue, oldValue, expectChange) {
   const checkType = 'invalidated';
   const object = { [checkType]: newValue };
-  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
   expect(result === expectChange).toBeTruthy();
 }
 
 function validateSelectionsChanged(newValue, oldValue, expectChange) {
   const checkType = 'selections';
   const object = { [checkType]: newValue };
-  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
   expect(result === expectChange).toBeTruthy();
 }
 
@@ -470,7 +497,7 @@ function validateRemindersChanged(newValue, oldValue, expectChange) {
   const checkType = 'reminders';
   const attr = 'enabled';
   const object = { [attr]: newValue };
-  const result = GroupsDataActions.isValueChanged(object, checkType, oldValue);
+  const result = GroupsDataActions.isAttributeChanged(object, checkType, oldValue);
   expect(result === expectChange).toBeTruthy();
 }
 

--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -37,7 +37,7 @@ function loadCheckData() {
 }
 
 /**
- * change context ID in reducers and clear old data while new data being loaded
+ * change context ID and load check data in reducers from group data reducer
  * @param {Object} contextId
  * @param {Function} dispatch
  * @param {Object} state
@@ -55,6 +55,7 @@ function changeContextIdInReducers(contextId, dispatch, state) {
     }
   }
 
+  // if check data not found in group data reducer, set to defaults
   const selections = oldGroupObject['selections'] || [];
   const reminders = oldGroupObject['reminders'] || false;
   const invalidated = oldGroupObject['invalidated'] || false;
@@ -115,11 +116,10 @@ export const changeCurrentContextId = contextId => (dispatch, getState) => {
     const refStr = `${tool} ${groupId} ${bookId} ${chapter}:${verse}`;
     console.log(`changeCurrentContextId() - setting new contextId to: ${refStr}`);
 
-    if (!groupDataLoaded) { // if group data not found, do load from file
+    if (!groupDataLoaded) { // if group data not found, load from file
       dispatch(loadCheckData());
     }
     saveContextId(state, contextId);
-
     const projectDir = getProjectSaveLocation(state);
 
     // commit project changes after delay

--- a/src/js/actions/ContextIdActions.js
+++ b/src/js/actions/ContextIdActions.js
@@ -57,6 +57,7 @@ function changeContextIdInReducers(contextId, dispatch, state) {
 
   // if check data not found in group data reducer, set to defaults
   const selections = oldGroupObject['selections'] || [];
+  const nothingToSelect = oldGroupObject['nothingToSelect'] || false;
   const reminders = oldGroupObject['reminders'] || false;
   const invalidated = oldGroupObject['invalidated'] || false;
   const comments = oldGroupObject['comments'] || '';
@@ -68,7 +69,8 @@ function changeContextIdInReducers(contextId, dispatch, state) {
     {
       type: consts.CHANGE_SELECTIONS,
       modifiedTimestamp: null,
-      selections: selections,
+      selections,
+      nothingToSelect,
       username: null,
     },
     {

--- a/src/js/actions/GroupsDataActions.js
+++ b/src/js/actions/GroupsDataActions.js
@@ -63,16 +63,16 @@ export const findGroupDataItem = (contextId, groupData) => {
 };
 
 /**
- * get value for check type and compare with old value - tricky because there is no consistency in field names and representation of value for checks
+ * get value for check attribute and compare with old value - tricky because there is no consistency in field names and representation of value for checks
  * @param {Object} object
- * @param {String} checkType
+ * @param {String} checkAttr
  * @param {*} oldValue
  * @return {Boolean} true if value has changed
  */
-export function isValueChanged(object, checkType, oldValue) {
+export function isAttributeChanged(object, checkAttr, oldValue) {
   let value;
 
-  switch (checkType) {
+  switch (checkAttr) {
   case 'reminders':
     value = !!object['enabled']; // just want true if enabled
     return value !== !!oldValue; // compare boolean equivalents
@@ -80,10 +80,10 @@ export function isValueChanged(object, checkType, oldValue) {
     value = object['text'];
     return value ? (value !== oldValue) : (!value !== !oldValue); // if text set, do exact match.  Otherwise compare boolean equivalents
   case 'invalidated':
-    value = !!object[checkType]; // just want true if set
+    value = !!object[checkAttr]; // just want true if set
     return value !== !!oldValue; // compare boolean equivalents
   case 'selections': {
-    value = object[checkType];
+    value = object[checkAttr];
     const hasSelection = value && value.length;
 
     if (hasSelection) {
@@ -95,8 +95,8 @@ export function isValueChanged(object, checkType, oldValue) {
   }
   case 'verseEdits':
     return true !== !!oldValue; // TRICKY: verse edit is special case since its value is always true
-  default:
-    console.log(`isValueChanged() - unsupported check type: ${checkType}`);
+  default: // put warning in log that this check attribute is not supported
+    console.log(`isValueChanged() - unsupported check attribute: ${checkAttr}`);
     return false;
   }
 }
@@ -192,9 +192,9 @@ export function verifyGroupDataMatchesWithFs(toolName) {
                   const oldGroupObject = (index >= 0) ? currentGroupData[index] : null;
 
                   if (oldGroupObject) {
-                    // only toggle if values are different (folderName contains type such as 'selections`)
+                    // only toggle if attribute values are different (folderName contains check attribute such as 'selections`)
                     const oldValue = oldGroupObject[folderName];
-                    const isChanged = isValueChanged(object, folderName, oldValue);
+                    const isChanged = isAttributeChanged(object, folderName, oldValue);
 
                     if (isChanged) {
                       // TRICKY: we are using the contextId of oldGroupObject here because sometimes


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix no selection needed not shown when navigating away and back
- performance tweaks for updating group data with latest settings.

#### Please include detailed Test instructions for your pull request:
- use build below for testing.
- verify that `no selection needed` is persisted on navigating away and back.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6488)
<!-- Reviewable:end -->
