### PR TITLE
Feature 7225/Show failed downloads on error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22919,8 +22919,8 @@
     },
     "node_modules/tc-source-content-updater": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.2.0.tgz",
-      "integrity": "sha512-rNIFhtpDMea5zM73A7pTzvcoBjRySd5zSOoe8GPHDoah4FXx/1q7WRMQysCk9RzO9v2RrM/jeSRBXqUZHQLTkQ==",
+      "resolved": "git+ssh://git@github.com/unfoldingWord/tc-source-content-updater.git#801b086c96fc36961f258df726293452ddff3fa0",
+      "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",
@@ -45107,9 +45107,8 @@
       }
     },
     "tc-source-content-updater": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.2.0.tgz",
-      "integrity": "sha512-rNIFhtpDMea5zM73A7pTzvcoBjRySd5zSOoe8GPHDoah4FXx/1q7WRMQysCk9RzO9v2RrM/jeSRBXqUZHQLTkQ==",
+      "version": "git+ssh://git@github.com/unfoldingWord/tc-source-content-updater.git#801b086c96fc36961f258df726293452ddff3fa0",
+      "from": "tc-source-content-updater@1.2.0",
       "requires": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22919,8 +22919,8 @@
     },
     "node_modules/tc-source-content-updater": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/unfoldingWord/tc-source-content-updater.git#801b086c96fc36961f258df726293452ddff3fa0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.2.0.tgz",
+      "integrity": "sha512-rNIFhtpDMea5zM73A7pTzvcoBjRySd5zSOoe8GPHDoah4FXx/1q7WRMQysCk9RzO9v2RrM/jeSRBXqUZHQLTkQ==",
       "dependencies": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",
@@ -45107,8 +45107,9 @@
       }
     },
     "tc-source-content-updater": {
-      "version": "git+ssh://git@github.com/unfoldingWord/tc-source-content-updater.git#801b086c96fc36961f258df726293452ddff3fa0",
-      "from": "tc-source-content-updater@1.2.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.2.0.tgz",
+      "integrity": "sha512-rNIFhtpDMea5zM73A7pTzvcoBjRySd5zSOoe8GPHDoah4FXx/1q7WRMQysCk9RzO9v2RrM/jeSRBXqUZHQLTkQ==",
       "requires": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",

--- a/src/js/actions/SourceContentUpdatesActions.js
+++ b/src/js/actions/SourceContentUpdatesActions.js
@@ -136,12 +136,12 @@ export const downloadSourceContentUpdates = (resourcesToDownload, refreshUpdates
 
         if (errors && errors.length) {
           for (const error of errors) {
-            let errorType = error.parseError ? 'parse error' : 'download error';
+            let errorType = error.parseError ? 'updates.update_error_reason_parse' : 'updates.update_error_reason_parse';
 
             if (error.parseError && error.errorMessage.indexOf(' - cannot find ')) {
-              errorType = 'missing dependency';
+              errorType = 'updates.update_error_reason_missing_dependency';
             }
-            errorStr += `${error.downloadUrl} - ${errorType}\n`;
+            errorStr += `${error.downloadUrl} ⬅︎ ${translate(errorType)}\n`;
           }
         }
 

--- a/src/js/containers/SourceContentUpdatesDialogContainer.js
+++ b/src/js/containers/SourceContentUpdatesDialogContainer.js
@@ -13,6 +13,26 @@ import SourceContentUpdateDialog from '../components/dialogComponents/SourceCont
 import { languagesObjectToResourcesArray, createLanguagesObjectFromResources } from '../helpers/combineResources';
 
 /**
+ * format a localized error message
+ * @param {function} translate
+ * @param {string} errorStr
+ * @return {JSX.Element}
+ */
+export function getResourceDownloadsAlertMessage(translate, errorStr= '') {
+  const parts = errorStr.split('\n').map(line => (
+    <>
+      {line}
+      <br/>
+    </>
+  ));
+  return <>
+    {translate('updates.source_content_updates_unsuccessful_download')}
+    <br/><br/>
+    {parts}
+  </>;
+}
+
+/**
  * Renders a dialog displaying a list of new content updates.
  *
  * @class

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -85,7 +85,7 @@
     "failed_checking_for_source_content_updates": "Unable to finish checking for source content updates.",
     "downloading_source_content_updates": "Downloading source content updates...",
     "source_content_updates_successful_download": "Source content updates downloaded successfully!",
-    "source_content_updates_unsuccessful_download": "Failed to download source content updates.",
+    "source_content_updates_unsuccessful_download": "Failed to download source content updates:",
     "source_content_up_to_date": "All source content is up to date.",
     "select_the_gateway_language_content_to_download": "Select the Gateway Language content you would like to download and update.",
     "unable_to_check": "Unable to check for updates",

--- a/src/locale/English-en_US.json
+++ b/src/locale/English-en_US.json
@@ -98,7 +98,10 @@
     "download_error": "Unable to download update.",
     "source_label": "Source:",
     "local_timestamp": "Local:",
-    "online_timestamp": "Online:"
+    "online_timestamp": "Online:",
+    "update_error_reason_parse": "parse error",
+    "update_error_reason_download": "download error",
+    "update_error_reason_missing_dependency": "missing dependency"
   },
   "users": {
     "category": "Category:",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- show failed resource downloads on error.

#### Please include detailed Test instructions for your pull request:

- [ ] test with attached build below
- [ ] select twl joel resource for download:
![Screen Shot 2022-02-10 at 4 17 24 PM](https://user-images.githubusercontent.com/14238574/153498438-1b716fb4-be2a-4530-9b42-e4a886d71047.png)


- [ ]On error It should show the repos that failed to download and show a reason:

![Screen Shot 2022-02-10 at 4 18 05 PM](https://user-images.githubusercontent.com/14238574/153498323-5af5e027-4839-4244-a769-6826c559c1db.png)


#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7236)
<!-- Reviewable:end -->
