### PR TITLE
Bugfix/Fix that available catagories were sometimes empty on toolcard when different GL selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Debugging App Startup Code
 - if you do not see under remote target `electron/js2c/browser_init` and an `inspect` link,
   make sure `Discover network targets` is selected and click `Configure` button.  Make sure `localhost:5656` is added under `Target discovery settings` and click `Done`.
 - Under remote target `electron/js2c/browser_init` click on `inspect` link.
--
+

--- a/src/js/components/home/toolsManagement/ToolsCards.js
+++ b/src/js/components/home/toolsManagement/ToolsCards.js
@@ -70,7 +70,7 @@ const ToolsCards = ({
           tools.map((tool, i) => {
             const glSelected = resourcesHelpers.splitVersionAndOwner(manifest.toolsSelectedGLs?.[tool.name] || '').version;
             const glOwnerSelected = manifest.toolsSelectedOwners?.[tool.name] || DEFAULT_OWNER;
-            const availableCategories = getAvailableCategories(glSelected, tool.name, projectSaveLocation, { withCategoryName: true });
+            const availableCategories = getAvailableCategories(glSelected, tool.name, projectSaveLocation, { withCategoryName: true }, glOwnerSelected);
             let isOLBookVersionMissing = false;
             let missingOLResource = {};
 


### PR DESCRIPTION

#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix that tools were getting the available categories for the D43 and …not the current owner

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translationcore/7268)
<!-- Reviewable:end -->
