### PR TITLE
Feature 6586/Protect from tN crashes if user tries to open 2.1.0 project in 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "translationCore",
   "productName": "translationCore",
   "version": "2.1.0",
-  "minCompatibleVersion": "2.0.0",
+  "minCompatibleVersion": "2.1.0",
   "manifestVersion": "7",
   "description": "A bridge between TS and TM",
   "main": "src/es6-init.js",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Moved up minCompatibleVersion to 2.1.0 to Protect from tN crashes if user tries to open 2.1.0 project in 2.0.0

#### Please include detailed Test instructions for your pull request:
- with local build select a project and then exit app.
- launch tC 2.0.0 - try to select the project above and should see warning that you need to update tCore.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6603)
<!-- Reviewable:end -->
