### PR TITLE
Bugfix 6597/Fix resource upgrade with empty user resource folder

### DIFF
--- a/src/js/actions/__tests__/MigrationActions.test.js
+++ b/src/js/actions/__tests__/MigrationActions.test.js
@@ -39,6 +39,7 @@ describe('migrate tCore resources', () => {
 
       // when
       migrateResourcesFolder();
+
       // then
       const folders = getResourceFolders();
       expect(folders).toMatchSnapshot();
@@ -231,6 +232,54 @@ describe('migrate tCore resources', () => {
       const folders = getResourceFolders();
       expect(folders).toMatchSnapshot();
       verifyResources(oldHelpsExpected, oldBibleExpected);
+    });
+
+    it('test with empty uhb folder - should upgrade', () => {
+      // given
+      const uhbFolder = path.join(USER_RESOURCES_PATH, 'hbo/bibles/uhb');
+      fs.ensureDirSync(uhbFolder);
+      const migrateResourcesFolder = MigrationActions.migrateResourcesFolder();
+
+      // when
+      migrateResourcesFolder();
+
+      // then
+      const folders = getResourceFolders();
+      expect(folders).toMatchSnapshot();
+      const uhbVersionExists = fs.existsSync(path.join(uhbFolder, 'v0'));
+      expect(uhbVersionExists).toBeTruthy();
+    });
+
+    it('test with empty hbo bibles folder - should upgrade', () => {
+      // given
+      const uhbFolder = path.join(USER_RESOURCES_PATH, 'hbo/bibles');
+      fs.ensureDirSync(uhbFolder);
+      const migrateResourcesFolder = MigrationActions.migrateResourcesFolder();
+
+      // when
+      migrateResourcesFolder();
+
+      // then
+      const folders = getResourceFolders();
+      expect(folders).toMatchSnapshot();
+      const uhbVersionExists = fs.existsSync(path.join(uhbFolder, 'uhb/v0'));
+      expect(uhbVersionExists).toBeTruthy();
+    });
+
+    it('test with empty hbo language folder - should upgrade', () => {
+      // given
+      const uhbFolder = path.join(USER_RESOURCES_PATH, 'hbo');
+      fs.ensureDirSync(uhbFolder);
+      const migrateResourcesFolder = MigrationActions.migrateResourcesFolder();
+
+      // when
+      migrateResourcesFolder();
+
+      // then
+      const folders = getResourceFolders();
+      expect(folders).toMatchSnapshot();
+      const uhbVersionExists = fs.existsSync(path.join(uhbFolder, 'bibles/uhb/v0'));
+      expect(uhbVersionExists).toBeTruthy();
     });
   });
 

--- a/src/js/actions/__tests__/__snapshots__/MigrationActions.test.js.snap
+++ b/src/js/actions/__tests__/__snapshots__/MigrationActions.test.js.snap
@@ -94,6 +94,60 @@ Array [
 ]
 `;
 
+exports[`migrate tCore resources Test without grc resource migration test with empty hbo bibles folder - should upgrade 1`] = `
+Array [
+  "<HOME_DIR>/translationCore/resources/hbo/bibles/uhb/v0",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt/v0.2",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/translationHelps/translationWords/v8",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ult/v12.1",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ust/v10",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationAcademy/v9",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationNotes/v15",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationWords/v10",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/hi/translationHelps/translationWords/v8.1",
+]
+`;
+
+exports[`migrate tCore resources Test without grc resource migration test with empty hbo language folder - should upgrade 1`] = `
+Array [
+  "<HOME_DIR>/translationCore/resources/hbo/bibles/uhb/v0",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt/v0.2",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/translationHelps/translationWords/v8",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ult/v12.1",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ust/v10",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationAcademy/v9",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationNotes/v15",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationWords/v10",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/hi/translationHelps/translationWords/v8.1",
+]
+`;
+
+exports[`migrate tCore resources Test without grc resource migration test with empty uhb folder - should upgrade 1`] = `
+Array [
+  "<HOME_DIR>/translationCore/resources/hbo/bibles/uhb/v0",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt/v0.2",
+  "<HOME_DIR>/translationCore/resources/el-x-koine/translationHelps/translationWords/v8",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ult/v12.1",
+  "<HOME_DIR>/translationCore/resources/en/bibles/ust/v10",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/en/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationAcademy/v9",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationNotes/v15",
+  "<HOME_DIR>/translationCore/resources/en/translationHelps/translationWords/v10",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/ugl/v0",
+  "<HOME_DIR>/translationCore/resources/hi/lexicons/uhl/v0.1",
+  "<HOME_DIR>/translationCore/resources/hi/translationHelps/translationWords/v8.1",
+]
+`;
+
 exports[`migrate tCore resources Test without grc resource migration test with no user resources 1`] = `
 Array [
   "<HOME_DIR>/translationCore/resources/el-x-koine/bibles/ugnt/v0.2",

--- a/src/js/helpers/ResourcesHelpers.js
+++ b/src/js/helpers/ResourcesHelpers.js
@@ -1156,33 +1156,38 @@ export function getMissingResources() {
           const staticResourceVersionPath = ResourceAPI.getLatestVersion(staticResourcePath);
           let isOldResource = false;
           const filename = 'manifest.json';
-          const userResourceManifestPath = path.join(userResourceVersionPath, filename);
           const staticResourceManifestPath = path.join(staticResourceVersionPath, filename);
 
-          if (fs.existsSync(userResourceManifestPath) && fs.existsSync(staticResourceManifestPath)) {
-            const { catalog_modified_time: userModifiedTime } = fs.readJsonSync(userResourceManifestPath) || {};
-            const { catalog_modified_time: staticModifiedTime } = fs.readJsonSync(staticResourceManifestPath) || {};
-            isOldResource = !userModifiedTime || (userModifiedTime < staticModifiedTime);
+          if (userResourceVersionPath) {
+            const userResourceManifestPath = path.join(userResourceVersionPath, filename);
 
-            if (isOldResource) {
-              console.log('getMissingResources() - userModifiedTime: ' + userModifiedTime);
-              console.log('getMissingResources() - staticModifiedTime: ' + staticModifiedTime);
-            }
-          } else if (!fs.existsSync(userResourceManifestPath)) {
-            if (fs.existsSync(staticResourceManifestPath)) {
-              console.log('getMissingResources() - missing user manifest: ' + userResourceManifestPath);
-              console.log('getMissingResources() - but found static manifest: ' + staticResourceManifestPath);
-              isOldResource = true;
-            } else { // if no manifest.json, fall back to checking versions
-              const userVersion = path.basename(userResourceVersionPath);
-              const staticVersion = path.basename(staticResourceVersionPath);
-              isOldResource = ResourceAPI.compareVersions(userVersion, staticVersion) < 0;
+            if (fs.existsSync(userResourceManifestPath) && fs.existsSync(staticResourceManifestPath)) {
+              const { catalog_modified_time: userModifiedTime } = fs.readJsonSync(userResourceManifestPath) || {};
+              const { catalog_modified_time: staticModifiedTime } = fs.readJsonSync(staticResourceManifestPath) || {};
+              isOldResource = !userModifiedTime || (userModifiedTime < staticModifiedTime);
 
               if (isOldResource) {
-                console.log('getMissingResources() - userVersion: ' + userVersion);
-                console.log('getMissingResources() - staticVersion: ' + staticVersion);
+                console.log('getMissingResources() - userModifiedTime: ' + userModifiedTime);
+                console.log('getMissingResources() - staticModifiedTime: ' + staticModifiedTime);
+              }
+            } else if (!fs.existsSync(userResourceManifestPath)) {
+              if (fs.existsSync(staticResourceManifestPath)) {
+                console.log('getMissingResources() - missing user manifest: ' + userResourceManifestPath);
+                console.log('getMissingResources() - but found static manifest: ' + staticResourceManifestPath);
+                isOldResource = true;
+              } else { // if no manifest.json, fall back to checking versions
+                const userVersion = path.basename(userResourceVersionPath);
+                const staticVersion = path.basename(staticResourceVersionPath);
+                isOldResource = ResourceAPI.compareVersions(userVersion, staticVersion) < 0;
+
+                if (isOldResource) {
+                  console.log('getMissingResources() - userVersion: ' + userVersion);
+                  console.log('getMissingResources() - staticVersion: ' + staticVersion);
+                }
               }
             }
+          } else { // resource folder was empty
+            isOldResource = true;
           }
 
           const deleteOldResources = preserveNeededOrigLangVersions(languageId, resourceId, userResourcePath);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix resource upgrade where user resource folder is empty.

#### Please include detailed Test instructions for your pull request:
- before running tC delete all version folders in `resources/hbo/bibles/uhb`
- test with local tC build.  Run tC.  Should see bundled uhb installed in resources at `resources/hbo/bibles/uhb/v2.1.8`

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6598)
<!-- Reviewable:end -->
