### PR TITLE
Bugfix 6990/fix for more than two original language words in alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19279,9 +19279,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "word-aligner": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.4.0.tgz",
-      "integrity": "sha512-TojJFi0ObcPJWgviFEAWL4av+9M6kqx6+xT17OOsJPOyFCiSsrCJwEiMTLiaWv1jo9mK0r7/u2c4B8r2i2SPvw==",
+      "version": "0.4.1-alpha",
+      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.4.1-alpha.tgz",
+      "integrity": "sha512-48vQCjpPaFThl4WukqO/b+/WO3MgeassdvmY8Xq8vboiHQVTLnBdrt/GzURVko9JGJYcu7OsJOEIKomHqZ8yoQ==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "fs-extra": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19279,9 +19279,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "word-aligner": {
-      "version": "0.4.1-alpha",
-      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.4.1-alpha.tgz",
-      "integrity": "sha512-48vQCjpPaFThl4WukqO/b+/WO3MgeassdvmY8Xq8vboiHQVTLnBdrt/GzURVko9JGJYcu7OsJOEIKomHqZ8yoQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-1.0.0.tgz",
+      "integrity": "sha512-eok7g0bz5yCodu3UusLpIbZMIjP7NkW4E4lpJH70txYFJsNYsASQaGdlc09MzyTwfQcxN076in/zWoNwyHug7g==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "fs-extra": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "tsv-groupdata-parser": "0.9.16",
     "usfm-js": "2.1.0",
     "uuid": "3.2.1",
-    "word-aligner": "0.4.0",
+    "word-aligner": "0.4.1-alpha",
     "wordmap": "0.8.2",
     "wordmap-lexer": "0.3.6",
     "xregexp": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "tsv-groupdata-parser": "0.9.16",
     "usfm-js": "2.1.0",
     "uuid": "3.2.1",
-    "word-aligner": "0.4.1-alpha",
+    "word-aligner": "1.0.0",
     "wordmap": "0.8.2",
     "wordmap-lexer": "0.3.6",
     "xregexp": "3.2.0",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated word-aligner with fix for more than two original language words in alignment

#### Please include detailed Test instructions for your pull request:
- open an Esther project, start tW, add en_ult pane to SP, navigate to Evil and select 8:6.  SHould see "destroyed" highlighted:

![Screen Shot 2020-06-16 at 3 09 33 PM](https://user-images.githubusercontent.com/14238574/84817893-ab06ad80-afe3-11ea-9202-4eca438f3052.png)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/6998)
<!-- Reviewable:end -->
