### PR TITLE
QA Fail 6589/Cannot return to Tools page after uploading an only project

### DIFF
--- a/src/js/actions/ProjectUploadActions.js
+++ b/src/js/actions/ProjectUploadActions.js
@@ -14,6 +14,8 @@ import migrateSaveChangesInOldProjects from '../helpers/ProjectMigration/migrate
 import * as GogsApiHelpers from '../helpers/GogsApiHelpers';
 import { delay } from '../common/utils';
 import * as ProjectLoadingActions from './MyProjects/ProjectLoadingActions';
+import * as ProjectDetailsActions from './ProjectDetailsActions';
+import * as MyProjectsActions from './MyProjects/MyProjectsActions';
 
 /**
  * prepare project for upload. Initialize git if necessary and then commit changes to git
@@ -100,6 +102,7 @@ export function uploadProject(projectPath, user, onLine = navigator.onLine) {
       resolve();
     } else if (!user.localUser) {
       dispatch(OnlineModeConfirmActions.confirmOnlineAction(async () => {
+        dispatch(ProjectDetailsActions.resetProjectDetail()); // clear current project selection
         dispatch(AlertModalActions.closeAlertDialog());
         await delay(500); // for screen to update
         const projectName = projectPath.split(path.sep).pop();
@@ -184,6 +187,7 @@ export function uploadProject(projectPath, user, onLine = navigator.onLine) {
           }
           resolve();
         }
+        dispatch(MyProjectsActions.getMyProjects()); // update list and deselect this project
       }));
     } else {
       console.warn('uploadProject: User not logged in');


### PR DESCRIPTION

#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix problem that after upload of selected project, user is stuck with project selected and tools disabled.

#### Please include detailed Test instructions for your pull request:
- should fix the problem in issue. https://github.com/unfoldingword/translationcore/issues/6589

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6593)
<!-- Reviewable:end -->
