### PR TITLE
Feature 6746/When downloading Bibles from catalog, Ignore books not supported by USFM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17616,9 +17616,9 @@
       }
     },
     "tc-source-content-updater": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-0.7.0.tgz",
-      "integrity": "sha512-4i89pETK3Hzm+8UeFvaJjCQnwFcqCFnd6FARh5MSbj04S8UykyajH8JSxRVRNrQdCtACxW6dWj2dsuPx/flC3g==",
+      "version": "0.7.1-alpha",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-0.7.1-alpha.tgz",
+      "integrity": "sha512-1zpiofkHzryh+m10DNrMUoZgy3eFezKgYW7Hs7YAoQ0XxogP798cQXjdpGG5M53W5Km6FnWN5im/esQIM0OM7A==",
       "requires": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17616,9 +17616,9 @@
       }
     },
     "tc-source-content-updater": {
-      "version": "0.7.1-alpha",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-0.7.1-alpha.tgz",
-      "integrity": "sha512-1zpiofkHzryh+m10DNrMUoZgy3eFezKgYW7Hs7YAoQ0XxogP798cQXjdpGG5M53W5Km6FnWN5im/esQIM0OM7A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-0.8.0.tgz",
+      "integrity": "sha512-49HtZt3sToT9h9zETmtwIVYBsppJYk8OnvdHhl0WHkxlgvvVbL6xZkdmmOG+eoxEvg29Q5OHdzF7QGyoANgFgw==",
       "requires": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "string-punctuation-tokenizer": "2.0.0",
     "sudo-prompt": "6.2.1",
     "tc-electron-env": "0.9.0",
-    "tc-source-content-updater": "0.7.0",
+    "tc-source-content-updater": "0.7.1-alpha",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "string-punctuation-tokenizer": "2.0.0",
     "sudo-prompt": "6.2.1",
     "tc-electron-env": "0.9.0",
-    "tc-source-content-updater": "0.7.1-alpha",
+    "tc-source-content-updater": "0.8.0",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "5.3.2",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated tc-source-content-updater

#### Please include detailed Test instructions for your pull request:
- should not throw exception when bibles contain books not supported in tC, but for now there is no way to test but by unit tests

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7080)
<!-- Reviewable:end -->
