### PR TITLE
Bugfix 7023/Improve error handling when category missing from group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18119,9 +18119,9 @@
       }
     },
     "tsv-groupdata-parser": {
-      "version": "0.9.17-alpha",
-      "resolved": "https://registry.npmjs.org/tsv-groupdata-parser/-/tsv-groupdata-parser-0.9.17-alpha.tgz",
-      "integrity": "sha512-D6eTUicEAX9XvmKGF7B6ZnjnoLYN1qBUCrc1tXYWkiSDZ5zZstKatwZu0DOcOdbMjWtGsqwN9PZ+D/fRa8eNcQ==",
+      "version": "0.9.17",
+      "resolved": "https://registry.npmjs.org/tsv-groupdata-parser/-/tsv-groupdata-parser-0.9.17.tgz",
+      "integrity": "sha512-bsvPVwvDq0F/XrcjOERxkMYHacyNL9HPYZS59l20OyOmedgE0QfslCmNoo3Q0RuWv4gPeprkNH0egjved4sDAw==",
       "requires": {
         "fs-extra": "^7.0.1",
         "ospath": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18119,9 +18119,8 @@
       }
     },
     "tsv-groupdata-parser": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/tsv-groupdata-parser/-/tsv-groupdata-parser-0.9.16.tgz",
-      "integrity": "sha512-Tl2Q+0uaWkne2BSfX+IqEuhKdYVJ0k2bvCt6mhzCU0P2iL9eFRt9+zAcfRYLAp4gm+CruC8rQCVCOaADwomu+w==",
+      "version": "github:translationCoreApps/tsv-groupdata-parser#29b73c4fd1609298a4aaf3ccdc03e63684a1930f",
+      "from": "github:translationCoreApps/tsv-groupdata-parser#bugfix-mcleanb-7023",
       "requires": {
         "fs-extra": "^7.0.1",
         "ospath": "^1.2.2",
@@ -18762,6 +18761,12 @@
         "chokidar": "^2.1.8"
       },
       "dependencies": {
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "optional": true
+        },
         "chokidar": {
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -18771,11 +18776,66 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
             "normalize-path": "^3.0.0",
             "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18119,8 +18119,9 @@
       }
     },
     "tsv-groupdata-parser": {
-      "version": "github:translationCoreApps/tsv-groupdata-parser#29b73c4fd1609298a4aaf3ccdc03e63684a1930f",
-      "from": "github:translationCoreApps/tsv-groupdata-parser#bugfix-mcleanb-7023",
+      "version": "0.9.17-alpha",
+      "resolved": "https://registry.npmjs.org/tsv-groupdata-parser/-/tsv-groupdata-parser-0.9.17-alpha.tgz",
+      "integrity": "sha512-D6eTUicEAX9XvmKGF7B6ZnjnoLYN1qBUCrc1tXYWkiSDZ5zZstKatwZu0DOcOdbMjWtGsqwN9PZ+D/fRa8eNcQ==",
       "requires": {
         "fs-extra": "^7.0.1",
         "ospath": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "4.0.1",
     "truncate-utf8-bytes": "1.0.2",
-    "tsv-groupdata-parser": "0.9.16",
+    "tsv-groupdata-parser": "github:translationCoreApps/tsv-groupdata-parser#bugfix-mcleanb-7023",
     "usfm-js": "2.1.0",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "4.0.1",
     "truncate-utf8-bytes": "1.0.2",
-    "tsv-groupdata-parser": "0.9.17-alpha",
+    "tsv-groupdata-parser": "0.9.17",
     "usfm-js": "2.1.0",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "4.0.1",
     "truncate-utf8-bytes": "1.0.2",
-    "tsv-groupdata-parser": "github:translationCoreApps/tsv-groupdata-parser#bugfix-mcleanb-7023",
+    "tsv-groupdata-parser": "0.9.17-alpha",
     "usfm-js": "2.1.0",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",

--- a/src/js/components/home/toolsManagement/CategoryCheckbox.js
+++ b/src/js/components/home/toolsManagement/CategoryCheckbox.js
@@ -25,7 +25,7 @@ const CategoryCheckbox = ({
   selectedCategories,
   availableSubcategories = [],
 }) => {
-  const currentSubcategoriesSelected = availableSubcategories.filter((subcat) => selectedCategories.includes(subcat.id));
+  const currentSubcategoriesSelected = availableSubcategories.filter((subcat) => subcat && selectedCategories.includes(subcat.id));
   const allSubcategoriesSelected = isEqual(availableSubcategories, currentSubcategoriesSelected);
   const allSubcategoriesUnselected = currentSubcategoriesSelected.length === 0;
   const isChecked = allSubcategoriesSelected;

--- a/src/js/components/home/toolsManagement/ToolCardBoxes.js
+++ b/src/js/components/home/toolsManagement/ToolCardBoxes.js
@@ -61,13 +61,15 @@ class ToolCardBoxes extends React.Component {
       const category = availableCategories[cat];
 
       for (const group in category) {
-        fullText = loadArticleData(
-          TRANSLATION_ACADEMY,
-          category[group].id,
-          selectedGL,
-        );
+        if (group && category[group]) {
+          fullText = loadArticleData(
+            TRANSLATION_ACADEMY,
+            category[group].id,
+            selectedGL,
+          );
 
-        articles[category[group].id] = fullText.substr(0,600) ;
+          articles[category[group].id] = fullText.substr(0, 600);
+        }
       }
     }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated tsv-groupdata-parser and added safe error recovery for when we cannot look up localized group name for groupId
- added safe error recovery for check categories not in a group.

#### Please include detailed Test instructions for your pull request:
- test with build attached
- should be able to open Obadiah project without crashing.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7027)
<!-- Reviewable:end -->
