### PR TITLE
Bugfix 6902/Fix crash on renaming archive projects

### DIFF
--- a/src/js/actions/ProjectInformationCheckActions.js
+++ b/src/js/actions/ProjectInformationCheckActions.js
@@ -19,6 +19,7 @@ import * as MissingVersesActions from './MissingVersesActions';
 import * as ProjectValidationActions from './Import/ProjectValidationActions';
 import * as AlertModalActions from './AlertModalActions';
 import { closeProject, loadProjectDetails } from './MyProjects/ProjectLoadingActions';
+import * as BodyUIActions from './BodyUIActions';
 // constants
 const PROJECT_INFORMATION_CHECK_NAMESPACE = 'projectInformationCheck';
 
@@ -546,6 +547,7 @@ export function saveAndCloseProjectInformationCheckIfValid() {
         // TRICKY: close the project so that changes can be re-loaded by the tools.
         dispatch(closeProject());
         dispatch(MyProjectsActions.getMyProjects());
+        dispatch(BodyUIActions.goToStep(2)); // go to projects page now that project is closed
       }
     }
     dispatch(AlertModalActions.closeAlertDialog());

--- a/src/js/components/home/toolsManagement/ToolsCards.js
+++ b/src/js/components/home/toolsManagement/ToolsCards.js
@@ -17,7 +17,6 @@ const ToolsCards = ({
   actions,
   translate,
   onSelectTool,
-  bookName,
   loggedInUser,
   projectSaveLocation,
   manifest,
@@ -39,7 +38,7 @@ const ToolsCards = ({
         </Card>
       </MuiThemeProvider>
     );
-  } else if (bookName.length === 0 && projectSaveLocation === 0) {
+  } else if (!projectSaveLocation) {
     return (
       <MuiThemeProvider>
         <Card style={{
@@ -125,7 +124,6 @@ ToolsCards.propTypes = {
   onSelectTool: PropTypes.func.isRequired,
   translate: PropTypes.func.isRequired,
   actions: PropTypes.object.isRequired,
-  bookName: PropTypes.string.isRequired,
   loggedInUser: PropTypes.bool.isRequired,
   projectSaveLocation: PropTypes.string.isRequired,
   manifest: PropTypes.object.isRequired,

--- a/src/js/containers/home/ToolsManagementContainer.js
+++ b/src/js/containers/home/ToolsManagementContainer.js
@@ -70,7 +70,6 @@ class ToolsManagementContainer extends Component {
       toggleHomeView,
       sourceContentUpdateCount,
     } = this.props;
-    const name = ''; // TODO - we were reading this from a global variable that was always an empty string, need to remove
 
     const instructions = (
       <div>
@@ -102,7 +101,6 @@ class ToolsManagementContainer extends Component {
             toolsCategories={toolsCategories}
             manifest={manifest}
             translate={translate}
-            bookName={name}
             loggedInUser={loggedInUser}
             toggleHomeView={toggleHomeView}
             actions={{ ...this.props.actions }}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Removed unused bookName property in ToolsCards
- fixed handling of missing projectSaveLocation in ToolsCards
- after project rename, fix bug that that user would see empty tools list.  Fixed to return to projects page

#### Please include detailed Test instructions for your pull request:
- should be able to rename archive project without crash.  Other projects should still open.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6903)
<!-- Reviewable:end -->
