### PR TITLE
Bugfix 7028/Make Word Bank font sizer stationary 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,8 +17708,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:translationCoreApps/tc-ui-toolkit#1b5932844c094d1a30cf9092da788f9cafeb3882",
-      "from": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
+      "version": "5.3.0-alpha",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.3.0-alpha.tgz",
+      "integrity": "sha512-nm3Q7h5xPFTnccy07udKZfJONxqXlKA58JDGxrPn9NfwaDlkp/yCLSE2wemgEWn9ckjTszLf9ZD3WPaHBaXFag==",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,9 +17708,8 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "5.3.0-alpha",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.3.0-alpha.tgz",
-      "integrity": "sha512-nm3Q7h5xPFTnccy07udKZfJONxqXlKA58JDGxrPn9NfwaDlkp/yCLSE2wemgEWn9ckjTszLf9ZD3WPaHBaXFag==",
+      "version": "github:translationCoreApps/tc-ui-toolkit#0181f638c5826e3b68b100c7ac3a1075a2fc2702",
+      "from": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,8 +17708,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:translationCoreApps/tc-ui-toolkit#0181f638c5826e3b68b100c7ac3a1075a2fc2702",
-      "from": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.3.0.tgz",
+      "integrity": "sha512-89mOCHmasSj7l2sm7oVWjqeGYvp9dJPA8SIEdimDhdi67Ac9LulOEckcuBV414zaxfT79ukV8dX94QVWHI9Sng==",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,9 +17708,8 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.2.2.tgz",
-      "integrity": "sha512-XFh3AxlIQB31ReHtCuzLk4V5JQVSnEZWdmv43Q8As2hY1QLfFfhOmDji5u7h2W68TtEMwsDoROakhl7xLViQJA==",
+      "version": "github:translationCoreApps/tc-ui-toolkit#1b5932844c094d1a30cf9092da788f9cafeb3882",
+      "from": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "5.3.0-alpha",
+    "tc-ui-toolkit": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.17",
     "usfm-js": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
+    "tc-ui-toolkit": "5.3.0-alpha",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.17",
     "usfm-js": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
+    "tc-ui-toolkit": "5.3.0",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.17",
     "usfm-js": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "tc-source-content-updater": "0.6.20",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
-    "tc-ui-toolkit": "5.2.2",
+    "tc-ui-toolkit": "github:translationCoreApps/tc-ui-toolkit#bugfix-mcleanb-7028",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "0.9.17",
     "usfm-js": "2.1.0",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated tc-ui-toolkit & wA

#### Please include detailed Test instructions for your pull request:
- merge before https://github.com/unfoldingWord/wordAlignment/pull/292
- test with tC branch `bugfix-mcleanb-7028`
- in wA, when changing font size on word bank, should not see font resize slider move.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7061)
<!-- Reviewable:end -->
