### PR TITLE
Fix link to builds for Zulip notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -330,7 +330,7 @@ jobs:
         run: echo "::set-env name=BRANCH::$(node -p -e "'$REF'.substr(11)")" # strips off "refs/heads/"
 
       - name: Notify Zulip of push
-        if: github.event_name == 'push'
+#        if: github.event_name == 'push'
         env:
           TOKEN: ${{ secrets.ZULIP_TOKEN }}
           USER: github-bot@unfoldingword.zulipchat.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -344,4 +344,4 @@ jobs:
             -d "to=$CHANNEL" \
             -d "subject=$SUBJECT" \
             -d "content=Branch [$BRANCH](https://github.com/$REPOSITORY/tree/$BRANCH) has new builds based on [$SHORT_SHA](https://github.com/$REPOSITORY/commit/$SHA).
-                        You can view logs and download artifacts from the [Actions](https://github.com/$REPOSITORY/commit/$SHA/checks) tab."
+                        [Download the builds from here](https://github.com/$REPOSITORY/actions/runs/$GITHUB_ACTION)."


### PR DESCRIPTION
If I did this correctly, this patch should link directly to the page which shows the built binaries for QA to test and download.

Expected output is a link to a page like this https://github.com/unfoldingWord/translationCore/actions/runs/32631095 . Note that I used https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables to find the variable name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6658)
<!-- Reviewable:end -->
