### PR TITLE
Feature 6251/Tweaks for when toolcard progress around 0% and 100%

### DIFF
--- a/__tests__/ToolCardProgress.test.js
+++ b/__tests__/ToolCardProgress.test.js
@@ -7,22 +7,129 @@ import ToolCardProgress from '../src/js/components/home/toolsManagement/ToolCard
 // Tests for ToolCardProgress React Component
 describe('Test ToolCardProgress component',()=>{
   test('Test progress=.50 to be white text', () => {
+    // given
     const progress = .50;
+    const expectedText = '50%';
+    const expectedProgressBar = 50;
+    const expectedSytleLeft = expectedProgressBar/2 + '%';
+    const expectedStyleColor = '#fff';
     const renderer = new ShallowRenderer();
+
+    // when
     renderer.render(<ToolCardProgress progress={progress} />);
-    const result = renderer.getRenderOutput();
-    expect(result.props.children.props.children[0].props.style.left).toBe('25%');
-    expect(result.props.children.props.children[1].props.value).toBe(50);
-    expect(result.props.children.props.children[0].props.style.color).toBe('#fff');
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
   });
 
   test('Test progress=.20 to be black text', () => {
+    // given
     const progress = .20;
+    const expectedText = '20%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = '50%';
+    const expectedStyleColor = '#000';
     const renderer = new ShallowRenderer();
+
+    // when
     renderer.render(<ToolCardProgress progress={progress} />);
-    const result = renderer.getRenderOutput();
-    expect(result.props.children.props.children[1].props.value).toBe(20);
-    expect(result.props.children.props.children[0].props.style.left).toBe('50%');
-    expect(result.props.children.props.children[0].props.style.color).toBe('#000');
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
+  });
+
+  test('Test progress=.995 to show 99%', () => {
+    // given
+    const progress = .995;
+    const expectedText = '99%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = expectedProgressBar/2 + '%';
+    const expectedStyleColor = '#fff';
+    const renderer = new ShallowRenderer();
+
+    // when
+    renderer.render(<ToolCardProgress progress={progress} />);
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
+  });
+
+  test('Test progress=.9999 to show 99%', () => {
+    // given
+    const progress = .9999;
+    const expectedText = '99%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = expectedProgressBar/2 + '%';
+    const expectedStyleColor = '#fff';
+    const renderer = new ShallowRenderer();
+
+    // when
+    renderer.render(<ToolCardProgress progress={progress} />);
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
+  });
+
+  test('Test progress=1 to show 100%', () => {
+    // given
+    const progress = 1;
+    const expectedText = '100%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = expectedProgressBar/2 + '%';
+    const expectedStyleColor = '#fff';
+    const renderer = new ShallowRenderer();
+
+    // when
+    renderer.render(<ToolCardProgress progress={progress} />);
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
+  });
+
+  test('Test progress=.0099 to show <1%', () => {
+    // given
+    const progress = .0099;
+    const expectedText = '<1%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = '50%';
+    const expectedStyleColor = '#000';
+    const renderer = new ShallowRenderer();
+
+    // when
+    renderer.render(<ToolCardProgress progress={progress} />);
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
+  });
+
+  test('Test progress=0 to show 0%', () => {
+    // given
+    const progress = 0;
+    const expectedText = '0%';
+    const expectedProgressBar = progress*100;
+    const expectedSytleLeft = '50%';
+    const expectedStyleColor = '#000';
+    const renderer = new ShallowRenderer();
+
+    // when
+    renderer.render(<ToolCardProgress progress={progress} />);
+
+    // then
+    validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText);
   });
 });
+
+//
+// Helper Functions
+//
+
+function validateToolCardProgress(renderer, expectedProgressBar, expectedSytleLeft, expectedStyleColor, expectedText) {
+  const result = renderer.getRenderOutput();
+  const child0Props = result.props.children.props.children[0].props;
+  const child1Props = result.props.children.props.children[1].props;
+  expect(child1Props.value).toBe(expectedProgressBar);
+  expect(child0Props.style.left).toBe(expectedSytleLeft);
+  expect(child0Props.style.color).toBe(expectedStyleColor);
+  expect(child0Props.children).toBe(expectedText);
+}
+

--- a/src/js/components/home/toolsManagement/ToolCardProgress.js
+++ b/src/js/components/home/toolsManagement/ToolCardProgress.js
@@ -10,14 +10,20 @@ const ToolCardProgress = ({ progress }) => {
     progress = 0;
   }
 
-  const progressPercentage = (progress * 100).toFixed() + '%';
+  const progressPercent = progress * 100;
+  let progressPercentageStr = Math.floor(progressPercent) + '%'; // truncation instead of rounding
+
+  if ((progressPercent > 0) && (progressPercent < 1)) {
+    progressPercentageStr = '<1%'; // so we don't show zero when there is some progress
+  }
+
   const strokeColor = 'var(--accent-color-dark)';
   let textColor = '#000';
   let percentagePosition = '50%';
 
   if (progress >= .25) {
     textColor = '#fff';
-    percentagePosition = ((progress / 2) * 100) + '%';
+    percentagePosition = (progressPercent / 2) + '%';
   }
 
   const containerStyle = {
@@ -28,10 +34,10 @@ const ToolCardProgress = ({ progress }) => {
       <div>
         <div style={{
           position:'relative', float:'left', left:percentagePosition, zIndex: 1, color: textColor,
-        }}>{progressPercentage}</div>
+        }}>{progressPercentageStr}</div>
         <LinearProgress
           mode="determinate"
-          value={progress * 100}
+          value={progressPercent}
           color={strokeColor}
           style={containerStyle} />
       </div>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes issues https://github.com/unfoldingword-dev/translationcore/issues/6251 and https://github.com/unfoldingWord-dev/translationCore/issues/4414
- fix tool progress to not show 100% if any checks missing (will show 99% if progress between 99% and 100%)
- fix tool progress to show '<1%' if progress is between 0 and 1%.

#### Please include detailed Test instructions for your pull request:
- open an fully aligned book such as https://git.door43.org/lrsallee/en_ult_luk_book
- WA tool should show 100% complete, tW should show 0% and tN should show 0%
- launch wA tool and unalign a word.  Go back to tools and should show 99% complete in wA.
- launch tN , make a selection, and click save. Go back to tools and should show '<1%' complete in tN.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/translationcore/6489)
<!-- Reviewable:end -->
