### PR TITLE
Bugfix 7164/Strip existing white space between \p and newlines on USFM output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "tc-ui-toolkit": "5.3.3",
         "truncate-utf8-bytes": "1.0.2",
         "tsv-groupdata-parser": "^0.10.0",
-        "usfm-js": "3.3.1-alpha",
+        "usfm-js": "3.3.1-alpha.2",
         "uuid": "3.2.1",
         "word-aligner": "1.0.0",
         "wordmap": "0.8.2",
@@ -24203,9 +24203,9 @@
       }
     },
     "node_modules/usfm-js": {
-      "version": "3.3.1-alpha",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.tgz",
-      "integrity": "sha512-5Z0cB17FFhDKW8G4Zq65+w+HoL3P7qkVLqPpvAtXVCgi1LN/KTMGyVU1KYATedJyy2wa3x/S4IOwYTZCuSMQfA==",
+      "version": "3.3.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.2.tgz",
+      "integrity": "sha512-IoV4ayMep1gT6ASy3o6YiAMhfwMQuNbeyeJMKTMoaakAzOE6KCqndVyRv/JHJm6Sphtw7LYG6NwPX4twz+mnaQ==",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0"
       }
@@ -46083,9 +46083,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "3.3.1-alpha",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.tgz",
-      "integrity": "sha512-5Z0cB17FFhDKW8G4Zq65+w+HoL3P7qkVLqPpvAtXVCgi1LN/KTMGyVU1KYATedJyy2wa3x/S4IOwYTZCuSMQfA==",
+      "version": "3.3.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.2.tgz",
+      "integrity": "sha512-IoV4ayMep1gT6ASy3o6YiAMhfwMQuNbeyeJMKTMoaakAzOE6KCqndVyRv/JHJm6Sphtw7LYG6NwPX4twz+mnaQ==",
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "tc-ui-toolkit": "5.3.3",
         "truncate-utf8-bytes": "1.0.2",
         "tsv-groupdata-parser": "^0.10.0",
-        "usfm-js": "3.3.0",
+        "usfm-js": "3.3.1-alpha",
         "uuid": "3.2.1",
         "word-aligner": "1.0.0",
         "wordmap": "0.8.2",
@@ -24203,9 +24203,9 @@
       }
     },
     "node_modules/usfm-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.0.tgz",
-      "integrity": "sha512-jPINaycpoloxT8XT7K8VCAEPAHXYkShqtiaaQaam74E1GHzNpVOLus0e0lKSaBIwKvM7Wpy5CBHaI1mDrC8EQg==",
+      "version": "3.3.1-alpha",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.tgz",
+      "integrity": "sha512-5Z0cB17FFhDKW8G4Zq65+w+HoL3P7qkVLqPpvAtXVCgi1LN/KTMGyVU1KYATedJyy2wa3x/S4IOwYTZCuSMQfA==",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0"
       }
@@ -46083,9 +46083,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.0.tgz",
-      "integrity": "sha512-jPINaycpoloxT8XT7K8VCAEPAHXYkShqtiaaQaam74E1GHzNpVOLus0e0lKSaBIwKvM7Wpy5CBHaI1mDrC8EQg==",
+      "version": "3.3.1-alpha",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.tgz",
+      "integrity": "sha512-5Z0cB17FFhDKW8G4Zq65+w+HoL3P7qkVLqPpvAtXVCgi1LN/KTMGyVU1KYATedJyy2wa3x/S4IOwYTZCuSMQfA==",
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "tc-ui-toolkit": "5.3.3",
         "truncate-utf8-bytes": "1.0.2",
         "tsv-groupdata-parser": "^0.10.0",
-        "usfm-js": "3.3.1-alpha.2",
+        "usfm-js": "3.3.1",
         "uuid": "3.2.1",
         "word-aligner": "1.0.0",
         "wordmap": "0.8.2",
@@ -24203,9 +24203,9 @@
       }
     },
     "node_modules/usfm-js": {
-      "version": "3.3.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.2.tgz",
-      "integrity": "sha512-IoV4ayMep1gT6ASy3o6YiAMhfwMQuNbeyeJMKTMoaakAzOE6KCqndVyRv/JHJm6Sphtw7LYG6NwPX4twz+mnaQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1.tgz",
+      "integrity": "sha512-UB9cV4MGEEiO1WuC3EzGyj/2OvPbBBY8w8MK2odfGITKa5Z4lxTwjoPNLnllFyviyx8jD6DOt78dtR8XdCpWbw==",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0"
       }
@@ -46083,9 +46083,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "usfm-js": {
-      "version": "3.3.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1-alpha.2.tgz",
-      "integrity": "sha512-IoV4ayMep1gT6ASy3o6YiAMhfwMQuNbeyeJMKTMoaakAzOE6KCqndVyRv/JHJm6Sphtw7LYG6NwPX4twz+mnaQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-3.3.1.tgz",
+      "integrity": "sha512-UB9cV4MGEEiO1WuC3EzGyj/2OvPbBBY8w8MK2odfGITKa5Z4lxTwjoPNLnllFyviyx8jD6DOt78dtR8XdCpWbw==",
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "tc-ui-toolkit": "5.3.3",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "^0.10.0",
-    "usfm-js": "3.3.1-alpha",
+    "usfm-js": "3.3.1-alpha.2",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",
     "wordmap": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "tc-ui-toolkit": "5.3.3",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "^0.10.0",
-    "usfm-js": "3.3.0",
+    "usfm-js": "3.3.1-alpha",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",
     "wordmap": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "tc-ui-toolkit": "5.3.3",
     "truncate-utf8-bytes": "1.0.2",
     "tsv-groupdata-parser": "^0.10.0",
-    "usfm-js": "3.3.1-alpha.2",
+    "usfm-js": "3.3.1",
     "uuid": "3.2.1",
     "word-aligner": "1.0.0",
     "wordmap": "0.8.2",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for more edge cases where the project already has a space(s) after the paragraph marker.

#### Please include detailed Test instructions for your pull request:

- [ ] test with build below
- [ ] try exporting these repos:

  - [en_new_rev_book.zip](https://github.com/unfoldingWord/translationCore/files/7570972/en_new_rev_book.zip)
  - [en_loc_luk_book.zip](https://github.com/unfoldingWord/translationCore/files/7570973/en_loc_luk_book.zip)

- [ ] check the output USFM to make sure is no space between the \p and newline:

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7191)
<!-- Reviewable:end -->
