### PR TITLE
Bugfix 6678/Save verse edits for all checks in group data index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,7 +2350,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -2652,9 +2651,9 @@
       "dev": true
     },
     "checking-tool-wrapper": {
-      "version": "3.0.2-beta.2",
-      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.2-beta.2.tgz",
-      "integrity": "sha512-lLsh9kTHoKGdm9CL0mzXmlwOy1vmDIZoEQHfoJmKynfZ8wkgjhKkNpKaevw7TvPk5tWCwHRu4Y6AFx1f+zI2QQ==",
+      "version": "3.0.2-beta.3",
+      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.2-beta.3.tgz",
+      "integrity": "sha512-uF5gmxw+NGLYRcSFy68UYDDaVrzC7G/S/sCfKiDSZIB3p7iQFlZT5m/e6nXPsB4CQQ7skn90Kq0F0NB4F4PfzQ==",
       "requires": {
         "@material-ui/icons": "3.0.2",
         "crypto-js": "^3.1.9-1",
@@ -2770,8 +2769,7 @@
         "acorn": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-          "optional": true
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
         },
         "acorn-globals": {
           "version": "1.0.9",
@@ -2949,7 +2947,6 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -6229,8 +6226,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6248,13 +6244,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6267,18 +6261,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6381,8 +6372,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6392,7 +6382,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6405,20 +6394,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6435,7 +6421,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6516,8 +6501,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6527,7 +6511,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6603,8 +6586,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6634,7 +6616,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6652,7 +6633,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6691,13 +6671,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7456,8 +7434,7 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "optional": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2652,9 +2652,9 @@
       "dev": true
     },
     "checking-tool-wrapper": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.1.tgz",
-      "integrity": "sha512-6bmQa5h6umxQroaqr9yJ2YI/VJRzr/P6JjLS/wivEoPGLRZD/j5r0XgwFWqHyduIWXsrBdanlvvPAoP4CGwDSA==",
+      "version": "3.0.2-beta.2",
+      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.2-beta.2.tgz",
+      "integrity": "sha512-lLsh9kTHoKGdm9CL0mzXmlwOy1vmDIZoEQHfoJmKynfZ8wkgjhKkNpKaevw7TvPk5tWCwHRu4Y6AFx1f+zI2QQ==",
       "requires": {
         "@material-ui/icons": "3.0.2",
         "crypto-js": "^3.1.9-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2651,9 +2651,9 @@
       "dev": true
     },
     "checking-tool-wrapper": {
-      "version": "3.0.2-beta.3",
-      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.2-beta.3.tgz",
-      "integrity": "sha512-uF5gmxw+NGLYRcSFy68UYDDaVrzC7G/S/sCfKiDSZIB3p7iQFlZT5m/e6nXPsB4CQQ7skn90Kq0F0NB4F4PfzQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/checking-tool-wrapper/-/checking-tool-wrapper-3.0.2.tgz",
+      "integrity": "sha512-0cfiZDFN44V6sz/ZhLt6HVQzKMaB1QFFsQh+6DVlHfTYgJHxPVFQECZHMW4EM3ajM3G4q1z/8meRRr6nX+kRKw==",
       "requires": {
         "@material-ui/icons": "3.0.2",
         "crypto-js": "^3.1.9-1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
-    "checking-tool-wrapper": "3.0.2-beta.3",
+    "checking-tool-wrapper": "3.0.2",
     "crypto-js": "3.1.8",
     "csv": "1.2.1",
     "deep-equal": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
-    "checking-tool-wrapper": "3.0.1",
+    "checking-tool-wrapper": "3.0.2-beta.2",
     "crypto-js": "3.1.8",
     "csv": "1.2.1",
     "deep-equal": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
-    "checking-tool-wrapper": "3.0.2-beta.2",
+    "checking-tool-wrapper": "3.0.2-beta.3",
     "crypto-js": "3.1.8",
     "csv": "1.2.1",
     "deep-equal": "1.0.1",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated checking-tool-wrapper - verse edits indicators not saved for all checks for a verse

#### Please include detailed Test instructions for your pull request:
- testing: checkout tCore branch `bugfix-mcleanb-6678`, do `npm run load-apps` `npm ci`
- open a clean titus project select en for GL of tW.  launch tW.  Select group `pure, purify..`
- do edit of Titus 1:15 and should see verse edit indications for all 3 instances in group `pure, purify..`
- restart tCore, reopen project and launch tW - should still see verse edit indications for all 3 instances of 1:15.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6720)
<!-- Reviewable:end -->
