### PR TITLE
feature / updated tc-source-content-updater to use the latest catalog URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "translationCore",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "GPL-2.0",
       "dependencies": {
         "@craco/craco": "5.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "string-punctuation-tokenizer": "^2.2.0",
         "sudo-prompt": "6.2.1",
         "tc-electron-env": "0.10.0",
-        "tc-source-content-updater": "1.4.16",
+        "tc-source-content-updater": "1.4.18",
         "tc-strings": "0.1.7",
         "tc-tool": "4.1.0",
         "tc-ui-toolkit": "6.2.7",
@@ -24453,9 +24453,9 @@
       }
     },
     "node_modules/tc-source-content-updater": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.4.16.tgz",
-      "integrity": "sha512-YfR5HDLW3MidpWGkZN/Sy60JMW24LtEF4nkqH3x8uwxUF1IUZQZ31hz7ir1mi7dNDpeKqE+mw1H2R3v/pb+oxw==",
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.4.18.tgz",
+      "integrity": "sha512-ZlvUxW8FVWRkp5tiaFX6+TIGjUJwMtcK1ztty2O/pUfixSaqPm8e20mfKoz93G+bsxheHK6fueI5m301uo12RQ==",
       "dependencies": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",
@@ -47860,9 +47860,9 @@
       }
     },
     "tc-source-content-updater": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.4.16.tgz",
-      "integrity": "sha512-YfR5HDLW3MidpWGkZN/Sy60JMW24LtEF4nkqH3x8uwxUF1IUZQZ31hz7ir1mi7dNDpeKqE+mw1H2R3v/pb+oxw==",
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/tc-source-content-updater/-/tc-source-content-updater-1.4.18.tgz",
+      "integrity": "sha512-ZlvUxW8FVWRkp5tiaFX6+TIGjUJwMtcK1ztty2O/pUfixSaqPm8e20mfKoz93G+bsxheHK6fueI5m301uo12RQ==",
       "requires": {
         "adm-zip": "^0.4.11",
         "agentkeepalive": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "string-punctuation-tokenizer": "^2.2.0",
     "sudo-prompt": "6.2.1",
     "tc-electron-env": "0.10.0",
-    "tc-source-content-updater": "1.4.16",
+    "tc-source-content-updater": "1.4.18",
     "tc-strings": "0.1.7",
     "tc-tool": "4.1.0",
     "tc-ui-toolkit": "6.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "translationCore",
   "productName": "translationCore",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "minCompatibleVersion": "3.4.0",
   "manifestVersion": "8",
   "description": "A bridge between TS and TM",


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updatefor tC to use the right catalog URLs and make sure that it doesn't get any resources other than RC containers. Again, the old v5 links work, and redirect to use the metadataType=rc parameter, but would be nice to make sure everything uses the v1 API. 

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
