### PR TITLE
Add script to fetch latest tCore release links

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "update-apps": "git submodule foreach --recursive git checkout develop && git submodule foreach --recursive git pull",
     "update-attributions": "node scripts/attributions/generateAttributionData.js src/js/components/home/license/attributionData.json",
     "update-resources": "node scripts/resources/updateResources.js tcResources en hi el-x-koine hbo --allAlignedBibles --uWoriginalLanguage --unfoldingWordOrg --preProd",
-    "update-version": "node ./scripts/versionScript.js"
+    "update-version": "node ./scripts/versionScript.js",
+    "get-latest-release-links": "python3 scripts/latest/getLatestTcore.py"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit adds a new npm script `get-latest-release-links` to package.json. The script runs a Python script to retrieve the latest tCore release download links, improving automation for release management.

#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
