### PR TITLE
Online import: offer to overwrite an existing project like local import

### DIFF
--- a/src/js/actions/Import/OnlineImportWorkflowActions.js
+++ b/src/js/actions/Import/OnlineImportWorkflowActions.js
@@ -158,13 +158,37 @@ export const onlineImport = () => (dispatch, getState) => new Promise((resolve, 
         dispatch({ type: consts.UPDATE_SELECTED_PROJECT_FILENAME, selectedProjectFilename: renamingResults.newRepoName });
         await delay(200);
       }
-      await dispatch(ProjectImportFilesystemActions.move());
 
-      if (renamingResults.repoRenamed) {
-        await dispatch(ProjectDetailsActions.doRenamePrompting());
-        const message = translate('projects.preparing_project_alert');
-        dispatch(showStatus(message)); // reshow  busy dialog after rename prompting
-        await delay(300);
+      let success = false;
+
+      if (ProjectDetailsHelpers.doesProjectAlreadyExist(renamingResults.newRepoName)) {
+        success = await dispatch(ProjectDetailsActions.handleOverwriteWarning(projectSaveLocation, renamingResults.newRepoName));
+        await delay(200);
+      } else {
+        await dispatch(ProjectImportFilesystemActions.move());
+
+        if (renamingResults.repoRenamed) {
+          await dispatch(ProjectDetailsActions.doRenamePrompting());
+          const message = translate('projects.preparing_project_alert');
+          dispatch(showStatus(message)); // reshow  busy dialog after rename prompting
+          await delay(300);
+        }
+        success = true;
+      }
+
+      if (!success) { // overwrite was canceled by the user - clean up the import
+        console.log('onlineImport() - import canceled by user');
+        // TRICKY: clear last project first to avoid triggering auto-saving.
+        dispatch(closeProject());
+        dispatch(ProjectImportStepperActions.cancelProjectValidationStepper());
+        deleteProjectFromImportsFolder(selectedProjectFilename);
+
+        if (projectSaveLocation) { // may have been renamed during validation
+          deleteProjectFromImportsFolder(path.basename(projectSaveLocation));
+        }
+        dispatch(AlertModalActions.closeAlertDialog());
+        resolve();
+        return;
       }
       dispatch(MyProjectsActions.getMyProjects());
 

--- a/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
+++ b/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
@@ -3,10 +3,12 @@ import thunk from 'redux-thunk';
 import fs from 'fs-extra';
 import path from 'path-extra';
 // actions
-import { getLocalizedErrorPrompt, recoverFailedOnlineImport } from '../OnlineImportWorkflowActions';
+import { getLocalizedErrorPrompt, onlineImport, recoverFailedOnlineImport } from '../OnlineImportWorkflowActions';
+import * as ProjectDetailsActions from '../../ProjectDetailsActions';
 // helpers
 import { IMPORTS_PATH, DCS_BASE_URL } from '../../../common/constants';
 import * as REPO from '../../../helpers/Repo';
+import * as ProjectDetailsHelpers from '../../../helpers/ProjectDetailsHelpers';
 jest.mock('fs-extra');
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -42,12 +44,36 @@ jest.mock('../../MyProjects/MyProjectsActions', () => ({ getMyProjects: () => ({
 jest.mock('../../MyProjects/ProjectLoadingActions', () => ({
   closeProject: () => ({ type: 'CLEAR_LAST_PROJECT' }),
   displayTools: jest.fn(() => ({ type: 'DISPLAY_TOOLS' })),
+  openProject: jest.fn(() => ({ type: 'OPEN_PROJECT' })),
+  showInvalidVersionError: jest.fn(() => ({ type: 'SHOW_INVALID_VERSION_ERROR' })),
 }));
 jest.mock('../../../helpers/TargetLanguageHelpers', ()=> ({
   generateTargetBibleFromTstudioProjectPath: () => {},
   targetBibleExists:() => false,
 }));
-jest.mock('../../../helpers/ProjectValidation/ProjectStructureValidationHelpers', () => ({ ensureSupportedVersion: () => {} }));
+jest.mock('../../../helpers/ProjectValidation/ProjectStructureValidationHelpers', () => ({
+  ensureSupportedVersion: () => {},
+  isProjectSupported: () => Promise.resolve(true),
+}));
+jest.mock('../../../helpers/Import/OnlineImportWorkflowHelpers', () => ({
+  generateImportPath: jest.fn(() => Promise.resolve(require('path-extra').join(require('../../../common/constants').IMPORTS_PATH, 'es-419_tit_text_ulb'))),
+  verifyThisIsTCoreOrTStudioProject: jest.fn(() => true),
+}));
+jest.mock('../../../helpers/CopyrightCheckHelpers', () => ({ assignLicenseToOnlineImportedProject: jest.fn(() => Promise.resolve()) }));
+jest.mock('../../../helpers/Import/ProjectImportFilesystemHelpers', () => ({
+  deleteImportsFolder: jest.fn(() => Promise.resolve()),
+  deleteProjectFromImportsFolder: jest.fn(),
+}));
+jest.mock('../../ProjectDetailsActions', () => ({
+  ...require.requireActual('../../ProjectDetailsActions'),
+  updateProjectNameIfNecessary: jest.fn(),
+  handleOverwriteWarning: jest.fn(),
+  doRenamePrompting: jest.fn(() => () => Promise.resolve()),
+}));
+jest.mock('../../../helpers/ProjectDetailsHelpers', () => ({
+  ...require.requireActual('../../../helpers/ProjectDetailsHelpers'),
+  doesProjectAlreadyExist: jest.fn(),
+}));
 
 const mock_translate = (t, opts) => {
   if (opts) {
@@ -106,6 +132,92 @@ describe('OnlineImportWorkflowActions.onlineImport', () => {
     const store = mockStore(initialState);
     store.dispatch(recoverFailedOnlineImport('import failed'));
     expect(store.getActions()).toMatchSnapshot();
+  });
+});
+
+describe('OnlineImportWorkflowActions.onlineImport overwrite handling', () => {
+  let initialState = {};
+
+  beforeEach(() => {
+    fs.__resetMockFS();
+    jest.spyOn(REPO.default, 'clone').mockImplementation(() => Promise.resolve());
+    ProjectDetailsActions.updateProjectNameIfNecessary.mockImplementation((results) => () => {
+      results.repoRenamed = false;
+      results.repoExists = false;
+      results.newRepoName = importProjectName;
+      return Promise.resolve();
+    });
+    ProjectDetailsActions.handleOverwriteWarning.mockReset();
+    ProjectDetailsHelpers.doesProjectAlreadyExist.mockReset();
+    initialState = {
+      importOnlineReducer: { importLink: STANDARD_PROJECT },
+      settingsReducer: { onlineMode: true },
+      projectDetailsReducer: {
+        manifest: {},
+        projectSaveLocation: path.join(IMPORTS_PATH, importProjectName),
+      },
+      localImportReducer: { selectedProjectFilename: importProjectName },
+      loginReducer: { userdata: { username: 'johndoe' } },
+      projectInformationCheckReducer: {},
+      projectValidationReducer: {},
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('when project does not exist locally, should move project without overwrite prompt', async () => {
+    // given
+    ProjectDetailsHelpers.doesProjectAlreadyExist.mockReturnValue(false);
+    const store = mockStore(initialState);
+
+    // when
+    await store.dispatch(onlineImport());
+
+    // then
+    const actionTypes = store.getActions().map((action) => action.type);
+    expect(ProjectDetailsActions.handleOverwriteWarning).not.toHaveBeenCalled();
+    expect(actionTypes).toContain('MOVE');
+    expect(actionTypes).toContain('OPEN_PROJECT');
+  });
+
+  it('when project exists locally and user confirms overwrite, should merge instead of move', async () => {
+    // given
+    ProjectDetailsHelpers.doesProjectAlreadyExist.mockReturnValue(true);
+    ProjectDetailsActions.handleOverwriteWarning.mockImplementation(() => () => Promise.resolve(true));
+    const store = mockStore(initialState);
+
+    // when
+    await store.dispatch(onlineImport());
+
+    // then
+    const actionTypes = store.getActions().map((action) => action.type);
+    expect(ProjectDetailsActions.handleOverwriteWarning).toHaveBeenCalledTimes(1);
+    expect(ProjectDetailsActions.handleOverwriteWarning).toHaveBeenCalledWith(path.join(IMPORTS_PATH, importProjectName), importProjectName);
+    expect(actionTypes).not.toContain('MOVE');
+    expect(actionTypes).toContain('OPEN_PROJECT');
+  });
+
+  it('when project exists locally and user cancels overwrite, should clean up and not open project', async () => {
+    // given
+    ProjectDetailsHelpers.doesProjectAlreadyExist.mockReturnValue(true);
+    ProjectDetailsActions.handleOverwriteWarning.mockImplementation(() => () => Promise.resolve(false));
+    const { deleteProjectFromImportsFolder } = require('../../../helpers/Import/ProjectImportFilesystemHelpers');
+    deleteProjectFromImportsFolder.mockClear();
+    const store = mockStore(initialState);
+
+    // when
+    await store.dispatch(onlineImport());
+
+    // then
+    const actionTypes = store.getActions().map((action) => action.type);
+    expect(ProjectDetailsActions.handleOverwriteWarning).toHaveBeenCalledTimes(1);
+    expect(actionTypes).not.toContain('MOVE');
+    expect(actionTypes).not.toContain('OPEN_PROJECT');
+    expect(actionTypes).toContain('CLEAR_LAST_PROJECT'); // project was closed
+    expect(actionTypes).toContain('TOGGLE_PROJECT_VALIDATION_STEPPER'); // stepper was canceled
+    expect(deleteProjectFromImportsFolder).toHaveBeenCalledWith(importProjectName);
   });
 });
 

--- a/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
+++ b/src/js/actions/Import/__tests__/OnlineImportWorkflowActions.test.js
@@ -3,7 +3,9 @@ import thunk from 'redux-thunk';
 import fs from 'fs-extra';
 import path from 'path-extra';
 // actions
-import { getLocalizedErrorPrompt, onlineImport, recoverFailedOnlineImport } from '../OnlineImportWorkflowActions';
+import {
+  getLocalizedErrorPrompt, onlineImport, recoverFailedOnlineImport,
+} from '../OnlineImportWorkflowActions';
 import * as ProjectDetailsActions from '../../ProjectDetailsActions';
 // helpers
 import { IMPORTS_PATH, DCS_BASE_URL } from '../../../common/constants';

--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -563,8 +563,10 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
                 fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
                 fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
                 dispatch(setSaveLocation(oldProjectPath));
+                // TRICKY: resolve only after the merge/replace has finished so callers do not
+                // open the project while it is still being swapped out underneath them.
+                resolve(true);
               });
-              resolve(true);
             }
           } else { // if cancel
             dispatch(AlertModalActions.closeAlertDialog());

--- a/src/js/actions/ProjectDetailsActions.js
+++ b/src/js/actions/ProjectDetailsActions.js
@@ -557,15 +557,22 @@ export function handleOverwriteWarning(newProjectPath, projectName) {
             if (!hasRunOnce) {
               hasRunOnce = true;
               delay(500).then(() => { // wait for UI to update and alert to close
-                const oldProjectPath = path.join(PROJECTS_PATH, projectName);
-                console.log('handleOverwriteWarning() - doing overwrite/merge');
-                ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath, getUsername(getState()), dispatch);
-                fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
-                fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
-                dispatch(setSaveLocation(oldProjectPath));
-                // TRICKY: resolve only after the merge/replace has finished so callers do not
-                // open the project while it is still being swapped out underneath them.
-                resolve(true);
+                try {
+                  const oldProjectPath = path.join(PROJECTS_PATH, projectName);
+                  console.log('handleOverwriteWarning() - doing overwrite/merge');
+                  ProjectOverwriteHelpers.mergeOldProjectToNewProject(oldProjectPath, newProjectPath, getUsername(getState()), dispatch);
+                  fs.removeSync(oldProjectPath); // don't need the oldProjectPath any more now that .apps was merged in
+                  fs.moveSync(newProjectPath, oldProjectPath); // replace it with new project
+                  dispatch(setSaveLocation(oldProjectPath));
+                  // TRICKY: resolve only after the merge/replace has finished so callers do not
+                  // open the project while it is still being swapped out underneath them.
+                  resolve(true);
+                } catch (e) {
+                  // TRICKY: settle the promise on failure so the awaiting import flow cleans up
+                  // instead of hanging forever.
+                  console.error('handleOverwriteWarning() - overwrite/merge failed', e);
+                  resolve(false);
+                }
               });
             }
           } else { // if cancel


### PR DESCRIPTION
Fixes #7666

## What

When importing a project from Door43 that already exists locally, the user is now offered the same **overwrite/merge** dialog that local import has always shown, instead of the import failing with "Reimporting existing projects is not currently supported."

## How

`onlineImport()` now mirrors the branch local import has in `LocalImportWorkflowActions.localImport()`:

- After project-name resolution, `ProjectDetailsHelpers.doesProjectAlreadyExist()` is checked. If the project exists, the existing `ProjectDetailsActions.handleOverwriteWarning()` dialog is dispatched instead of `move()` — on confirm it runs the proven `ProjectOverwriteHelpers.mergeOldProjectToNewProject()` merge (preserves local checking data, merges alignments and manifest checkers/translators, records external verse edits, and invalidates stale selections).
- If the user cancels the overwrite, the import is cleaned up the same way local import does: the project is closed, the validation stepper is canceled, and the cloned project is removed from the imports folder.

No new merge logic, dialogs, or localization keys — this reuses the existing, tested overwrite machinery, keeping the two import flows symmetric.

## Testing

- Added three tests to `OnlineImportWorkflowActions.test.js` covering: no local duplicate (moves without prompting), duplicate + confirm (merges instead of moving), duplicate + cancel (cleans up, does not open project). All 11 tests in the suite pass; eslint clean on changed files.
- Not verified in this PR: a manual round-trip against live Door43 (import an existing project, e.g. a shared `tcorePSA` project, and confirm the overwrite merge in the running app). Recommend exercising that during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)