### PR TITLE
Addressed QA fail issues with target language text resizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,7 +17708,7 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:unfoldingWord/tc-ui-toolkit#11c4833274a02aea86fd390142447a71ca6f5f62",
+      "version": "github:unfoldingWord/tc-ui-toolkit#117c852ca14fe003f9740236ab39816990f1cdfa",
       "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
       "requires": {
         "@material-ui/core": "^4.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,7 +17708,7 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:unfoldingWord/tc-ui-toolkit#117c852ca14fe003f9740236ab39816990f1cdfa",
+      "version": "github:unfoldingWord/tc-ui-toolkit#49dd8ce7f7cdf2ab27d37cdf31fe4dd6625174a6",
       "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
       "requires": {
         "@material-ui/core": "^4.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,9 +17708,8 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-4.0.1.tgz",
-      "integrity": "sha512-3eiIW1/3D86BA0ID2G3f0q4FNc+ftpOSc9CJEVqO9LzNQm5Map/o2ll5WiGtR1wc4hpBt7pBuImSrXYCCJ1lpQ==",
+      "version": "github:unfoldingWord/tc-ui-toolkit#11c4833274a02aea86fd390142447a71ca6f5f62",
+      "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",
@@ -18762,6 +18761,12 @@
         "chokidar": "^2.1.8"
       },
       "dependencies": {
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "optional": true
+        },
         "chokidar": {
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -18771,11 +18776,66 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
             "normalize-path": "^3.0.0",
             "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,8 +17708,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:unfoldingWord/tc-ui-toolkit#49dd8ce7f7cdf2ab27d37cdf31fe4dd6625174a6",
-      "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-4.0.2.tgz",
+      "integrity": "sha512-eXjkskdkIi4RWcz9PLYyJF3RLIXyroCnwGY2sJO4ltr7kYxToCxFD3czPfxK7qmiIuVrSECH1WbWIvatQ8tI7A==",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
+    "tc-ui-toolkit": "4.0.2",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.16",
     "usfm-js": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "4.0.1",
+    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#bugfix-mannycolon-6970",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.16",
     "usfm-js": "2.1.0",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Should merge https://github.com/unfoldingWord/wordAlignment/pull/286 after merging this PR

#### Please include detailed Test instructions for your pull request:
- Checkout bugfix-mannycolon-6970
- `rm -rf node_mdoules && npm i`
- Open tC and make sure issues 1-8 are resolved.
- ***ISSUE 1:*** Vertical scroll bar
The vertical scroll bar is not shown soon enough with some fonts and sizes. This is an Arabic resource (NAV) at maximum size and the target language at 220%. The last line of text for the Arabic resource is not visible, but there is no scroll bar in that pane.
![image](https://user-images.githubusercontent.com/8171759/85790545-fdd41980-b6f5-11ea-9724-c3eaaf49d885.png)

If the target language is reduced to 220%, then the scroll bar appears as desired in the Arabic resource pane
![image](https://user-images.githubusercontent.com/8171759/85790954-b69a5880-b6f6-11ea-82c4-3c2ad9232cca.png)

- ***ISSUE 2***: Padding (and questionable text display
Here the target language is at 240%. Note that there is now an additional line of text showing for the Arabic resource, but the bottom is still clipped slightly.
![image](https://user-images.githubusercontent.com/8171759/85790836-85ba2380-b6f6-11ea-95a0-c58cc8f36b2f.png)

If the Arabic pane is scrolled to the bottom, it now appears that the bottom element that was previously clipped actually belongs to different text.
![image](https://user-images.githubusercontent.com/8171759/85791671-d716e280-b6f7-11ea-83b6-be8452f97ac1.png)

There probably should be a little more padding at the bottom of the pane when scrolled all the way to the bottom and the horizontal scroll bar is displayed.
![image](https://user-images.githubusercontent.com/8171759/85793038-06c6ea00-b6fa-11ea-9e28-af4262fe13c0.png)

- ***ISSUE 3***: Size selection not persisted
The font size for the target language and original language panes in the scripture pane of wA is reset to 100% when a different project is loaded or tC is ended. Sizes are persisted in tN and tW (until wA is again loaded), and for the other panes in wA.

- ***ISSUE 4***: Expand verses not working in Select mode
The Expand verses option in the 3 dot menu in the check pane of tN and tW is displayed but not work when the user is in Select mode.

- ***ISSUE 5***: Font size of the Hebrew verse reference
The font size being used for the verse reference for Hebrew in the scripture pane is significantly larger than it was before. The font size displayed at 100% changes significantly as the font size is adjusted. 
3.0.0 (80e133b) 
![image](https://user-images.githubusercontent.com/8171759/85798442-1b5bb000-b703-11ea-9ee4-a39b57c2edce.png)

3.0.0 (84a5a44) 
![image](https://user-images.githubusercontent.com/8171759/85798502-34fcf780-b703-11ea-9eeb-873ad4b79923.png)

- ***ISSUE 6***: Font size of Hebrew at 100% varies 
The font size displayed at 100% changes significantly after the font size is adjusted and then set back to 100%
3.0.0 (5c2609d) 
When first loaded:
![image](https://user-images.githubusercontent.com/8171759/85882374-ce301a80-b7a4-11ea-86cc-bdef8b531df7.png)

After adjusting font size and bringing back to 100%
![image](https://user-images.githubusercontent.com/8171759/85882442-e142ea80-b7a4-11ea-9c40-63c06a1d2ca1.png)

Movie showing the above process:
[fontSize.mp4.zip](https://github.com/unfoldingWord/translationCore/files/4838241/fontSize.mp4.zip)

- ***ISSUE 7***: Padding for title lines of RTL languages
The padding has been reduced (or eliminated) on the right side of the scripture panes that contain RTL languages. The image on top is from a previous build and the title lines for the RTL languages are right justified the same as the scripture text. In the bottom image, the title lines for the RTL languages are flush against the right hand side of the pane.
I think that is also why the padding between the left side of the RTL panes and the 3-dot menu (previously the close X) is also significantly larger now.
![image](https://user-images.githubusercontent.com/8171759/85905660-9be8e200-b7d1-11ea-994e-308dbd28f94a.png)

- ***ISSUE 8***: Vertical size of scripture pane
The vertical size of the scripture pane in wA now changes as the the user navigates through the verses.
![image](https://user-images.githubusercontent.com/8171759/86249303-b83fa280-bb74-11ea-8869-0908e8482cff.png)

![image](https://user-images.githubusercontent.com/8171759/86249448-ede48b80-bb74-11ea-82a8-1be5b6d71c26.png)



#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7026)
<!-- Reviewable:end -->
